### PR TITLE
Fix crash with no custom color temperature lightbulbs

### DIFF
--- a/pyezvizapi/light_bulb.py
+++ b/pyezvizapi/light_bulb.py
@@ -66,7 +66,7 @@ class EzvizLightBulb:
 
         return json_output
 
-    def get_feature_item(self, key: str, default_value: Any = None) -> Any:
+    def get_feature_item(self, key: str, default_value: Any = { "dataValue" : "" }) -> Any:
         """Get items fron FEATURE."""
         items = self._feature_json["featureItemDtos"]
         for item in items:


### PR DESCRIPTION
### Fix crash with no custom color temperature lightbulbs

Hello, thanks for your work ! 👍 

I found a small bug when using my lightbulbs when using the `device_light status` command.

Some lightbulbs do not have color temperature settings, it makes the command fail with:
`'NoneType' object has no attribute 'get'`

I just made a quick fix for my case, if you have any other idea, please share it 😃 