### PR TITLE
Guard for pagelist missing data

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name='pyezvizapi',
-    version="1.0.1.9",
+    version="1.0.2.0",
     license='Apache Software License 2.0',
     author='Renier Moorcroft',
     author_email='RenierM26@users.github.com',


### PR DESCRIPTION
- Update devices for in case API doesn't return data for all devices. (happens occasionally)
- Guard agents malformed or missing pagelist data.