### PR TITLE
[BUG] fix lightbulb's _write_state method when the target state is False

### DIFF
--- a/pyezvizapi/light_bulb.py
+++ b/pyezvizapi/light_bulb.py
@@ -169,7 +169,7 @@ class EzvizLightBulb:
         return self._client.set_device_feature_by_key(
             self._serial,
             self.get_product_id(),
-            state if state else not bool(item["dataValue"]),
+            state if state is not None else not bool(item["dataValue"]),
             item["itemKey"],
         )
 


### PR DESCRIPTION
When we intent to write a LightBulb's state to False, we actually toggle it 🥲