### PR TITLE
fix: add ALWAYS_ON_VIDEO mode to constants

### DIFF
--- a/pyezvizapi/constants.py
+++ b/pyezvizapi/constants.py
@@ -469,6 +469,7 @@ class BatteryCameraWorkMode(Enum):
     SUPER_POWER_SAVE = 3
     CUSTOM = 4
     HYBERNATE = 5  # not sure
+    ALWAYS_ON_VIDEO = 7
 
 
 @unique


### PR DESCRIPTION
add always_on_video mode to prevent ha from crashing
this fixes https://github.com/RenierM26/pyEzvizApi/issues/90 and https://github.com/home-assistant/core/issues/149686