### PR TITLE
Add support for Detector devices (door/window, water leak, siren sensors)

### DIFF
--- a/pyezvizapi/__init__.py
+++ b/pyezvizapi/__init__.py
@@ -10,6 +10,7 @@ symbols for convenient imports.
 from .camera import EzvizCamera
 from .cas import EzvizCAS
 from .client import EzvizClient
+from .detector import EzvizDetector
 from .constants import (
     AlarmDetectHumanCar,
     BatteryCameraNewWorkMode,
@@ -83,6 +84,7 @@ __all__ = [
     "EzvizCAS",
     "EzvizCamera",
     "EzvizClient",
+    "EzvizDetector",
     "EzvizDeviceRecord",
     "EzvizLightBulb",
     "EzvizSmartPlug",

--- a/pyezvizapi/client.py
+++ b/pyezvizapi/client.py
@@ -131,6 +131,7 @@ from .feature import optionals_mapping
 from .light_bulb import EzvizLightBulb
 from .models import EzvizDeviceRecord, build_device_records_map
 from .mqtt import MQTTClient
+from .detector import EzvizDetector
 from .smart_plug import EzvizSmartPlug
 from .utils import convert_to_dict, deep_merge
 
@@ -222,6 +223,7 @@ class EzvizClient:
         DeviceCatagories.LIGHTING.value,
         DeviceCatagories.SOCKET.value,
         DeviceCatagories.W2H_BASE_STATION_DEVICE_CATEGORY.value,
+        DeviceCatagories.DETECTOR_DEVICE_CATEGORY.value,
     ]
 
     def __init__(
@@ -255,6 +257,7 @@ class EzvizClient:
         self._cameras: dict[str, Any] = {}
         self._light_bulbs: dict[str, Any] = {}
         self._smart_plugs: dict[str, Any] = {}
+        self._detectors: dict[str, Any] = {}
         self.mqtt_client: MQTTClient | None = None
         self._debug_request_counters: dict[str, int] = {}
 
@@ -2258,6 +2261,23 @@ class EzvizClient:
                             "load_error",
                             str(err),
                         )
+                elif rec.device_category == DeviceCatagories.DETECTOR_DEVICE_CATEGORY.value:
+                    try:
+                        self._detectors[device] = EzvizDetector(
+                            self, device, dict(rec.raw)
+                        ).status()
+                    except (
+                        PyEzvizError,
+                        KeyError,
+                        TypeError,
+                        ValueError,
+                    ) as err:
+                        _LOGGER.warning(
+                            "Load_device_failed: serial=%s code=%s msg=%s",
+                            device,
+                            "load_error",
+                            str(err),
+                        )
                 else:
                     try:
                         # Create camera object
@@ -2279,7 +2299,7 @@ class EzvizClient:
                             "load_error",
                             str(err),
                         )
-        return {**self._cameras, **self._light_bulbs, **self._smart_plugs}
+        return {**self._cameras, **self._light_bulbs, **self._smart_plugs, **self._detectors}
 
     def _prefetch_latest_camera_alarms(
         self, serials: Iterable[str], *, chunk_size: int = 20
@@ -2397,6 +2417,14 @@ class EzvizClient:
         """
         self.load_devices(refresh=refresh)
         return self._smart_plugs
+
+    def load_detectors(self, refresh: bool = True) -> dict[Any, Any]:
+        """Load and return all detector/sensor status mappings.
+
+        refresh: pass-through to load_devices().
+        """
+        self.load_devices(refresh=refresh)
+        return self._detectors
 
     def get_device_infos(self, serial: str | None = None) -> dict[Any, Any]:
         """Load all devices and build dict per device serial."""

--- a/pyezvizapi/constants.py
+++ b/pyezvizapi/constants.py
@@ -496,3 +496,4 @@ class DeviceCatagories(Enum):
     LIGHTING = "lighting"
     SOCKET = "Socket"
     W2H_BASE_STATION_DEVICE_CATEGORY = "IGateWay"
+    DETECTOR_DEVICE_CATEGORY = "Detector"

--- a/pyezvizapi/detector.py
+++ b/pyezvizapi/detector.py
@@ -1,0 +1,130 @@
+"""Ezviz detector/sensor API.
+
+Detector-specific helpers to read device status for Ezviz sensors
+connected via a gateway (A3 hub). Covers door/window contact sensors
+(T2C), water leak sensors (T10C), indoor sirens (T9C), and similar
+Zigbee sub-devices.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from .utils import fetch_nested_value
+
+if TYPE_CHECKING:
+    from .client import EzvizClient
+from .models import EzvizDeviceRecord
+
+
+class EzvizDetector:
+    """Representation of an Ezviz detector / sensor device.
+
+    These are Zigbee sub-devices (door/window contacts, water leak
+    sensors, sirens) paired to an Ezviz gateway (e.g. CS-A3).
+    Status data comes primarily from the FEATURE_INFO section of the
+    pagelist API response.
+    """
+
+    def __init__(
+        self,
+        client: EzvizClient,
+        serial: str,
+        device_obj: EzvizDeviceRecord | dict | None = None,
+    ) -> None:
+        self._client = client
+        self._serial = serial
+        if device_obj is None:
+            self._device = self._client.get_device_infos(self._serial)
+        elif isinstance(device_obj, EzvizDeviceRecord):
+            self._device = dict(device_obj.raw)
+        else:
+            self._device = device_obj
+
+    def fetch_key(self, keys: list[Any], default_value: Any = None) -> Any:
+        """Fetch a nested key from the device payload."""
+        return fetch_nested_value(self._device, keys, default_value)
+
+    def _feature_global(self) -> dict[str, Any]:
+        """Return the FEATURE_INFO -> 0 -> global dict."""
+        fi = self._device.get("FEATURE_INFO") or {}
+        channel = fi.get("0") or fi.get(0) or {}
+        return channel.get("global") or {}
+
+    def status(self) -> dict[str, Any]:
+        """Return a status dictionary for this detector.
+
+        The output shape mirrors camera/light-bulb/smart-plug status
+        for common keys, then adds detector-specific fields extracted
+        from the FEATURE_INFO section.
+        """
+        feat = self._feature_global()
+        door_mag = feat.get("DoorMagnetic") or {}
+        water = feat.get("WaterOutSense") or {}
+        siren = feat.get("SirenMgr") or {}
+        battery_info = feat.get("BatteryInfo") or {}
+        power_mgr = feat.get("PowerMgr") or {}
+        zigbee = feat.get("ZigbeeMgr") or {}
+
+        battery_level = battery_info.get(
+            "SurplusPower", power_mgr.get("SurplusPower")
+        )
+
+        data: dict[str, Any] = {
+            "serial": self._serial,
+            "name": self.fetch_key(["deviceInfos", "name"]),
+            "version": self.fetch_key(["deviceInfos", "version"]),
+            "upgrade_available": bool(
+                self.fetch_key(["UPGRADE", "isNeedUpgrade"]) == 3
+            ),
+            "status": self.fetch_key(["deviceInfos", "status"]),
+            "device_category": self.fetch_key(["deviceInfos", "deviceCategory"]),
+            "device_sub_category": self.fetch_key(
+                ["deviceInfos", "deviceSubCategory"]
+            ),
+            "upgrade_percent": self.fetch_key(["STATUS", "upgradeProcess"]),
+            "upgrade_in_progress": bool(
+                self.fetch_key(["STATUS", "upgradeStatus"]) == 0
+            ),
+            "latest_firmware_info": self.fetch_key(
+                ["UPGRADE", "upgradePackageInfo"]
+            ),
+            "supportExt": self.fetch_key(["deviceInfos", "supportExt"]),
+            "switches": {},
+            "optionals": self.fetch_key(["STATUS", "optionals"]),
+            # Detector-specific fields
+            "battery_level": battery_level,
+            # Door/window magnetic contact (T2C)
+            "door_status": door_mag.get("DoorStatus"),
+            "door_open_remind": door_mag.get("OpenRemindSwitch"),
+            "door_closed_remind": door_mag.get("ClosedRemindSwitch"),
+            "door_open_gateway_alarm": door_mag.get("OpenGateWaySwitch"),
+            "door_closed_gateway_alarm": door_mag.get("ClosedGateWaySwitch"),
+            "door_open_detection_time": door_mag.get("OpenDetectionTime"),
+            # Water leak sensor (T10C)
+            "water_leak_status": water.get("WaterOutStatus"),
+            # Siren (T9C)
+            "siren_work_state": (
+                siren.get("SirenWorkState", {}).get("workState")
+            ),
+            "siren_alarm_volume": (
+                siren.get("SirenAlarmVolume", {}).get("alarmVolume")
+            ),
+            "siren_alarm_duration": (
+                siren.get("SirenAlarmDuration", {}).get("alarmDuration")
+            ),
+            "siren_tamper_detection": (
+                siren.get("SirenTamperCfg", {}).get("tamperDetection")
+            ),
+            "siren_motion_detection": (
+                siren.get("SirenMotionDetectCfg", {}).get("moveDetection")
+            ),
+            # Zigbee signal strength
+            "zigbee_signal": (
+                zigbee.get("ZigbeeSignal", {}).get("signal")
+            ),
+            # Power mode (battery / wired)
+            "power_mode": power_mgr.get("PowerMode", {}).get("mode"),
+        }
+
+        return data


### PR DESCRIPTION
## Summary

- Add `DETECTOR_DEVICE_CATEGORY` (`"Detector"`) to `DeviceCatagories` enum and `SUPPORTED_CATEGORIES`
- Create `EzvizDetector` class that extracts sensor status from the `FEATURE_INFO` pagelist section
- Add `load_detectors()` convenience method and include detectors in `load_devices()` output

## Background

EZVIZ Zigbee sensors connected through a gateway (CS-A3) are returned by the pagelist API with `deviceCategory: "Detector"`. Since this category was not in `SUPPORTED_CATEGORIES`, these devices were silently filtered out by `load_devices()`.

The `FEATURE_INFO` section of the API response contains rich, structured data for each detector sub-device:

| Sub-category | Model | Data available |
|---|---|---|
| T2C (door/window contact) | CS-T2C-A0-BG | `DoorMagnetic.DoorStatus` (open/closed), battery level, open/close remind & gateway alarm settings |
| T10C (water leak) | CS-T10C-A0-BG | `WaterOutSense.WaterOutStatus`, battery level |
| T9C (indoor siren) | CS-T9C-A0-BG | Siren work state, alarm volume/duration, tamper detection, Zigbee signal, power mode |

## Changes

### `constants.py`
- Added `DETECTOR_DEVICE_CATEGORY = "Detector"` to `DeviceCatagories`

### `detector.py` (new)
- `EzvizDetector` class following the same pattern as `EzvizSmartPlug`/`EzvizLightBulb`
- `status()` returns a dict with common fields (serial, name, version, etc.) plus detector-specific fields extracted from `FEATURE_INFO`

### `client.py`
- Added `"Detector"` to `SUPPORTED_CATEGORIES`
- Added `_detectors` dict and Detector handling branch in `load_devices()`
- Added `load_detectors()` method
- Included `_detectors` in `load_devices()` return value

### `__init__.py`
- Export `EzvizDetector`

## Test plan

- [x] Verified against live EZVIZ account with 6x T2C, 2x T10C, 1x T9C, and 1x A3 gateway
- [x] All 15 devices (5 cameras + 1 gateway + 9 detectors) load successfully
- [x] `door_status`, `water_leak_status`, `battery_level`, `siren_work_state`, `zigbee_signal` all populated correctly
- [ ] Integration-side changes (HA custom component) to expose these as HA entities (separate PR)


Made with [Cursor](https://cursor.com)