### PR TITLE
Add offline parser and utility tests

### DIFF
--- a/tests/test_feature.py
+++ b/tests/test_feature.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+from pyezvizapi.feature import (
+    blc_current_value,
+    custom_voice_volume_config,
+    day_night_mode_value,
+    display_mode_value,
+    has_algorithm_subtype,
+    lens_defog_value,
+    night_vision_payload,
+    normalize_port_security,
+    optionals_mapping,
+    port_security_has_port,
+    port_security_port_enabled,
+    supplement_light_available,
+    supplement_light_enabled,
+)
+
+
+def test_optionals_mapping_decodes_supported_locations() -> None:
+    assert optionals_mapping({"statusInfo": {"optionals": '{"display_mode": {"mode": 2}}'}}) == {
+        "display_mode": {"mode": 2}
+    }
+    assert optionals_mapping({"STATUS": {"optionals": '{"inverse_mode": {"enable": 1}}'}}) == {
+        "inverse_mode": {"enable": 1}
+    }
+
+
+def test_feature_helpers_decode_nested_json_strings() -> None:
+    payload = {
+        "statusInfo": {
+            "optionals": {
+                "CustomVoice_Volume": '{"volume": "7", "microphone_volume": 3}',
+                "AlgorithmInfo": [
+                    {"channel": "1", "SubType": "human", "Value": "1"},
+                    {"channel": 2, "SubType": "vehicle", "Value": 0},
+                ],
+                "display_mode": '{"mode": 3}',
+                "inverse_mode": {"enable": 1, "position": 4},
+                "device_ICR_DSS": '{"mode": 2, "sensitivity": 3}',
+            }
+        }
+    }
+
+    assert custom_voice_volume_config(payload) == {"volume": 7, "microphone_volume": 3}
+    assert has_algorithm_subtype(payload, "human", channel=1) is True
+    assert has_algorithm_subtype(payload, "human", channel=2) is False
+    assert display_mode_value(payload) == 3
+    assert blc_current_value(payload) == 4
+    assert day_night_mode_value(payload) == 2
+
+
+def test_supplement_light_and_defog_helpers() -> None:
+    payload = {
+        "FEATURE_INFO": {
+            "0": {
+                "Video": {
+                    "SupplementLightMgr": '{"ImageSupplementLightModeSwitchParams": "{\\"enabled\\": \\"true\\"}"}',
+                    "LensCleaning": {"DefogCfg": {"enabled": True, "defogMode": "open"}},
+                }
+            }
+        }
+    }
+
+    assert supplement_light_available(payload) is True
+    assert supplement_light_enabled(payload) is True
+    assert lens_defog_value(payload) == 1
+
+
+def test_port_security_normalization_handles_nested_payloads() -> None:
+    payload = {
+        "NetworkSecurityProtection": {
+            "enabled": True,
+            "value": '{"portSecurityList": [{"portNo": "554", "enabled": true}, {"portNo": 8000, "enabled": false}]}',
+        }
+    }
+
+    assert port_security_has_port(payload, 554) is True
+    assert port_security_port_enabled(payload, 554) is True
+    assert port_security_port_enabled(payload, 8000) is False
+
+    normalized = normalize_port_security(payload)
+    assert normalized["enabled"] is True
+    assert normalized["portSecurityList"] == [
+        {"portNo": 554, "enabled": True},
+        {"portNo": 8000, "enabled": False},
+    ]
+
+
+def test_night_vision_payload_sanitizes_mode_specific_fields() -> None:
+    payload = {
+        "statusInfo": {
+            "optionals": {
+                "NightVision_Model": '{"graphicType": "2", "luminance": "10", "duration": "999"}'
+            }
+        }
+    }
+
+    smart = night_vision_payload(payload)
+    assert smart["graphicType"] == 2
+    assert smart["luminance"] == 20
+    assert smart["duration"] == 120
+
+    color = night_vision_payload(payload, mode=1, luminance=5)
+    assert color["graphicType"] == 1
+    assert color["luminance"] == 20
+    assert "duration" not in color

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from pyezvizapi.models import EzvizDeviceRecord, build_device_records_map
+
+
+def test_device_record_from_api_tolerates_mixed_shapes() -> None:
+    record = EzvizDeviceRecord.from_api(
+        "ABC123",
+        {
+            "deviceInfos": {
+                "name": "Front Door",
+                "deviceCategory": "camera",
+                "deviceSubCategory": "doorbell",
+                "version": "1.2.3",
+                "status": 1,
+                "supportExt": {"SupportExt": "1"},
+            },
+            "STATUS": {"globalStatus": 0, "optionals": {"foo": "bar"}},
+            "SWITCH": [
+                {"type": 7, "enable": 1},
+                {"type": 21, "enable": False},
+                {"type": "ignored", "enable": True},
+            ],
+            "CONNECTION": {"localIp": "192.0.2.10"},
+            "VTM": {"0": {"battery": 88}},
+            "CLOUD": {"0": {"cloud": True}},
+        },
+    )
+
+    assert record.serial == "ABC123"
+    assert record.name == "Front Door"
+    assert record.device_category == "camera"
+    assert record.device_sub_category == "doorbell"
+    assert record.status == 1
+    assert record.switches == {7: True, 21: False}
+    assert record.connection == {"localIp": "192.0.2.10"}
+    assert record.vtm == {"battery": 88}
+    assert record.cloud == {"cloud": True}
+
+
+def test_build_device_records_map_wraps_payloads() -> None:
+    records = build_device_records_map({"ABC123": {"deviceInfos": {"name": "Camera"}}})
+
+    assert list(records) == ["ABC123"]
+    assert records["ABC123"].name == "Camera"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import datetime as dt
+
+from pyezvizapi.utils import (
+    coerce_int,
+    decode_json,
+    deep_merge,
+    fetch_nested_value,
+    first_nested,
+    iter_nested,
+    parse_timezone_value,
+    return_password_hash,
+    string_to_list,
+)
+
+
+def test_coerce_int_handles_common_api_shapes() -> None:
+    assert coerce_int(True) == 1
+    assert coerce_int(False) == 0
+    assert coerce_int("42") == 42
+    assert coerce_int(12.9) == 12
+    assert coerce_int("not-a-number") is None
+    assert coerce_int(None) is None
+
+
+def test_decode_json_returns_none_for_invalid_strings() -> None:
+    assert decode_json('{"enabled": true}') == {"enabled": True}
+    assert decode_json("not json") is None
+    assert decode_json({"already": "decoded"}) == {"already": "decoded"}
+
+
+def test_string_to_list_only_splits_strings_with_separator() -> None:
+    assert string_to_list("a,b,c") == ["a", "b", "c"]
+    assert string_to_list("abc") == "abc"
+    assert string_to_list(["a", "b"]) == ["a", "b"]
+
+
+def test_nested_helpers_support_dicts_lists_and_wildcards() -> None:
+    payload = {
+        "devices": [
+            {"serial": "A", "status": {"online": True}},
+            {"serial": "B", "status": {"online": False}},
+        ]
+    }
+
+    assert list(iter_nested(payload, ["devices", "*", "serial"])) == ["A", "B"]
+    assert first_nested(payload, ["devices", 1, "status", "online"]) is False
+    assert fetch_nested_value(payload, ["devices", 0, "serial"]) == "A"
+    assert fetch_nested_value(payload, ["missing"], default_value="fallback") == "fallback"
+
+
+def test_deep_merge_merges_dicts_and_concatenates_lists() -> None:
+    merged = deep_merge(
+        {"a": {"x": 1}, "items": [1], "keep": True},
+        {"a": {"y": 2}, "items": [2], "replace": "new"},
+    )
+
+    assert merged == {
+        "a": {"x": 1, "y": 2},
+        "items": [1, 2],
+        "keep": True,
+        "replace": "new",
+    }
+
+
+def test_return_password_hash_is_stable() -> None:
+    assert return_password_hash("ABCDEF") == "aa37ad52a5a65df39791a95818fb3298"
+
+
+def test_parse_timezone_value_supports_offsets() -> None:
+    tz = parse_timezone_value("UTC+02:30")
+    assert tz.utcoffset(None) == dt.timedelta(hours=2, minutes=30)
+
+    tz = parse_timezone_value("GMT-5")
+    assert tz.utcoffset(None) == -dt.timedelta(hours=5)
+
+    tz = parse_timezone_value(120)
+    assert tz.utcoffset(None) == dt.timedelta(hours=2)


### PR DESCRIPTION
## Summary
- add offline tests for utility coercion, nested lookups, timezone parsing, password hashing, and deep merge behavior
- add feature helper tests for optionals decoding, supplement light, defog, port security, algorithm metadata, and night vision payload sanitizing
- add device record model tests for tolerant parsing of mixed EZVIZ payload shapes

## Local validation
- ruff check .
- mypy --install-types --non-interactive .
- pytest -q
- python -m build
- twine check dist/*
