### PR TITLE
Mark package as typed

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,9 @@ dev = ["build", "ruff", "mypy", "pytest", "twine", "types-requests"]
 [tool.setuptools.packages.find]
 include = ["pyezvizapi*"]
 
+[tool.setuptools.package-data]
+pyezvizapi = ["py.typed"]
+
 [tool.ruff]
 line-length = 100
 target-version = "py312"


### PR DESCRIPTION
## Summary
- add the PEP 561 py.typed marker to pyezvizapi
- include py.typed in built wheels via setuptools package-data
- verify downstream type checkers can discover the package's inline type hints

## Local validation
- ruff check .
- mypy --install-types --non-interactive .
- pytest -q
- python -m build
- twine check dist/*
- verified pyezvizapi/py.typed is present in the built wheel
