### PR TITLE
Improve release publishing hygiene

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,11 +1,3 @@
-# This workflow will upload a Python Package to PyPI when a release is created
-# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python#publishing-to-package-registries
-
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
-
 name: Upload Python Package
 
 on:
@@ -24,13 +16,31 @@ jobs:
 
       - uses: actions/setup-python@v6
         with:
-          python-version: "3.x"
+          python-version: "3.12"
+
+      - name: Verify release tag matches package version
+        shell: bash
+        run: |
+          python - <<'PY'
+          import os
+          import tomllib
+
+          ref_name = os.environ["GITHUB_REF_NAME"]
+          with open("pyproject.toml", "rb") as file:
+              version = tomllib.load(file)["project"]["version"]
+          expected = f"v{version}"
+          if ref_name != expected:
+              raise SystemExit(
+                  f"Release tag {ref_name!r} does not match pyproject version {version!r}; "
+                  f"expected {expected!r}."
+              )
+          PY
 
       - name: Build release distributions
         run: |
-          # NOTE: put your own distribution build steps here.
-          python -m pip install build
+          python -m pip install -U pip build twine
           python -m build
+          twine check dist/*
 
       - name: Upload distributions
         uses: actions/upload-artifact@v7
@@ -43,14 +53,11 @@ jobs:
     needs:
       - release-build
     permissions:
-      # IMPORTANT: this permission is mandatory for trusted publishing
       id-token: write
 
-    # Dedicated environments with protections for publishing are strongly recommended.
-    # For more information, see: https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment#deployment-protection-rules
     environment:
       name: pypi
-      url: https://pypi.org/project/YOURPROJECT/${{ github.event.release.name }}
+      url: https://pypi.org/project/pyezvizapi/${{ github.event.release.name }}
 
     steps:
       - name: Retrieve release distributions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,34 @@
+# Changelog
+
+All notable changes to this project should be documented in this file.
+
+This project follows [Semantic Versioning](https://semver.org/) for published releases.
+
+## Unreleased
+
+### Added
+
+- Modern package build checks in CI, including wheel install and CLI smoke tests.
+- Offline tests for utility helpers, feature parsing, device parsing, MQTT decoding, pagelist pagination, HTTP helpers, and auth/token lifecycle behavior.
+- PEP 561 `py.typed` marker so downstream type checkers can consume inline package types.
+- Example wrappers for MQTT listening and RTSP authentication testing.
+
+### Changed
+
+- Consolidated package metadata into `pyproject.toml` while keeping `setup.py` as a compatibility shim.
+- Restored the installed `pyezvizapi` console script via `project.scripts`.
+- Replaced CLI table rendering dependency on pandas with a small stdlib formatter.
+
+### Removed
+
+- Removed pandas from the runtime dependency set.
+
+## Release checklist
+
+Before publishing a release:
+
+1. Move relevant entries from `Unreleased` to a dated version section.
+2. Bump `project.version` in `pyproject.toml`.
+3. Ensure CI is green on `main`.
+4. Create a GitHub release whose tag matches `v<pyproject version>`.
+5. Confirm the PyPI publish workflow completes successfully.

--- a/README.md
+++ b/README.md
@@ -250,7 +250,9 @@ Contributions are welcome — the API surface is large and there are many improv
 
 ## Versioning
 
-We follow SemVer when publishing the library. See repository tags for released versions.
+We follow SemVer when publishing the library. See `CHANGELOG.md` and repository tags for released versions.
+
+Release tags should match the package version in `pyproject.toml` using the form `v<version>` (for example, `v1.0.4.5`). The PyPI publish workflow validates this before uploading distributions.
 
 ## License
 


### PR DESCRIPTION
## Summary
- add a CHANGELOG.md with an Unreleased section and release checklist
- document that release tags should match pyproject.toml versions as v<version>
- tighten the PyPI publish workflow to Python 3.12, build + twine check, and validate release tag/version alignment
- fix the PyPI environment URL to the pyezvizapi project instead of the placeholder

## Local validation
- ruff check .
- mypy --install-types --non-interactive .
- pytest -q
- python -m build
- twine check dist/*
- manually verified the release tag/version validation script with GITHUB_REF_NAME=v1.0.4.5
