### PR TITLE
Run CI across supported Python versions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,20 +29,26 @@ jobs:
   lint-test:
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.12", "3.13"]
+
+    name: lint-test (py${{ matrix.python-version }})
 
     steps:
       - uses: actions/checkout@v6
 
       - uses: actions/setup-python@v6
         with:
-          python-version: "3.12"
+          python-version: ${{ matrix.python-version }}
 
       - name: Cache pip
         uses: actions/cache@v5
         with:
           path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('pyproject.toml') }}
-          restore-keys: ${{ runner.os }}-pip-
+          key: ${{ runner.os }}-py${{ matrix.python-version }}-pip-${{ hashFiles('pyproject.toml') }}
+          restore-keys: ${{ runner.os }}-py${{ matrix.python-version }}-pip-
 
       - name: Upgrade pip
         run: python -m pip install -U pip wheel


### PR DESCRIPTION
## Summary
- add a CI matrix for Python 3.12 and 3.13, matching the declared supported runtime range
- name matrix jobs by Python version for easier failures triage
- include the Python version in the pip cache key to avoid cross-version cache confusion

## Local validation
- parsed .github/workflows/ci.yaml and verified matrix values
- ruff check .
- mypy --install-types --non-interactive .
- pytest -q
- python -m build
- twine check dist/*
