### PR TITLE
Improve PyPI project metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,21 @@ license = "Apache-2.0"
 authors = [
   { name = "Renier Moorcroft", email = "RenierM26@users.github.com" }
 ]
+keywords = ["ezviz", "home-assistant", "camera", "mqtt", "iot", "cli"]
+classifiers = [
+  "Development Status :: 4 - Beta",
+  "Environment :: Console",
+  "Intended Audience :: Developers",
+  "Intended Audience :: End Users/Desktop",
+  "Operating System :: OS Independent",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3 :: Only",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Topic :: Home Automation",
+  "Topic :: Software Development :: Libraries :: Python Modules",
+  "Typing :: Typed",
+]
 dependencies = [
   "requests",
   "xmltodict",


### PR DESCRIPTION
## Summary
- add PyPI keywords for EZVIZ, Home Assistant, camera, MQTT, IoT, and CLI discovery
- add trove classifiers for supported Python versions, typed package status, console/library use, and home automation topic
- avoid deprecated license classifier because the package already uses the modern SPDX license expression

## Local validation
- ruff check .
- mypy --install-types --non-interactive .
- pytest -q
- python -m build
- twine check dist/*
- inspected wheel METADATA for keywords and Typing :: Typed classifier
