### PR TITLE
Add CLI auth token tests

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,8 +1,12 @@
 from __future__ import annotations
 
 import importlib.util
+import json
+from typing import Any, ClassVar
 
+import pyezvizapi.__main__ as cli_module
 from pyezvizapi.__main__ import _format_cell, _write_table
+from pyezvizapi.exceptions import EzvizAuthVerificationCode
 
 
 def test_cli_imports_without_pandas_installed() -> None:
@@ -30,3 +34,136 @@ def test_write_table_outputs_fixed_width_rows(capsys) -> None:
     assert "Front" in output
     assert "XYZ" in output
     assert "False" in output
+
+
+class _FakeClient:
+    instances: ClassVar[list[_FakeClient]] = []
+
+    def __init__(
+        self,
+        account: str | None = None,
+        password: str | None = None,
+        url: str | None = None,
+        *,
+        token: dict[str, Any] | None = None,
+        **_kwargs: Any,
+    ) -> None:
+        self.account = account
+        self.password = password
+        self.url = url
+        self.token = token
+        self.login_calls: list[int | None] = []
+        self.closed = False
+        self.exported_token = {"session_id": "new-session", "api_url": url}
+        self.device_infos = {"CAM123": {"deviceInfos": {"name": "Front"}}}
+        self.__class__.instances.append(self)
+
+    def login(self, sms_code: int | None = None) -> None:
+        self.login_calls.append(sms_code)
+
+    def get_device_infos(self, serial: str | None = None) -> dict[str, Any]:
+        if serial:
+            return self.device_infos.get(serial, {})
+        return self.device_infos
+
+    def export_token(self) -> dict[str, Any]:
+        return dict(self.exported_token)
+
+    def close_session(self) -> None:
+        self.closed = True
+
+
+def _install_fake_client(monkeypatch) -> type[_FakeClient]:
+    _FakeClient.instances = []
+    monkeypatch.setattr(cli_module, "EzvizClient", _FakeClient)
+    return _FakeClient
+
+
+def test_main_requires_existing_token_or_credentials(tmp_path, caplog) -> None:
+    missing_token = tmp_path / "missing-token.json"
+
+    assert cli_module.main(["--token-file", str(missing_token), "device_infos"]) == 2
+
+    assert "Provide --token-file" in caplog.text
+
+
+def test_main_uses_existing_token_file_without_login(monkeypatch, tmp_path, capsys) -> None:
+    fake_client = _install_fake_client(monkeypatch)
+    token_file = tmp_path / "token.json"
+    token_file.write_text(
+        json.dumps({"session_id": "saved-session", "api_url": "apiieu.ezvizlife.com"}),
+        encoding="utf-8",
+    )
+
+    assert cli_module.main(["--token-file", str(token_file), "device_infos", "--serial", "CAM123"]) == 0
+
+    client = fake_client.instances[0]
+    assert client.account is None
+    assert client.password is None
+    assert client.token == {"session_id": "saved-session", "api_url": "apiieu.ezvizlife.com"}
+    assert client.login_calls == []
+    assert client.closed is True
+    assert json.loads(capsys.readouterr().out) == {"deviceInfos": {"name": "Front"}}
+
+
+def test_main_logs_in_with_credentials_and_saves_token(monkeypatch, tmp_path) -> None:
+    fake_client = _install_fake_client(monkeypatch)
+    token_file = tmp_path / "saved-token.json"
+
+    assert (
+        cli_module.main(
+            [
+                "--username",
+                "user@example.test",
+                "--password",
+                "secret",
+                "--region",
+                "apiieu.ezvizlife.com",
+                "--token-file",
+                str(token_file),
+                "--save-token",
+                "device_infos",
+            ]
+        )
+        == 0
+    )
+
+    client = fake_client.instances[0]
+    assert client.login_calls == [None]
+    assert client.closed is True
+    assert json.loads(token_file.read_text(encoding="utf-8")) == {
+        "session_id": "new-session",
+        "api_url": "apiieu.ezvizlife.com",
+    }
+
+
+def test_main_prompts_for_mfa_code_and_retries_login(monkeypatch, tmp_path) -> None:
+    class MfaClient(_FakeClient):
+        def login(self, sms_code: int | None = None) -> None:
+            self.login_calls.append(sms_code)
+            if sms_code is None:
+                raise EzvizAuthVerificationCode("MFA required")
+
+    MfaClient.instances = []
+    monkeypatch.setattr(cli_module, "EzvizClient", MfaClient)
+    monkeypatch.setattr("builtins.input", lambda _prompt: "123456")
+    token_file = tmp_path / "unused-token.json"
+
+    assert (
+        cli_module.main(
+            [
+                "--username",
+                "user@example.test",
+                "--password",
+                "secret",
+                "--token-file",
+                str(token_file),
+                "device_infos",
+            ]
+        )
+        == 0
+    )
+
+    client = MfaClient.instances[0]
+    assert client.login_calls == [None, 123456]
+    assert client.closed is True


### PR DESCRIPTION
## Summary
- add offline CLI tests for missing token/credential validation
- cover loading an existing token file without logging in
- cover username/password login with --save-token persistence
- cover MFA prompt/retry behavior without touching the EZVIZ cloud

## Local validation
- ruff check .
- mypy --install-types --non-interactive .
- pytest -q
- python -m build
- twine check dist/*
