### PR TITLE
Update changelog for test coverage work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,15 @@ This project follows [Semantic Versioning](https://semver.org/) for published re
 
 ### Added
 
-- Modern package build checks in CI, including wheel install and CLI smoke tests.
-- Offline tests for utility helpers, feature parsing, device parsing, MQTT decoding, pagelist pagination, HTTP helpers, and auth/token lifecycle behavior.
+- Modern package build checks in CI, including wheel install, CLI smoke tests, and supported Python version matrix coverage.
+- Offline tests for utility helpers, feature parsing, device parsing, MQTT decoding, pagelist pagination, HTTP helpers, auth/token lifecycle behavior, camera/light/smart-plug status helpers, alarm parsing, and CLI command dispatch.
 - PEP 561 `py.typed` marker so downstream type checkers can consume inline package types.
 - Example wrappers for MQTT listening and RTSP authentication testing.
 
 ### Changed
 
+- Added Home Assistant integration contract documentation for stable APIs, status payloads, auth exceptions, MQTT behavior, and release coordination.
+- Added PyPI keywords and Trove classifiers for supported Python versions, typed-package status, Home Assistant/EZVIZ discovery, and CLI/library usage.
 - Consolidated package metadata into `pyproject.toml` while keeping `setup.py` as a compatibility shim.
 - Restored the installed `pyezvizapi` console script via `project.scripts`.
 - Replaced CLI table rendering dependency on pandas with a small stdlib formatter.


### PR DESCRIPTION
## Summary
- update the Unreleased changelog entries to include recent Python matrix, metadata, docs, status-helper, alarm parser, and CLI coverage work
- keep the release notes aligned with the sequence of merged quality-focused PRs

## Local validation
- ruff check .
- mypy --install-types --non-interactive .
- pytest -q
- python -m build
- twine check dist/*
