### PR TITLE
Update changelog for offline coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,14 @@ This project follows [Semantic Versioning](https://semver.org/) for published re
 ### Added
 
 - Modern package build checks in CI, including wheel install, CLI smoke tests, and supported Python version matrix coverage.
-- Offline tests for utility helpers, feature parsing, device parsing, MQTT decoding, pagelist pagination, HTTP helpers, auth/token lifecycle behavior, camera/light/smart-plug status helpers, alarm parsing, and CLI command dispatch.
+- Offline tests for utility helpers, feature parsing, device parsing, MQTT decoding, pagelist pagination, HTTP helpers, auth/token lifecycle behavior, camera/light/smart-plug status helpers, alarm parsing, CLI command dispatch, load-device aggregation, unified-message request building, device add/security flows, devconfig/network helpers, IoT feature/action helpers, device maintenance/admin helpers, and voice/whistle/chime helpers.
 - PEP 561 `py.typed` marker so downstream type checkers can consume inline package types.
 - Example wrappers for MQTT listening and RTSP authentication testing.
 
 ### Changed
 
 - Added Home Assistant integration contract documentation for stable APIs, status payloads, auth exceptions, MQTT behavior, and release coordination.
+- Limited alarm prefetching to camera devices so smart-plug/socket serials are not queried as camera alarm targets.
 - Added PyPI keywords and Trove classifiers for supported Python versions, typed-package status, Home Assistant/EZVIZ discovery, and CLI/library usage.
 - Consolidated package metadata into `pyproject.toml` while keeping `setup.py` as a compatibility shim.
 - Restored the installed `pyezvizapi` console script via `project.scripts`.


### PR DESCRIPTION
## Summary
- expand the Unreleased test coverage note for the newly merged offline request/control suites
- document the alarm-prefetch behavior fix that limits alarm targets to camera devices

## Local validation
- inspected CHANGELOG.md diff
- ran a small text assertion for the new changelog entries
