### PR TITLE
Add device wrapper helper tests

### DIFF
--- a/tests/test_camera_status.py
+++ b/tests/test_camera_status.py
@@ -157,3 +157,21 @@ def test_camera_status_prefers_typed_record_core_fields_and_switches() -> None:
     assert status["supportExt"] == {"SupportExt": "1"}
     assert status["switches"] == {7: True, 21: False}
     assert cast(dict[str, Any], status)["CUSTOM_TOP_LEVEL"] == {"kept": True}
+
+
+def test_camera_fetch_key_and_refresh_alarms_delegate(monkeypatch) -> None:
+    camera = EzvizCamera(cast(EzvizClient, object()), "CAM123", _camera_payload())
+    calls = 0
+
+    def fake_alarm_list(prefetched: dict[str, object] | None = None) -> None:
+        nonlocal calls
+        assert prefetched is None
+        calls += 1
+
+    monkeypatch.setattr(camera, "_alarm_list", fake_alarm_list)
+
+    assert camera.fetch_key(["deviceInfos", "name"]) == "Front Door"
+    assert camera.fetch_key(["missing"], default_value="fallback") == "fallback"
+    camera.refresh_alarms()
+
+    assert calls == 1

--- a/tests/test_light_plug_status.py
+++ b/tests/test_light_plug_status.py
@@ -229,3 +229,30 @@ def test_smart_plug_power_methods_write_plug_switch() -> None:
         ("PLUG123", DeviceSwitchType.PLUG.value, 1),
         ("PLUG123", DeviceSwitchType.PLUG.value, 0),
     ]
+
+
+def test_light_helper_methods_fetch_features_and_defaults() -> None:
+    light = EzvizLightBulb(cast(EzvizClient, object()), "LIGHT123", _light_payload())
+
+    assert light.fetch_key(["deviceInfos", "name"]) == "Porch Light"
+    assert light.fetch_key(["missing"], default_value="fallback") == "fallback"
+    assert light.get_feature_json()["productId"] == "prod-light"
+    assert light.get_product_id() == "prod-light"
+    assert light.get_feature_item("brightness") == {"itemKey": "brightness", "dataValue": 66}
+    assert light.get_feature_item("missing") == {"dataValue": ""}
+    assert light.get_feature_item("missing", {"dataValue": 12}) == {"dataValue": 12}
+
+
+def test_smart_plug_fetch_key_and_power_methods() -> None:
+    client = _FakeControlClient()
+    plug = EzvizSmartPlug(cast(EzvizClient, client), "PLUG123", _plug_payload())
+
+    assert plug.fetch_key(["deviceInfos", "name"]) == "Heater Plug"
+    assert plug.fetch_key(["missing"], default_value="fallback") == "fallback"
+    assert plug.power_on() is True
+    assert plug.power_off() is True
+
+    assert client.switch_calls == [
+        ("PLUG123", DeviceSwitchType.PLUG.value, 1),
+        ("PLUG123", DeviceSwitchType.PLUG.value, 0),
+    ]


### PR DESCRIPTION
## Summary
- add offline coverage for light-bulb helper methods around nested fetches, feature JSON, product id, and feature item defaults
- add smart-plug fetch/power helper coverage
- add camera fetch_key and refresh_alarms delegation coverage

## Local validation
- ruff check .
- mypy --install-types --non-interactive .
- pytest -q
- python -m build
- twine check dist/*
