### PR TITLE
Add RTSP and utility helper tests

### DIFF
--- a/tests/test_rtsp_auth.py
+++ b/tests/test_rtsp_auth.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import hashlib
+
+from pyezvizapi.test_cam_rtsp import TestRTSPAuth, genmsg_describe
+
+
+def test_genmsg_describe_builds_rtsp_describe_request() -> None:
+    request = genmsg_describe(
+        "rtsp://192.0.2.10/h264",
+        3,
+        "UnitTest",
+        "Basic abc123",
+    )
+
+    assert request == (
+        "DESCRIBE rtsp://192.0.2.10/h264 RTSP/1.0\r\n"
+        "CSeq: 3\r\n"
+        "Authorization: Basic abc123\r\n"
+        "User-Agent: UnitTest\r\n"
+        "Accept: application/sdp\r\n\r\n"
+    )
+
+
+def test_generate_auth_string_builds_digest_response() -> None:
+    auth = TestRTSPAuth("192.0.2.10", "user", "pass", "/h264")
+
+    header = auth.generate_auth_string(b"realm-1", "DESCRIBE", "/h264", b"nonce-1")
+
+    ha1 = hashlib.md5(b"user:realm-1:pass").hexdigest()
+    ha2 = hashlib.md5(b"DESCRIBE:/h264").hexdigest()
+    expected_response = hashlib.md5(f"{ha1}:nonce-1:{ha2}".encode()).hexdigest()
+    assert header == (
+        'Digest username="user", realm="realm-1", algorithm="MD5", '
+        f'nonce="nonce-1", uri="/h264", response="{expected_response}"'
+    )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -13,6 +13,7 @@ from pyezvizapi.exceptions import PyEzvizError
 from pyezvizapi.utils import (
     coerce_int,
     compute_motion_from_alarm,
+    convert_to_dict,
     decode_json,
     decrypt_image,
     deep_merge,
@@ -210,3 +211,11 @@ def test_decrypt_image_rejects_invalid_password_and_malformed_payloads() -> None
 
     with pytest.raises(PyEzvizError, match="Invalid image data after trimming preamble"):
         decrypt_image((b"x" * 40) + encrypted[:20], "ABCDEF")
+
+
+def test_convert_to_dict_decodes_json_string_values_in_place() -> None:
+    payload = {"nested": '{"enabled": true}', "invalid": "not-json", "plain": 1}
+
+    assert convert_to_dict(payload) is payload
+    assert payload == {"nested": {"enabled": True}, "invalid": "not-json", "plain": 1}
+    assert convert_to_dict(["not", "a", "dict"]) == ["not", "a", "dict"]


### PR DESCRIPTION
## Summary
- add offline RTSP helper tests for DESCRIBE request generation and digest auth header construction
- add convert_to_dict() coverage for in-place JSON string conversion and non-dict passthrough

## Local validation
- ruff check .
- mypy --install-types --non-interactive .
- pytest -q
- python -m build
- twine check dist/*
