### PR TITLE
Add CI coverage reporting

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -62,14 +62,21 @@ jobs:
       - name: mypy (auto-install any missing stubs)
         run: mypy --install-types --non-interactive .
 
-      - name: pytest (skip gracefully if no tests yet)
+      - name: pytest with coverage (skip gracefully if no tests yet)
         shell: bash
         run: |
           if compgen -G "tests/test_*.py" > /dev/null; then
-            pytest -q
+            pytest --cov=pyezvizapi --cov-report=term-missing --cov-report=xml
           else
             echo "No tests found under tests/, skipping pytest."
           fi
+
+      - name: Upload coverage XML
+        if: always() && hashFiles('coverage.xml') != ''
+        uses: actions/upload-artifact@v7
+        with:
+          name: coverage-py${{ matrix.python-version }}
+          path: coverage.xml
 
       - name: Build package
         run: python -m build

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ Issues = "https://github.com/RenierM26/pyEzvizApi/issues"
 pyezvizapi = "pyezvizapi.__main__:main"
 
 [project.optional-dependencies]
-dev = ["build", "ruff", "mypy", "pytest", "twine", "types-requests"]
+dev = ["build", "ruff", "mypy", "pytest", "pytest-cov", "twine", "types-requests"]
 
 [tool.setuptools.packages.find]
 include = ["pyezvizapi*"]
@@ -110,3 +110,12 @@ python_functions = ["test_*"]
 
 [tool.coverage.run]
 source = ["pyezvizapi"]
+
+
+[tool.coverage.report]
+show_missing = true
+skip_covered = true
+exclude_also = [
+  "if TYPE_CHECKING:",
+  "if __name__ == .__main__.",
+]


### PR DESCRIPTION
## Summary
- add pytest-cov to the dev extra
- run CI tests with terminal and XML coverage reports
- upload per-Python coverage XML artifacts from the CI matrix
- configure coverage reporting to show missing lines while skipping fully covered files

## Local validation
- ruff check .
- mypy --install-types --non-interactive .
- pytest -q
- python -m build
- twine check dist/*
- pytest --cov=pyezvizapi --cov-report=term-missing --cov-report=xml
