### PR TITLE
Add conservative coverage floor

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -66,7 +66,7 @@ jobs:
         shell: bash
         run: |
           if compgen -G "tests/test_*.py" > /dev/null; then
-            pytest --cov=pyezvizapi --cov-report=term-missing --cov-report=xml
+            pytest --cov=pyezvizapi --cov-report=term-missing --cov-report=xml --cov-fail-under=85
           else
             echo "No tests found under tests/, skipping pytest."
           fi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,6 +113,7 @@ source = ["pyezvizapi"]
 
 
 [tool.coverage.report]
+fail_under = 85
 show_missing = true
 skip_covered = true
 exclude_also = [


### PR DESCRIPTION
## Summary
- add a conservative 85% coverage floor to coverage.py config
- enforce the same floor in CI pytest coverage runs
- keep the threshold below current local coverage to avoid brittle failures while preventing major regressions

## Local validation
- ruff check .
- mypy --install-types --non-interactive .
- pytest -q
- python -m build
- twine check dist/*
- pytest --cov=pyezvizapi --cov-report=term-missing --cov-report=xml --cov-fail-under=85
