### PR TITLE
Add CI pip consistency checks

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -56,6 +56,9 @@ jobs:
       - name: Install project + dev deps
         run: pip install -e .[dev]
 
+      - name: Check installed dependency consistency
+        run: python -m pip check
+
       - name: Ruff
         run: ruff check .
 
@@ -90,5 +93,6 @@ jobs:
           python -m venv /tmp/pyezvizapi-wheel-smoke
           /tmp/pyezvizapi-wheel-smoke/bin/python -m pip install -U pip
           /tmp/pyezvizapi-wheel-smoke/bin/python -m pip install dist/*.whl
+          /tmp/pyezvizapi-wheel-smoke/bin/python -m pip check
           /tmp/pyezvizapi-wheel-smoke/bin/python -m pyezvizapi --help
           /tmp/pyezvizapi-wheel-smoke/bin/pyezvizapi --help


### PR DESCRIPTION
## Summary
- run `python -m pip check` after the editable dev install in CI
- run `pip check` again inside the built-wheel smoke-test virtualenv
- keep package validation focused on dependency metadata consistency without changing runtime code

## Local validation
- python -m pip check
- ruff check .
- mypy --install-types --non-interactive .
- pytest -q
- python -m build
- twine check dist/*
- local wheel smoke install + pip check + CLI help
