### PR TITLE
Ignore Ruff cache artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,6 +120,9 @@ venv.bak/
 # mkdocs documentation
 /site
 
+# Ruff
+.ruff_cache/
+
 # mypy
 .mypy_cache/
 .dmypy.json


### PR DESCRIPTION
## Summary
- add `.ruff_cache/` to `.gitignore`
- keep generated Ruff cache artifacts out of future commits

## Local validation
- ruff check .
- mypy --install-types --non-interactive .
- pytest -q
- python -m build
- twine check dist/*
