### PR TITLE
Update changelog for formatting hygiene

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ This project follows [Semantic Versioning](https://semver.org/) for published re
 - Added CI `pip check` validation for both editable development installs and built-wheel smoke-test installs.
 - Documented the development validation workflow, artifact cleanup commands, and offline-test policy in the README.
 - Added contributor, support, security, PR checklist, and issue-template documentation for safer reports and easier maintenance.
+- Added editor and Git line-ending defaults, plus Ruff cache ignores, to reduce generated-artifact and formatting drift.
 - Added Home Assistant integration contract documentation for stable APIs, status payloads, auth exceptions, MQTT behavior, and release coordination.
 - Limited alarm prefetching to camera devices so smart-plug/socket serials are not queried as camera alarm targets.
 - Added PyPI keywords and Trove classifiers for supported Python versions, typed-package status, Home Assistant/EZVIZ discovery, and CLI/library usage.


### PR DESCRIPTION
## Summary
- update the Unreleased changelog for recent formatting/repo-hygiene work
- mention editor defaults, Git line-ending normalization, and Ruff cache ignores

## Local validation
- ruff check .
- mypy --install-types --non-interactive .
- pytest -q
- python -m build
- twine check dist/*
