### PR TITLE
Smoke-test release wheel before publishing

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -42,6 +42,16 @@ jobs:
           python -m build
           twine check dist/*
 
+      - name: Smoke-test built wheel and CLI
+        shell: bash
+        run: |
+          python -m venv /tmp/pyezvizapi-release-smoke
+          /tmp/pyezvizapi-release-smoke/bin/python -m pip install -U pip
+          /tmp/pyezvizapi-release-smoke/bin/python -m pip install dist/*.whl
+          /tmp/pyezvizapi-release-smoke/bin/python -m pip check
+          /tmp/pyezvizapi-release-smoke/bin/python -m pyezvizapi --help
+          /tmp/pyezvizapi-release-smoke/bin/pyezvizapi --help
+
       - name: Upload distributions
         uses: actions/upload-artifact@v7
         with:


### PR DESCRIPTION
## Summary
- add a release workflow wheel smoke test before uploading distributions
- install the built wheel in a clean venv
- run `pip check` plus both module and console-script CLI help commands before PyPI publishing

## Local validation
- ruff check .
- mypy --install-types --non-interactive .
- pytest -q
- python -m build
- twine check dist/*
- local release-style wheel smoke install + pip check + CLI help
