### PR TITLE
Add package documentation metadata links

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,8 @@ dependencies = [
 [project.urls]
 Homepage = "https://github.com/RenierM26/pyEzvizApi/"
 Repository = "https://github.com/RenierM26/pyEzvizApi/"
+Documentation = "https://github.com/RenierM26/pyEzvizApi/tree/main/docs"
+Changelog = "https://github.com/RenierM26/pyEzvizApi/blob/main/CHANGELOG.md"
 Issues = "https://github.com/RenierM26/pyEzvizApi/issues"
 
 [project.scripts]


### PR DESCRIPTION
## Summary
- add PyPI project URL metadata for documentation
- add PyPI project URL metadata for the changelog
- keep package users pointed at the Home Assistant contract docs and release notes from the package page

## Local validation
- ruff check .
- mypy --install-types --non-interactive .
- pytest -q
- python -m build
- twine check dist/*
