### PR TITLE
Route issues through structured templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,9 @@
-blank_issues_enabled: true
+blank_issues_enabled: false
 contact_links:
   - name: Home Assistant integration contract
     url: https://github.com/RenierM26/pyEzvizApi/blob/main/docs/home-assistant-contract.md
     about: Review integration-facing compatibility expectations before proposing breaking changes.
+
+  - name: Security policy
+    url: https://github.com/RenierM26/pyEzvizApi/blob/main/SECURITY.md
+    about: Report vulnerabilities or security-sensitive behavior without posting secrets publicly.


### PR DESCRIPTION
## Summary
- disable blank GitHub issues so reports go through the structured bug/feature templates
- add a Security policy contact link for vulnerability or security-sensitive reports
- keep redaction guidance visible before users post credentials, tokens, or private camera details publicly

## Local validation
- ruff check .
- mypy --install-types --non-interactive .
- pytest -q
- python -m build
- twine check dist/*
