### PR TITLE
Add CodeQL security scan workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,47 @@
+name: CodeQL
+
+on:
+  pull_request:
+    branches: [ main ]
+    types: [ opened, synchronize, reopened, ready_for_review ]
+    paths:
+      - "pyezvizapi/**"
+      - "examples/**"
+      - "pyproject.toml"
+      - ".github/workflows/codeql.yml"
+  push:
+    branches: [ main ]
+    paths:
+      - "pyezvizapi/**"
+      - "examples/**"
+      - "pyproject.toml"
+      - ".github/workflows/codeql.yml"
+  schedule:
+    - cron: "24 3 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  security-events: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    name: Analyze Python
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: github/codeql-action/init@v4
+        with:
+          languages: python
+          queries: security-and-quality
+
+      - uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:python"


### PR DESCRIPTION
## Summary
- add a CodeQL workflow for Python security-and-quality analysis
- run CodeQL on relevant pull requests and pushes to main
- add a weekly scheduled scan and manual dispatch
- keep workflow permissions least-privilege with read-only contents plus security event upload

## Local validation
- ruff check .
- mypy --install-types --non-interactive .
- pytest -q
- python -m build
- twine check dist/*
