### PR TITLE
Add one-click manual release workflow

### DIFF
--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -141,6 +141,7 @@ jobs:
             dist/*
             --repo "${GITHUB_REPOSITORY}"
             --title "v${RELEASE_VERSION}"
+            --target "${GITHUB_SHA}"
             --generate-notes
           )
           if [[ "${PRERELEASE}" == "true" ]]; then

--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -1,0 +1,149 @@
+name: Manual Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to release, matching pyproject.toml, e.g. 1.0.4.5"
+        required: true
+        type: string
+      prerelease:
+        description: "Mark the GitHub release as a prerelease"
+        required: true
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+
+jobs:
+  release-build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Verify requested version matches package version
+        shell: bash
+        env:
+          RELEASE_VERSION: ${{ inputs.version }}
+        run: |
+          python - <<'PY'
+          import os
+          import tomllib
+
+          requested = os.environ["RELEASE_VERSION"].strip()
+          if requested.startswith("v"):
+              raise SystemExit("Use the bare version input, e.g. 1.0.4.5, not v1.0.4.5.")
+
+          with open("pyproject.toml", "rb") as file:
+              version = tomllib.load(file)["project"]["version"]
+
+          if requested != version:
+              raise SystemExit(
+                  f"Requested release version {requested!r} does not match pyproject version {version!r}."
+              )
+
+          print(f"Release version {requested!r} matches pyproject.toml.")
+          PY
+
+      - name: Verify release tag does not already exist
+        shell: bash
+        env:
+          RELEASE_VERSION: ${{ inputs.version }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          tag="v${RELEASE_VERSION}"
+          if git ls-remote --exit-code --tags origin "refs/tags/${tag}" >/dev/null 2>&1; then
+            echo "Tag ${tag} already exists. Refusing to reuse a release tag."
+            exit 1
+          fi
+          if gh release view "${tag}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
+            echo "GitHub release ${tag} already exists. Refusing to overwrite it."
+            exit 1
+          fi
+          echo "Release tag ${tag} is available."
+
+      - name: Build release distributions
+        run: |
+          python -m pip install -U pip build twine
+          python -m build
+          twine check dist/*
+
+      - name: Smoke-test built wheel and CLI
+        shell: bash
+        run: |
+          python -m venv /tmp/pyezvizapi-manual-release-smoke
+          /tmp/pyezvizapi-manual-release-smoke/bin/python -m pip install -U pip
+          /tmp/pyezvizapi-manual-release-smoke/bin/python -m pip install dist/*.whl
+          /tmp/pyezvizapi-manual-release-smoke/bin/python -m pip check
+          /tmp/pyezvizapi-manual-release-smoke/bin/python -m pyezvizapi --help
+          /tmp/pyezvizapi-manual-release-smoke/bin/pyezvizapi --help
+
+      - name: Upload release distributions
+        uses: actions/upload-artifact@v7
+        with:
+          name: release-dists
+          path: dist/
+
+  pypi-publish:
+    runs-on: ubuntu-latest
+    needs:
+      - release-build
+    permissions:
+      id-token: write
+
+    environment:
+      name: pypi
+      url: https://pypi.org/project/pyezvizapi/${{ inputs.version }}
+
+    steps:
+      - name: Retrieve release distributions
+        uses: actions/download-artifact@v8
+        with:
+          name: release-dists
+          path: dist/
+
+      - name: Publish release distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/
+
+  github-release:
+    runs-on: ubuntu-latest
+    needs:
+      - release-build
+      - pypi-publish
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Retrieve release distributions
+        uses: actions/download-artifact@v8
+        with:
+          name: release-dists
+          path: dist/
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_VERSION: ${{ inputs.version }}
+          PRERELEASE: ${{ inputs.prerelease }}
+        run: |
+          args=(
+            "v${RELEASE_VERSION}"
+            dist/*
+            --repo "${GITHUB_REPOSITORY}"
+            --title "v${RELEASE_VERSION}"
+            --generate-notes
+          )
+          if [[ "${PRERELEASE}" == "true" ]]; then
+            args+=(--prerelease)
+          fi
+          gh release create "${args[@]}"


### PR DESCRIPTION
## Summary
- add a manual release workflow that can publish by running one workflow with a version input
- verify the requested version matches `pyproject.toml`
- refuse to reuse an existing tag or GitHub release
- build distributions, run `twine check`, smoke-test the wheel, run `pip check`, and check both CLI help entry points
- publish to PyPI using trusted publishing, then create a GitHub release with the built artifacts

## Local validation
- ruff check .
- mypy --install-types --non-interactive .
- pytest -q
- python -m build
- twine check dist/*
- local manual-release-style wheel smoke install + pip check + CLI help
