### PR TITLE
Bump version from 1.0.4.5 to 1.0.4.6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyezvizapi"
-version = "1.0.4.5"
+version = "1.0.4.6"
 description = "EZVIZ API client for Home Assistant and CLI"
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
## Summary

- Bump version to 1.0.4.6

## Validation

Please check the commands that were run locally:

- [ ] `ruff check .`
- [ ] `mypy --install-types --non-interactive .`
- [ ] `pytest --cov=pyezvizapi --cov-report=term-missing --cov-report=xml --cov-fail-under=85`
- [ ] `python -m build`
- [ ] `twine check dist/*`
- [ ] `python -m pip check`

## Compatibility

- [ ] Tests are offline and do not require EZVIZ credentials, real cameras, cloud calls, or live network access.
- [ ] Home Assistant / custom integration behavior is preserved, or the intended compatibility impact is described above.
- [ ] Generated artifacts were removed before commit (`dist`, `build`, `*.egg-info`, caches, coverage files).
