### PR TITLE
Prepare release v1.0.4.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This project follows [Semantic Versioning](https://semver.org/) for published re
 
 ## Unreleased
 
+## v1.0.4.6 - 2026-04-27
+
 ### Added
 
 - Modern package build checks in CI, including wheel install, CLI smoke tests, and supported Python version matrix coverage.


### PR DESCRIPTION
## Summary
- move current `Unreleased` changelog entries into a dated `v1.0.4.6` release section
- leave a fresh empty `Unreleased` section for future changes

After this PR is reviewed and merged, run the Manual Release workflow with version `1.0.4.6`.
