### PR TITLE
Use existing PyPI publisher from manual release

### DIFF
--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -90,34 +90,10 @@ jobs:
           name: release-dists
           path: dist/
 
-  pypi-publish:
-    runs-on: ubuntu-latest
-    needs:
-      - release-build
-    permissions:
-      id-token: write
-
-    environment:
-      name: pypi
-      url: https://pypi.org/project/pyezvizapi/${{ inputs.version }}
-
-    steps:
-      - name: Retrieve release distributions
-        uses: actions/download-artifact@v8
-        with:
-          name: release-dists
-          path: dist/
-
-      - name: Publish release distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          packages-dir: dist/
-
   github-release:
     runs-on: ubuntu-latest
     needs:
       - release-build
-      - pypi-publish
     permissions:
       contents: write
 
@@ -143,6 +119,7 @@ jobs:
             --title "v${RELEASE_VERSION}"
             --target "${GITHUB_SHA}"
             --generate-notes
+            --notes "This release was created by the Manual Release workflow after local release checks passed. The Upload Python Package workflow publishes the distributions to PyPI from this GitHub release."
           )
           if [[ "${PRERELEASE}" == "true" ]]; then
             args+=(--prerelease)


### PR DESCRIPTION
## Summary
- remove direct PyPI publishing from the Manual Release workflow
- keep the manual workflow as the one-click release entry point: validate version, build, twine check, wheel smoke test, and create the GitHub release
- rely on the existing Upload Python Package workflow, which is already trusted by PyPI, to publish when the GitHub release is created
- keep the release tag pinned to the exact commit that created the release

## Why
The previous Manual Release workflow failed PyPI trusted publishing because PyPI trusts `.github/workflows/python-publish.yml`, not `.github/workflows/manual-release.yml`. Creating the GitHub release lets the existing known-good publisher handle PyPI upload.

## Local validation
- ruff check .
- mypy --install-types --non-interactive .
- pytest -q
- python -m build
- twine check dist/*
