### PR TITLE
Clean up fixable CodeQL alerts

### DIFF
--- a/pyezvizapi/client.py
+++ b/pyezvizapi/client.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from collections.abc import Callable, Iterable, Mapping
 import datetime as dt
 import hashlib
+from importlib import import_module
 import json
 import logging
 from typing import Any, ClassVar, NotRequired, TypedDict, cast
@@ -107,7 +108,6 @@ from .api_endpoints import (
     API_ENDPOINT_V3_ALARMS,
     API_ENDPOINT_VIDEO_ENCRYPT,
 )
-from .camera import EzvizCamera
 from .cas import EzvizCAS
 from .constants import (
     DEFAULT_TIMEOUT,
@@ -128,10 +128,8 @@ from .exceptions import (
     PyEzvizError,
 )
 from .feature import optionals_mapping
-from .light_bulb import EzvizLightBulb
 from .models import EzvizDeviceRecord, build_device_records_map
 from .mqtt import MQTTClient
-from .smart_plug import EzvizSmartPlug
 from .utils import convert_to_dict, deep_merge
 
 _LOGGER = logging.getLogger(__name__)
@@ -371,8 +369,8 @@ class EzvizClient:
                 method,
                 url,
                 self._summarize_payload(params),
-                self._summarize_payload(data),
-                self._summarize_payload(json_body),
+                self._summarize_payload(data, include_preview=False),
+                self._summarize_payload(json_body, include_preview=False),
             )
         try:
             req = self._session.request(
@@ -495,19 +493,33 @@ class EzvizClient:
         return None
 
     @staticmethod
-    def _summarize_payload(payload: Any) -> str:
-        """Return a compact description of payload content for debug logs."""
+    def _summarize_payload(  # noqa: PLR0911
+        payload: Any, *, include_preview: bool = True
+    ) -> str:
+        """Return a compact, credential-safe payload description for debug logs."""
 
         if payload is None:
             return "-"
         if isinstance(payload, Mapping):
-            keys = ", ".join(sorted(str(key) for key in payload))
+            sensitive_keys = {
+                "password",
+                "oldPassword",
+                "newPassword",
+                "token",
+                "sessionId",
+            }
+            keys = ", ".join(
+                "<redacted>" if str(key) in sensitive_keys else str(key)
+                for key in sorted(payload)
+            )
             return f"dict[{keys}]"
         if isinstance(payload, (list, tuple, set)):
             return f"{type(payload).__name__}(len={len(payload)})"
         if isinstance(payload, (bytes, bytearray)):
             return f"bytes(len={len(payload)})"
         if isinstance(payload, str):
+            if not include_preview:
+                return f"str(len={len(payload)})"
             trimmed = payload[:32] + "…" if len(payload) > 32 else payload
             return f"str(len={len(payload)}, preview={trimmed!r})"
         return f"{type(payload).__name__}"
@@ -2227,8 +2239,12 @@ class EzvizClient:
 
                 if rec.device_category == DeviceCatagories.LIGHTING.value:
                     try:
+                        ezviz_light_bulb = cast(
+                            Any, import_module("pyezvizapi.light_bulb")
+                        ).EzvizLightBulb
+
                         # Create a light bulb object
-                        self._light_bulbs[device] = EzvizLightBulb(
+                        self._light_bulbs[device] = ezviz_light_bulb(
                             self, device, dict(rec.raw)
                         ).status()
                     except (
@@ -2245,8 +2261,12 @@ class EzvizClient:
                         )
                 elif rec.device_category == DeviceCatagories.SOCKET.value:
                     try:
+                        ezviz_smart_plug = cast(
+                            Any, import_module("pyezvizapi.smart_plug")
+                        ).EzvizSmartPlug
+
                         # Create a smart plug object
-                        self._smart_plugs[device] = EzvizSmartPlug(
+                        self._smart_plugs[device] = ezviz_smart_plug(
                             self, device, dict(rec.raw)
                         ).status()
                     except (
@@ -2263,8 +2283,12 @@ class EzvizClient:
                         )
                 else:
                     try:
+                        ezviz_camera = cast(
+                            Any, import_module("pyezvizapi.camera")
+                        ).EzvizCamera
+
                         # Create camera object
-                        cam = EzvizCamera(self, device, dict(rec.raw))
+                        cam = ezviz_camera(self, device, dict(rec.raw))
                         self._cameras[device] = cam.status(
                             refresh=refresh,
                             latest_alarm=latest_alarms.get(device),
@@ -2405,7 +2429,6 @@ class EzvizClient:
         """Load all devices and build dict per device serial."""
         devices = self._get_page_list()
         result: dict[str, Any] = {}
-        _res_id = "NONE"
 
         for device in devices.get("deviceInfos", []) or []:
             _serial = device["deviceSerial"]

--- a/pyezvizapi/client.py
+++ b/pyezvizapi/client.py
@@ -369,8 +369,8 @@ class EzvizClient:
                 method,
                 url,
                 self._summarize_payload(params),
-                self._summarize_payload(data, include_preview=False),
-                self._summarize_payload(json_body, include_preview=False),
+                self._body_debug_summary(data),
+                self._body_debug_summary(json_body),
             )
         try:
             req = self._session.request(
@@ -493,9 +493,7 @@ class EzvizClient:
         return None
 
     @staticmethod
-    def _summarize_payload(  # noqa: PLR0911
-        payload: Any, *, include_preview: bool = True
-    ) -> str:
+    def _summarize_payload(payload: Any) -> str:
         """Return a compact, credential-safe payload description for debug logs."""
 
         if payload is None:
@@ -509,8 +507,8 @@ class EzvizClient:
                 "sessionId",
             }
             keys = ", ".join(
-                "<redacted>" if str(key) in sensitive_keys else str(key)
-                for key in sorted(payload)
+                "<redacted>" if key in sensitive_keys else key
+                for key in sorted(str(key) for key in payload)
             )
             return f"dict[{keys}]"
         if isinstance(payload, (list, tuple, set)):
@@ -518,11 +516,20 @@ class EzvizClient:
         if isinstance(payload, (bytes, bytearray)):
             return f"bytes(len={len(payload)})"
         if isinstance(payload, str):
-            if not include_preview:
-                return f"str(len={len(payload)})"
             trimmed = payload[:32] + "…" if len(payload) > 32 else payload
             return f"str(len={len(payload)}, preview={trimmed!r})"
         return f"{type(payload).__name__}"
+
+    @staticmethod
+    def _body_debug_summary(payload: Any) -> str:
+        """Return a request-body summary without inspecting sensitive contents."""
+
+        if payload is None:
+            return "-"
+        try:
+            return f"{type(payload).__name__}(len={len(payload)})"
+        except TypeError:
+            return type(payload).__name__
 
     def _ensure_ok(self, payload: dict, message: str) -> None:
         """Raise PyEzvizError with context if response is not OK.

--- a/pyezvizapi/test_cam_rtsp.py
+++ b/pyezvizapi/test_cam_rtsp.py
@@ -117,7 +117,7 @@ class TestRTSPAuth:
         describe = genmsg_describe(
             url, seq, self._rtsp_details["defaultUserAgent"], auth_seq
         )
-        _LOGGER.debug("RTSP DESCRIBE (basic):\n%s", describe)
+        _LOGGER.debug("RTSP DESCRIBE (basic) request prepared for %s", url)
         session.send(describe.encode())
         msg1: bytes = session.recv(self._rtsp_details["bufLen"])
         seq += 1
@@ -146,7 +146,7 @@ class TestRTSPAuth:
             describe = genmsg_describe(
                 url, seq, self._rtsp_details["defaultUserAgent"], auth_seq
             )
-            _LOGGER.debug("RTSP DESCRIBE (digest):\n%s", describe)
+            _LOGGER.debug("RTSP DESCRIBE (digest) request prepared for %s", url)
             session.send(describe.encode())
             msg1 = session.recv(self._rtsp_details["bufLen"])
             decoded = msg1.decode()

--- a/pyezvizapi/utils.py
+++ b/pyezvizapi/utils.py
@@ -363,6 +363,8 @@ def normalize_alarm_time(
                         alarm_dt_local = event_local_reint
                         alarm_dt_utc = event_local_reint.astimezone(datetime.UTC)
                 except ValueError:
+                    # Some firmware returns malformed timestamp strings; keep the
+                    # epoch-derived value and allow the normal fallback path.
                     pass
 
             if alarm_dt_local is not None:
@@ -382,6 +384,8 @@ def normalize_alarm_time(
             alarm_dt_utc = alarm_dt_local.astimezone(datetime.UTC)
             alarm_str = alarm_dt_local.strftime("%Y-%m-%d %H:%M:%S")
         except ValueError:
+            # Leave the default empty result when neither epoch nor string parsing
+            # can interpret the camera-provided alarm timestamp.
             pass
 
     return alarm_dt_local, alarm_dt_utc, alarm_str

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12,8 +12,10 @@ from cli_fakes import (
 )
 
 import pyezvizapi.__main__ as cli_module
-from pyezvizapi.__main__ import _format_cell, _write_table
 from pyezvizapi.exceptions import EzvizAuthVerificationCode, PyEzvizError
+
+_format_cell = cli_module._format_cell  # noqa: SLF001
+_write_table = cli_module._write_table  # noqa: SLF001
 
 
 def test_cli_imports_without_pandas_installed() -> None:

--- a/tests/test_client_parsing.py
+++ b/tests/test_client_parsing.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from typing import Any
 
 import pyezvizapi.client as client_module
-from pyezvizapi.client import EzvizClient
 from pyezvizapi.constants import DeviceCatagories
 
 
@@ -79,8 +78,10 @@ def _page_list_fixture() -> dict[str, Any]:
     }
 
 
-def _client_with_fixture(monkeypatch) -> EzvizClient:
-    client = EzvizClient(token={"session_id": "session", "api_url": "apiieu.ezvizlife.com"})
+def _client_with_fixture(monkeypatch) -> client_module.EzvizClient:
+    client = client_module.EzvizClient(
+        token={"session_id": "session", "api_url": "apiieu.ezvizlife.com"}
+    )
     monkeypatch.setattr(client, "_get_page_list", _page_list_fixture)
     return client
 
@@ -115,7 +116,7 @@ def test_load_devices_routes_supported_categories(monkeypatch) -> None:
     client = _client_with_fixture(monkeypatch)
 
     class FakeCamera:
-        def __init__(self, _client: EzvizClient, serial: str, device_obj: dict[str, Any]) -> None:
+        def __init__(self, _client: client_module.EzvizClient, serial: str, device_obj: dict[str, Any]) -> None:
             self.serial = serial
             self.device_obj = device_obj
 
@@ -129,22 +130,22 @@ def test_load_devices_routes_supported_categories(monkeypatch) -> None:
             }
 
     class FakeLightBulb:
-        def __init__(self, _client: EzvizClient, serial: str, _device_obj: dict[str, Any]) -> None:
+        def __init__(self, _client: client_module.EzvizClient, serial: str, _device_obj: dict[str, Any]) -> None:
             self.serial = serial
 
         def status(self) -> dict[str, Any]:
             return {"kind": "light", "serial": self.serial}
 
     class FakeSmartPlug:
-        def __init__(self, _client: EzvizClient, serial: str, _device_obj: dict[str, Any]) -> None:
+        def __init__(self, _client: client_module.EzvizClient, serial: str, _device_obj: dict[str, Any]) -> None:
             self.serial = serial
 
         def status(self) -> dict[str, Any]:
             return {"kind": "plug", "serial": self.serial}
 
-    monkeypatch.setattr(client_module, "EzvizCamera", FakeCamera)
-    monkeypatch.setattr(client_module, "EzvizLightBulb", FakeLightBulb)
-    monkeypatch.setattr(client_module, "EzvizSmartPlug", FakeSmartPlug)
+    monkeypatch.setattr("pyezvizapi.camera.EzvizCamera", FakeCamera)
+    monkeypatch.setattr("pyezvizapi.light_bulb.EzvizLightBulb", FakeLightBulb)
+    monkeypatch.setattr("pyezvizapi.smart_plug.EzvizSmartPlug", FakeSmartPlug)
 
     loaded = client.load_devices(refresh=False)
 
@@ -166,14 +167,14 @@ def test_load_light_bulbs_returns_only_light_statuses(monkeypatch) -> None:
     client = _client_with_fixture(monkeypatch)
 
     class FakeCamera:
-        def __init__(self, _client: EzvizClient, serial: str, _device_obj: dict[str, Any]) -> None:
+        def __init__(self, _client: client_module.EzvizClient, serial: str, _device_obj: dict[str, Any]) -> None:
             self.serial = serial
 
         def status(self, *, refresh: bool = True, latest_alarm: dict[str, Any] | None = None) -> dict[str, Any]:
             return {"kind": "camera", "serial": self.serial, "refresh": refresh}
 
     class FakeLightBulb:
-        def __init__(self, _client: EzvizClient, serial: str, device_obj: dict[str, Any]) -> None:
+        def __init__(self, _client: client_module.EzvizClient, serial: str, device_obj: dict[str, Any]) -> None:
             self.serial = serial
             self.device_obj = device_obj
 
@@ -185,15 +186,15 @@ def test_load_light_bulbs_returns_only_light_statuses(monkeypatch) -> None:
             }
 
     class FakeSmartPlug:
-        def __init__(self, _client: EzvizClient, serial: str, _device_obj: dict[str, Any]) -> None:
+        def __init__(self, _client: client_module.EzvizClient, serial: str, _device_obj: dict[str, Any]) -> None:
             self.serial = serial
 
         def status(self) -> dict[str, Any]:
             return {"kind": "plug", "serial": self.serial}
 
-    monkeypatch.setattr(client_module, "EzvizCamera", FakeCamera)
-    monkeypatch.setattr(client_module, "EzvizLightBulb", FakeLightBulb)
-    monkeypatch.setattr(client_module, "EzvizSmartPlug", FakeSmartPlug)
+    monkeypatch.setattr("pyezvizapi.camera.EzvizCamera", FakeCamera)
+    monkeypatch.setattr("pyezvizapi.light_bulb.EzvizLightBulb", FakeLightBulb)
+    monkeypatch.setattr("pyezvizapi.smart_plug.EzvizSmartPlug", FakeSmartPlug)
 
     lights = client.load_light_bulbs(refresh=False)
 
@@ -208,21 +209,21 @@ def test_load_smart_plugs_returns_only_plug_statuses(monkeypatch) -> None:
     client = _client_with_fixture(monkeypatch)
 
     class FakeCamera:
-        def __init__(self, _client: EzvizClient, serial: str, _device_obj: dict[str, Any]) -> None:
+        def __init__(self, _client: client_module.EzvizClient, serial: str, _device_obj: dict[str, Any]) -> None:
             self.serial = serial
 
         def status(self, *, refresh: bool = True, latest_alarm: dict[str, Any] | None = None) -> dict[str, Any]:
             return {"kind": "camera", "serial": self.serial, "refresh": refresh}
 
     class FakeLightBulb:
-        def __init__(self, _client: EzvizClient, serial: str, _device_obj: dict[str, Any]) -> None:
+        def __init__(self, _client: client_module.EzvizClient, serial: str, _device_obj: dict[str, Any]) -> None:
             self.serial = serial
 
         def status(self) -> dict[str, Any]:
             return {"kind": "light", "serial": self.serial}
 
     class FakeSmartPlug:
-        def __init__(self, _client: EzvizClient, serial: str, device_obj: dict[str, Any]) -> None:
+        def __init__(self, _client: client_module.EzvizClient, serial: str, device_obj: dict[str, Any]) -> None:
             self.serial = serial
             self.device_obj = device_obj
 
@@ -233,9 +234,9 @@ def test_load_smart_plugs_returns_only_plug_statuses(monkeypatch) -> None:
                 "name": self.device_obj["deviceInfos"]["name"],
             }
 
-    monkeypatch.setattr(client_module, "EzvizCamera", FakeCamera)
-    monkeypatch.setattr(client_module, "EzvizLightBulb", FakeLightBulb)
-    monkeypatch.setattr(client_module, "EzvizSmartPlug", FakeSmartPlug)
+    monkeypatch.setattr("pyezvizapi.camera.EzvizCamera", FakeCamera)
+    monkeypatch.setattr("pyezvizapi.light_bulb.EzvizLightBulb", FakeLightBulb)
+    monkeypatch.setattr("pyezvizapi.smart_plug.EzvizSmartPlug", FakeSmartPlug)
 
     plugs = client.load_smart_plugs(refresh=False)
 
@@ -250,29 +251,29 @@ def test_load_devices_keeps_previous_light_status_when_new_status_fails(monkeypa
     client._light_bulbs["LIGHT123"] = {"kind": "light", "serial": "LIGHT123", "stale": True}
 
     class FakeCamera:
-        def __init__(self, _client: EzvizClient, serial: str, _device_obj: dict[str, Any]) -> None:
+        def __init__(self, _client: client_module.EzvizClient, serial: str, _device_obj: dict[str, Any]) -> None:
             self.serial = serial
 
         def status(self, *, refresh: bool = True, latest_alarm: dict[str, Any] | None = None) -> dict[str, Any]:
             return {"kind": "camera", "serial": self.serial}
 
     class BrokenLightBulb:
-        def __init__(self, _client: EzvizClient, _serial: str, _device_obj: dict[str, Any]) -> None:
+        def __init__(self, _client: client_module.EzvizClient, _serial: str, _device_obj: dict[str, Any]) -> None:
             pass
 
         def status(self) -> dict[str, Any]:
             raise ValueError("bad feature json")
 
     class FakeSmartPlug:
-        def __init__(self, _client: EzvizClient, serial: str, _device_obj: dict[str, Any]) -> None:
+        def __init__(self, _client: client_module.EzvizClient, serial: str, _device_obj: dict[str, Any]) -> None:
             self.serial = serial
 
         def status(self) -> dict[str, Any]:
             return {"kind": "plug", "serial": self.serial}
 
-    monkeypatch.setattr(client_module, "EzvizCamera", FakeCamera)
-    monkeypatch.setattr(client_module, "EzvizLightBulb", BrokenLightBulb)
-    monkeypatch.setattr(client_module, "EzvizSmartPlug", FakeSmartPlug)
+    monkeypatch.setattr("pyezvizapi.camera.EzvizCamera", FakeCamera)
+    monkeypatch.setattr("pyezvizapi.light_bulb.EzvizLightBulb", BrokenLightBulb)
+    monkeypatch.setattr("pyezvizapi.smart_plug.EzvizSmartPlug", FakeSmartPlug)
 
     loaded = client.load_devices(refresh=False)
 
@@ -281,13 +282,13 @@ def test_load_devices_keeps_previous_light_status_when_new_status_fails(monkeypa
 
 
 def test_prefetch_latest_camera_alarms_returns_empty_without_serials() -> None:
-    client = EzvizClient(token={"session_id": "session", "api_url": "apiieu.ezvizlife.com"})
+    client = client_module.EzvizClient(token={"session_id": "session", "api_url": "apiieu.ezvizlife.com"})
 
     assert client._prefetch_latest_camera_alarms([]) == {}
 
 
 def test_prefetch_latest_camera_alarms_uses_global_fetch_before_filtered_chunks() -> None:
-    client = EzvizClient(token={"session_id": "session", "api_url": "apiieu.ezvizlife.com"})
+    client = client_module.EzvizClient(token={"session_id": "session", "api_url": "apiieu.ezvizlife.com"})
     calls: list[dict[str, Any]] = []
 
     def fake_messages(**kwargs: Any) -> dict[str, Any]:
@@ -337,7 +338,7 @@ def test_prefetch_latest_camera_alarms_uses_global_fetch_before_filtered_chunks(
 
 
 def test_prefetch_latest_camera_alarms_follows_global_pages_until_matched() -> None:
-    client = EzvizClient(token={"session_id": "session", "api_url": "apiieu.ezvizlife.com"})
+    client = client_module.EzvizClient(token={"session_id": "session", "api_url": "apiieu.ezvizlife.com"})
     calls = 0
 
     def fake_messages(**_kwargs: Any) -> dict[str, Any]:
@@ -356,7 +357,7 @@ def test_prefetch_latest_camera_alarms_follows_global_pages_until_matched() -> N
 
 
 def test_prefetch_latest_camera_alarms_tolerates_api_errors() -> None:
-    client = EzvizClient(token={"session_id": "session", "api_url": "apiieu.ezvizlife.com"})
+    client = client_module.EzvizClient(token={"session_id": "session", "api_url": "apiieu.ezvizlife.com"})
 
     def fake_messages(**_kwargs: Any) -> dict[str, Any]:
         raise client_module.PyEzvizError("temporary alarm failure")
@@ -375,7 +376,7 @@ def test_load_devices_passes_prefetched_latest_alarm_to_camera_status(monkeypatc
         return {"CAM123": {"deviceSerial": "CAM123", "msgId": "alarm-1"}}
 
     class FakeCamera:
-        def __init__(self, _client: EzvizClient, serial: str, _device_obj: dict[str, Any]) -> None:
+        def __init__(self, _client: client_module.EzvizClient, serial: str, _device_obj: dict[str, Any]) -> None:
             self.serial = serial
 
         def status(
@@ -392,23 +393,23 @@ def test_load_devices_passes_prefetched_latest_alarm_to_camera_status(monkeypatc
             }
 
     class FakeLightBulb:
-        def __init__(self, _client: EzvizClient, serial: str, _device_obj: dict[str, Any]) -> None:
+        def __init__(self, _client: client_module.EzvizClient, serial: str, _device_obj: dict[str, Any]) -> None:
             self.serial = serial
 
         def status(self) -> dict[str, Any]:
             return {"kind": "light", "serial": self.serial}
 
     class FakeSmartPlug:
-        def __init__(self, _client: EzvizClient, serial: str, _device_obj: dict[str, Any]) -> None:
+        def __init__(self, _client: client_module.EzvizClient, serial: str, _device_obj: dict[str, Any]) -> None:
             self.serial = serial
 
         def status(self) -> dict[str, Any]:
             return {"kind": "plug", "serial": self.serial}
 
     monkeypatch.setattr(client, "_prefetch_latest_camera_alarms", fake_prefetch)
-    monkeypatch.setattr(client_module, "EzvizCamera", FakeCamera)
-    monkeypatch.setattr(client_module, "EzvizLightBulb", FakeLightBulb)
-    monkeypatch.setattr(client_module, "EzvizSmartPlug", FakeSmartPlug)
+    monkeypatch.setattr("pyezvizapi.camera.EzvizCamera", FakeCamera)
+    monkeypatch.setattr("pyezvizapi.light_bulb.EzvizLightBulb", FakeLightBulb)
+    monkeypatch.setattr("pyezvizapi.smart_plug.EzvizSmartPlug", FakeSmartPlug)
 
     loaded = client.load_devices(refresh=True)
 
@@ -428,7 +429,7 @@ def test_load_devices_skips_alarm_prefetch_when_refresh_false(monkeypatch) -> No
         raise AssertionError("prefetch should not run when refresh is false")
 
     class FakeCamera:
-        def __init__(self, _client: EzvizClient, serial: str, _device_obj: dict[str, Any]) -> None:
+        def __init__(self, _client: client_module.EzvizClient, serial: str, _device_obj: dict[str, Any]) -> None:
             self.serial = serial
 
         def status(
@@ -445,23 +446,23 @@ def test_load_devices_skips_alarm_prefetch_when_refresh_false(monkeypatch) -> No
             }
 
     class FakeLightBulb:
-        def __init__(self, _client: EzvizClient, serial: str, _device_obj: dict[str, Any]) -> None:
+        def __init__(self, _client: client_module.EzvizClient, serial: str, _device_obj: dict[str, Any]) -> None:
             self.serial = serial
 
         def status(self) -> dict[str, Any]:
             return {"kind": "light", "serial": self.serial}
 
     class FakeSmartPlug:
-        def __init__(self, _client: EzvizClient, serial: str, _device_obj: dict[str, Any]) -> None:
+        def __init__(self, _client: client_module.EzvizClient, serial: str, _device_obj: dict[str, Any]) -> None:
             self.serial = serial
 
         def status(self) -> dict[str, Any]:
             return {"kind": "plug", "serial": self.serial}
 
     monkeypatch.setattr(client, "_prefetch_latest_camera_alarms", unexpected_prefetch)
-    monkeypatch.setattr(client_module, "EzvizCamera", FakeCamera)
-    monkeypatch.setattr(client_module, "EzvizLightBulb", FakeLightBulb)
-    monkeypatch.setattr(client_module, "EzvizSmartPlug", FakeSmartPlug)
+    monkeypatch.setattr("pyezvizapi.camera.EzvizCamera", FakeCamera)
+    monkeypatch.setattr("pyezvizapi.light_bulb.EzvizLightBulb", FakeLightBulb)
+    monkeypatch.setattr("pyezvizapi.smart_plug.EzvizSmartPlug", FakeSmartPlug)
 
     loaded = client.load_devices(refresh=False)
 


### PR DESCRIPTION
## Summary
- stop logging RTSP DESCRIBE requests with Authorization headers
- make HTTP debug payload summaries avoid string previews for request bodies and redact sensitive key names
- break client/device module import cycles by resolving device wrappers lazily when loading devices
- document intentionally ignored timestamp parse fallbacks instead of empty except blocks
- remove an unused `_res_id` assignment and clean mixed import styles in tests

## Notes
I intentionally left the EZVIZ/CAS TLS and MD5 protocol alerts alone. Those appear tied to upstream EZVIZ/RTSP protocol compatibility rather than a safe local hardening change.

## Local validation
- ruff check .
- mypy --install-types --non-interactive .
- pytest -q
- python -m build
- twine check dist/*
