### PR TITLE
Add spelling and dependency audit checks

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -65,6 +65,14 @@ jobs:
       - name: Ruff
         run: ruff check .
 
+      - name: Codespell
+        if: matrix.python-version == '3.12'
+        run: codespell pyezvizapi tests README.md pyproject.toml .github
+
+      - name: Audit Python dependencies
+        if: matrix.python-version == '3.12'
+        run: pip-audit --progress-spinner off
+
       - name: mypy (auto-install any missing stubs)
         run: mypy --install-types --non-interactive .
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ Issues = "https://github.com/RenierM26/pyEzvizApi/issues"
 pyezvizapi = "pyezvizapi.__main__:main"
 
 [project.optional-dependencies]
-dev = ["build", "ruff", "mypy", "pytest", "pytest-cov", "twine", "types-requests"]
+dev = ["build", "codespell", "mypy", "pip-audit", "pytest", "pytest-cov", "ruff", "twine", "types-requests"]
 
 [tool.setuptools.packages.find]
 include = ["pyezvizapi*"]
@@ -109,6 +109,10 @@ testpaths = ["tests"]
 python_files = ["test_*.py"]
 python_classes = ["Test*"]
 python_functions = ["test_*"]
+
+[tool.codespell]
+ignore-words-list = "adss,aliase,anull,enull,hass,hassio,hybernate"
+skip = "*.egg-info,build,dist"
 
 [tool.coverage.run]
 source = ["pyezvizapi"]


### PR DESCRIPTION
## Summary
- add `codespell` and `pip-audit` to the dev dependency set
- configure `codespell` for project/protocol-specific words
- run `codespell` and `pip-audit` in CI on the Python 3.12 matrix leg to avoid duplicate work

## Why
These add low-noise checks similar to the kind of hygiene expected in Home Assistant-adjacent development without taking on the noise of raw pylint.

## Validation
- `ruff check .`
- `codespell pyezvizapi tests README.md pyproject.toml .github`
- `pip-audit --progress-spinner off`
- `mypy --install-types --non-interactive .`
- `pytest -q`
- `python -m build`
- `twine check dist/*`
