### PR TITLE
Add Pyright type checking

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -76,6 +76,10 @@ jobs:
       - name: mypy (auto-install any missing stubs)
         run: mypy --install-types --non-interactive .
 
+      - name: Pyright
+        if: matrix.python-version == '3.12'
+        run: pyright pyezvizapi
+
       - name: pytest with coverage (skip gracefully if no tests yet)
         shell: bash
         run: |

--- a/pyezvizapi/client.py
+++ b/pyezvizapi/client.py
@@ -667,7 +667,7 @@ class EzvizClient:
 
     def get_service_urls(self) -> Any:
         """Get Ezviz service urls."""
-        if not self._token["session_id"]:
+        if not self._token.get("session_id"):
             raise PyEzvizError("No Login token present!")
 
         try:
@@ -2620,7 +2620,7 @@ class EzvizClient:
                     "clientType": 3,
                     "netType": "WIFI",
                     "featureCode": FEATURE_CODE,
-                    "sessionId": self._token["session_id"],
+                    "sessionId": self._token.get("session_id"),
                 },
                 retry_401=True,
                 max_retries=0,
@@ -2979,12 +2979,14 @@ class EzvizClient:
 
     def login(self, sms_code: int | None = None) -> JsonDict:
         """Get or refresh ezviz login token."""
-        if self._token["session_id"] and self._token["rf_session_id"]:
+        session_id = self._token.get("session_id")
+        refresh_session_id = self._token.get("rf_session_id")
+        if session_id and refresh_session_id:
             try:
                 req = self._session.put(
                     url=f"https://{self._token['api_url']}{API_ENDPOINT_REFRESH_SESSION_ID}",
                     data={
-                        "refreshSessionId": self._token["rf_session_id"],
+                        "refreshSessionId": refresh_session_id,
                         "featureCode": FEATURE_CODE,
                     },
                     timeout=self._timeout,

--- a/pyezvizapi/mqtt.py
+++ b/pyezvizapi/mqtt.py
@@ -547,19 +547,20 @@ class MQTTClient:
         if callback_api_version is not None:
             client_kwargs["callback_api_version"] = callback_api_version.VERSION1
 
-        self.mqtt_client = mqtt.Client(**client_kwargs)
+        mqtt_client = mqtt.Client(**client_kwargs)
+        self.mqtt_client = mqtt_client
 
         # Bind callbacks
-        self.mqtt_client.on_connect = self._on_connect
-        self.mqtt_client.on_disconnect = self._on_disconnect
-        self.mqtt_client.on_subscribe = self._on_subscribe
-        self.mqtt_client.on_message = self._on_message
+        mqtt_client.on_connect = self._on_connect
+        mqtt_client.on_disconnect = self._on_disconnect
+        mqtt_client.on_subscribe = self._on_subscribe
+        mqtt_client.on_message = self._on_message
 
         # Auth (do not log these!)
-        self.mqtt_client.username_pw_set(MQTT_APP_KEY, APP_SECRET)
+        mqtt_client.username_pw_set(MQTT_APP_KEY, APP_SECRET)
 
         # Backoff for reconnects handled by paho
-        self.mqtt_client.reconnect_delay_set(min_delay=5, max_delay=10)
+        mqtt_client.reconnect_delay_set(min_delay=5, max_delay=10)
 
         _LOGGER.debug("Configured MQTT client for broker %s", broker)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ Issues = "https://github.com/RenierM26/pyEzvizApi/issues"
 pyezvizapi = "pyezvizapi.__main__:main"
 
 [project.optional-dependencies]
-dev = ["build", "codespell", "mypy", "pip-audit", "pytest", "pytest-cov", "ruff", "twine", "types-requests"]
+dev = ["build", "codespell", "mypy", "pip-audit", "pyright", "pytest", "pytest-cov", "ruff", "twine", "types-requests"]
 
 [tool.setuptools.packages.find]
 include = ["pyezvizapi*"]

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,0 +1,13 @@
+{
+  "include": ["pyezvizapi"],
+  "exclude": [
+    "**/__pycache__",
+    "build",
+    "dist"
+  ],
+  "pythonVersion": "3.12",
+  "typeCheckingMode": "basic",
+  "reportMissingImports": "none",
+  "reportMissingModuleSource": "none",
+  "reportUnsupportedDunderAll": "none"
+}


### PR DESCRIPTION
## Summary
- add Pyright to the dev dependency set and CI
- add `pyrightconfig.json` with project-appropriate settings
- fix Pyright findings around optional `ClientToken` keys
- avoid optional-member noise by configuring MQTT callbacks through a local client variable

## Why
Pyright gives useful extra type pressure alongside mypy, especially around TypedDict optional keys and optional member access, without reintroducing the wrapper/client import cycle.

## Validation
- `pyright pyezvizapi`
- `ruff check .`
- `mypy --install-types --non-interactive .`
- `codespell pyezvizapi tests README.md pyproject.toml .github`
- `pip-audit --progress-spinner off`
- `pytest -q`
- `python -m build`
- `twine check dist/*`
