### PR TITLE
Update docs for release and quality checks

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -98,4 +98,4 @@ jobs:
             - move current `Unreleased` changelog entries into a dated `v${{ inputs.version }}` release section
             - leave a fresh empty `Unreleased` section for future changes
 
-            After this PR is reviewed and merged, run the Manual Release workflow with version `${{ inputs.version }}`.
+            After this PR is reviewed and merged, run the Upload Python Package workflow manually with version `${{ inputs.version }}`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ This project follows [Semantic Versioning](https://semver.org/) for published re
 
 ## Unreleased
 
+### Added
+
+- Added manual release dispatch to the trusted PyPI publish workflow so releases can be published by running a workflow with the requested version.
+- Added `codespell`, `pip-audit`, and Pyright checks to CI for extra spelling, dependency vulnerability, and static typing coverage.
+
+### Changed
+
+- Reworked device wrapper construction through a dedicated factory to remove client/device module import cycles while preserving existing wrapper behavior.
+- Lazy-load top-level `pyezvizapi` package exports to reduce eager import graph pressure while keeping convenient imports such as `from pyezvizapi import EzvizClient`.
+- Tightened `EzvizClient` JSON payload typing with a shared `JsonDict` alias and fixed Pyright-reported optional-token and MQTT-client typing issues.
+- Updated release automation so the prepare step opens a changelog PR and the publish step validates, builds, smoke-tests, uploads to PyPI, and creates the GitHub release.
+
+### Removed
+
+- Removed the superseded manual-release workflow in favor of the trusted PyPI publish workflow dispatch path.
+
 ## v1.0.4.6 - 2026-04-27
 
 ### Added
@@ -42,8 +58,8 @@ This project follows [Semantic Versioning](https://semver.org/) for published re
 
 Before publishing a release:
 
-1. Move relevant entries from `Unreleased` to a dated version section.
-2. Bump `project.version` in `pyproject.toml`.
+1. Bump `project.version` in `pyproject.toml`.
+2. Move relevant entries from `Unreleased` to a dated version section by running **Prepare Release** with the bare version and merging the generated changelog PR.
 3. Ensure CI is green on `main`.
-4. Create a GitHub release whose tag matches `v<pyproject version>`.
-5. Confirm the PyPI publish workflow completes successfully.
+4. Run **Upload Python Package** manually with the same bare version.
+5. Confirm the workflow publishes to PyPI and creates the matching GitHub release/tag.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,10 @@ Before opening a pull request, run the same checks used by CI:
 
 ```bash
 ruff check .
+codespell pyezvizapi tests README.md pyproject.toml .github
+pip-audit --progress-spinner off
 mypy --install-types --non-interactive .
+pyright pyezvizapi
 pytest --cov=pyezvizapi --cov-report=term-missing --cov-report=xml --cov-fail-under=85
 python -m build
 twine check dist/*

--- a/README.md
+++ b/README.md
@@ -222,7 +222,10 @@ Run the same local validation used by CI:
 
 ```bash
 ruff check .
+codespell pyezvizapi tests README.md pyproject.toml .github
+pip-audit --progress-spinner off
 mypy --install-types --non-interactive .
+pyright pyezvizapi
 pytest --cov=pyezvizapi --cov-report=term-missing --cov-report=xml --cov-fail-under=85
 python -m build
 twine check dist/*
@@ -275,7 +278,13 @@ For vulnerability reports or security-sensitive behavior, see [`SECURITY.md`](SE
 
 We follow SemVer when publishing the library. See `CHANGELOG.md` and repository tags for released versions.
 
-Release tags should match the package version in `pyproject.toml` using the form `v<version>` (for example, `v1.0.4.5`). The PyPI publish workflow validates this before uploading distributions.
+Release tags should match the package version in `pyproject.toml` using the form `v<version>` (for example, `v1.0.4.7`). The PyPI publish workflow validates this before uploading distributions.
+
+Recommended release flow:
+
+1. Bump `project.version` in `pyproject.toml` and update `CHANGELOG.md` under `Unreleased` during normal PR work.
+2. Run **Prepare Release** with the bare version, then review and merge the generated changelog PR.
+3. Run **Upload Python Package** manually with the same bare version. That workflow validates the version, builds and smoke-tests the wheel/CLI, publishes to PyPI, then creates the matching GitHub release/tag.
 
 ## License
 

--- a/docs/home-assistant-contract.md
+++ b/docs/home-assistant-contract.md
@@ -147,10 +147,15 @@ For behavior used by Home Assistant integrations:
 
 When publishing a `pyezvizapi` release intended for Home Assistant consumption:
 
-1. Confirm CI is green on `main`.
+1. Confirm CI is green on `main`, including Ruff, codespell, dependency audit,
+   mypy, Pyright, tests, package build, metadata checks, and wheel smoke tests.
 2. Confirm `CHANGELOG.md` summarizes integration-facing changes.
-3. Publish to PyPI from a tag matching `v<pyproject version>`.
-4. Smoke-test installation in a clean environment.
-5. Update `requirements` pins in the custom integration first when appropriate.
-6. For Home Assistant core, open/update the dependency bump PR with a concise
+3. Run **Prepare Release** with the bare version and merge the generated
+   changelog PR.
+4. Run **Upload Python Package** manually with the same bare version so the
+   trusted publish workflow validates, builds, smoke-tests, uploads to PyPI, and
+   creates the matching GitHub release/tag.
+5. Smoke-test installation in a clean environment.
+6. Update `requirements` pins in the custom integration first when appropriate.
+7. For Home Assistant core, open/update the dependency bump PR with a concise
    list of integration-facing changes and relevant test coverage.


### PR DESCRIPTION
## Summary
- document recent unreleased changes in `CHANGELOG.md`
- update README and contributing validation commands for codespell, pip-audit, and Pyright
- document the current Prepare Release → Upload Python Package release flow
- update the Home Assistant release coordination checklist
- fix the Prepare Release PR body to reference the current publish workflow name

## Validation
- `ruff check .`
- `codespell pyezvizapi tests README.md pyproject.toml .github CHANGELOG.md CONTRIBUTING.md docs`
- `pyright pyezvizapi`
- `mypy --install-types --non-interactive .`
- `pip-audit --progress-spinner off`
- `pytest -q`
- `python -m build`
- `twine check dist/*`
