### PR TITLE
Remove duplicate pagelist filter

### DIFF
--- a/pyezvizapi/client.py
+++ b/pyezvizapi/client.py
@@ -4738,7 +4738,7 @@ class EzvizClient:
         return self._api_get_pagelist(
             page_filter="CLOUD, TIME_PLAN, CONNECTION, SWITCH,"
             "STATUS, WIFI, NODISTURB, KMS,"
-            "P2P, TIME_PLAN, CHANNEL, VTM, DETECTOR,"
+            "P2P, CHANNEL, VTM, DETECTOR,"
             "FEATURE, CUSTOM_TAG, UPGRADE, VIDEO_QUALITY,"
             "QOS, PRODUCTS_INFO, SIM_CARD, MULTI_UPGRADE_EXT,"
             "FEATURE_INFO",


### PR DESCRIPTION
## Summary
- remove the duplicate `TIME_PLAN` entry from the full pagelist filter list

## Why
The full pagelist request included `TIME_PLAN` twice. This is harmless, but redundant; keeping the filter list unique makes the request easier to read and avoids asking the API for the same section twice.

## Validation
- `ruff check .`
- `codespell pyezvizapi tests README.md pyproject.toml .github CHANGELOG.md CONTRIBUTING.md docs`
- `pyright pyezvizapi`
- `mypy --install-types --non-interactive .`
- `pip-audit --progress-spinner off`
- `pytest -q`
- `python -m build`
- `twine check dist/*`
