### PR TITLE
Accept string verification codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This project follows [Semantic Versioning](https://semver.org/) for published re
 
 ### Changed
 
+- Widened camera key/auth verification-code argument typing to accept string codes from Home Assistant forms without forcing callers to cast.
 - Reworked device wrapper construction through a dedicated factory to remove client/device module import cycles while preserving existing wrapper behavior.
 - Lazy-load top-level `pyezvizapi` package exports to reduce eager import graph pressure while keeping convenient imports such as `from pyezvizapi import EzvizClient`.
 - Tightened `EzvizClient` JSON payload typing with a shared `JsonDict` alias and fixed Pyright-reported optional-token and MQTT-client typing issues.

--- a/pyezvizapi/client.py
+++ b/pyezvizapi/client.py
@@ -2586,13 +2586,13 @@ class EzvizClient:
         return json_output
 
     def get_cam_key(
-        self, serial: str, smscode: int | None = None, max_retries: int = 0
+        self, serial: str, smscode: str | int | None = None, max_retries: int = 0
     ) -> Any:
         """Get Camera encryption key. The key that is set after the camera is added to the account.
 
         Args:
             serial (str): The camera serial number.
-            smscode (int | None): The 2FA code account when rights elevation is required.
+            smscode (str | int | None): The 2FA code account when rights elevation is required.
             max_retries (int): The maximum number of retries. Defaults to 0.
 
         Raises:
@@ -2653,7 +2653,7 @@ class EzvizClient:
         self,
         serial: str,
         encrypt_pwd: str | None = None,
-        msg_auth_code: int | None = None,
+        msg_auth_code: str | int | None = None,
         sender_type: int = 0,
         max_retries: int = 0,
     ) -> Any:
@@ -2662,7 +2662,7 @@ class EzvizClient:
         Args:
             serial (str): The camera serial number.
             encrypt_pwd (str | None): This is always none.
-            msg_auth_code (int | None): The 2FA code.
+            msg_auth_code (str | int | None): The 2FA code.
             sender_type (int): The sender type. Defaults to 0. Needs to be 3 when returning 2FA code.
             max_retries (int): The maximum number of retries. Defaults to 0.
 


### PR DESCRIPTION
## Summary
- widen `get_cam_key(..., smscode=...)` to accept `str | int | None`
- widen `get_cam_auth_code(..., msg_auth_code=...)` to accept `str | int | None`
- document the typing compatibility fix in the changelog

## Why
Home Assistant form values arrive as strings. Accepting string verification codes avoids downstream casts and preserves codes with leading zeroes.

## Validation
- `ruff check .`
- `codespell pyezvizapi tests README.md pyproject.toml .github CHANGELOG.md CONTRIBUTING.md docs`
- `pyright pyezvizapi`
- `mypy --install-types --non-interactive .`
- `pip-audit --progress-spinner off`
- `pytest -q`
- `python -m build`
- `twine check dist/*`
