### PR TITLE
Add read-only repository watch agent

### DIFF
--- a/.github/workflows/repo-watch.yml
+++ b/.github/workflows/repo-watch.yml
@@ -1,0 +1,39 @@
+name: Repository Watch
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "17 */6 * * *"
+
+permissions:
+  contents: read
+  actions: read
+  issues: read
+  pull-requests: read
+
+jobs:
+  repo-watch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Run repository monitor
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: python tools/repo_watch.py --repo RenierM26/pyEzvizApi --output .repo-watch
+
+      - name: Add dashboard to job summary
+        run: cat .repo-watch/dashboard.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload monitor artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: repo-watch
+          path: .repo-watch
+          retention-days: 14

--- a/.gitignore
+++ b/.gitignore
@@ -123,6 +123,9 @@ venv.bak/
 # Ruff
 .ruff_cache/
 
+# Repository monitor local output
+.repo-watch/
+
 # mypy
 .mypy_cache/
 .dmypy.json

--- a/docs/repo-watch-agent.md
+++ b/docs/repo-watch-agent.md
@@ -1,0 +1,64 @@
+# Repository Watch Agent
+
+This repository includes a small read-only monitor inspired by ClawSweeper's
+operating model: collect live GitHub state, write durable records, and publish a
+dashboard before any mutation is considered.
+
+The first version intentionally does not comment, label, close, merge, or push.
+It is a trust-building layer for maintainer attention.
+
+## Run Locally
+
+```bash
+python tools/repo_watch.py --repo RenierM26/pyEzvizApi --output .repo-watch
+```
+
+For higher rate limits, set `GITHUB_TOKEN` first. The token only needs read
+access for this version.
+
+Outputs:
+
+- `.repo-watch/state/latest.json` stores the sampled GitHub state.
+- `.repo-watch/records/RenierM26__pyEzvizApi/*.json` stores durable finding
+  records.
+- `.repo-watch/dashboard.md` stores the human-readable dashboard.
+
+## What It Watches
+
+- Open issues with no activity or bug reports that have not received a comment.
+- Open PRs with failed recent workflow runs, no labels, or draft state.
+- Recent workflow runs that failed, timed out, were cancelled, or need action.
+
+The action vocabulary is deliberately narrow:
+
+- `keep_open`
+- `needs_human`
+- `ci_failure_summary`
+
+## GitHub Actions
+
+`.github/workflows/repo-watch.yml` runs the monitor on a schedule and uploads the
+generated dashboard/records as an artifact.
+
+The workflow uses read-only permissions:
+
+```yaml
+permissions:
+  contents: read
+  actions: read
+  issues: read
+  pull-requests: read
+```
+
+## Promotion Path
+
+Keep the sequence conservative:
+
+1. Run read-only and inspect dashboard quality.
+2. Add marker-backed comments for high-signal CI failure summaries only.
+3. Add labels only after the comment mode is reliable.
+4. Consider close/merge actions last, and only with explicit opt-in labels.
+
+Future write mode should be a separate apply lane. It should re-fetch live
+GitHub state, compare the stored source hash/snapshot, and refuse to mutate when
+the item changed after review.

--- a/tools/repo_watch.py
+++ b/tools/repo_watch.py
@@ -1,0 +1,344 @@
+#!/usr/bin/env python3
+"""Read-only GitHub repository monitor for pyEzvizApi.
+
+The script borrows the safe parts of maintainer bots like ClawSweeper:
+collect live repository state, write durable records, and publish a compact
+dashboard. It deliberately does not mutate GitHub.
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+import hashlib
+import json
+import os
+from pathlib import Path
+import sys
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlencode
+from urllib.request import Request, urlopen
+
+GITHUB_API = "https://api.github.com"
+DEFAULT_REPO = "RenierM26/pyEzvizApi"
+SEVERITY_ORDER = {"high": 0, "medium": 1, "low": 2, "info": 3}
+
+
+@dataclass(frozen=True)
+class Finding:
+    kind: str
+    item: str
+    title: str
+    url: str
+    severity: str
+    action: str
+    evidence: list[str]
+
+
+class GitHubClient:
+    def __init__(self, token: str | None = None) -> None:
+        self.token = token
+
+    def get(self, path: str, params: dict[str, Any] | None = None) -> Any:
+        query = f"?{urlencode(params)}" if params else ""
+        url = f"{GITHUB_API}{path}{query}"
+        headers = {
+            "Accept": "application/vnd.github+json",
+            "User-Agent": "pyEzvizApi-repo-watch",
+            "X-GitHub-Api-Version": "2022-11-28",
+        }
+        if self.token:
+            headers["Authorization"] = f"Bearer {self.token}"
+
+        request = Request(url, headers=headers)
+        try:
+            with urlopen(request, timeout=30) as response:
+                return json.loads(response.read().decode("utf-8"))
+        except HTTPError as exc:
+            detail = exc.read().decode("utf-8", errors="replace")
+            raise RuntimeError(f"GitHub API request failed: {exc.code} {url}: {detail}") from exc
+        except URLError as exc:
+            raise RuntimeError(f"GitHub API request failed: {url}: {exc}") from exc
+
+
+def parse_timestamp(value: str) -> datetime:
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
+def utc_now() -> datetime:
+    return datetime.now(UTC)
+
+
+def stable_hash(payload: Any) -> str:
+    normalized = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.sha256(normalized.encode("utf-8")).hexdigest()
+
+
+def write_json(path: Path, payload: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def fetch_repo_state(client: GitHubClient, repo: str, limit: int) -> dict[str, Any]:
+    owner_repo = f"/repos/{repo}"
+    repo_info = client.get(owner_repo)
+    issues = client.get(
+        f"{owner_repo}/issues",
+        {"state": "open", "per_page": limit, "sort": "updated", "direction": "desc"},
+    )
+    pulls = client.get(
+        f"{owner_repo}/pulls",
+        {"state": "open", "per_page": limit, "sort": "updated", "direction": "desc"},
+    )
+    runs = client.get(
+        f"{owner_repo}/actions/runs",
+        {"per_page": limit, "status": "completed"},
+    )
+    return {
+        "repo": repo_info,
+        "issues": [item for item in issues if "pull_request" not in item],
+        "pulls": pulls,
+        "workflow_runs": runs.get("workflow_runs", []),
+    }
+
+
+def classify_issues(issues: list[dict[str, Any]], now: datetime) -> list[Finding]:
+    findings: list[Finding] = []
+    stale_after = now - timedelta(days=90)
+
+    for issue in issues:
+        labels = {label["name"].lower() for label in issue.get("labels", [])}
+        updated_at = parse_timestamp(issue["updated_at"])
+        evidence: list[str] = []
+        severity = "info"
+        action = "keep_open"
+
+        if "bug" in labels and issue.get("comments", 0) == 0:
+            severity = "medium"
+            action = "needs_human"
+            evidence.append("Open bug report has no comments yet.")
+
+        if updated_at < stale_after and not labels.intersection({"pinned", "security"}):
+            severity = "low" if severity == "info" else severity
+            action = "needs_human" if action == "keep_open" else action
+            evidence.append(f"No activity since {updated_at.date().isoformat()}.")
+
+        if not evidence:
+            continue
+
+        findings.append(
+            Finding(
+                kind="issue",
+                item=f"#{issue['number']}",
+                title=issue["title"],
+                url=issue["html_url"],
+                severity=severity,
+                action=action,
+                evidence=evidence,
+            )
+        )
+
+    return findings
+
+
+def classify_pulls(
+    pulls: list[dict[str, Any]], workflow_runs: list[dict[str, Any]]
+) -> list[Finding]:
+    findings: list[Finding] = []
+    failed_heads = {
+        run["head_sha"]
+        for run in workflow_runs
+        if run.get("conclusion") in {"failure", "timed_out", "cancelled", "action_required"}
+    }
+
+    for pull in pulls:
+        labels = {label["name"].lower() for label in pull.get("labels", [])}
+        evidence: list[str] = []
+        severity = "info"
+        action = "keep_open"
+        head_sha = pull.get("head", {}).get("sha")
+
+        if pull.get("draft"):
+            evidence.append("PR is currently marked as draft.")
+            action = "keep_open"
+
+        if head_sha in failed_heads:
+            evidence.append("Latest observed workflow run for this head SHA did not pass.")
+            severity = "high"
+            action = "ci_failure_summary"
+
+        if not labels and not pull.get("draft"):
+            evidence.append("PR has no labels.")
+            severity = "low" if severity == "info" else severity
+            action = "needs_human" if action == "keep_open" else action
+
+        if not evidence:
+            continue
+
+        findings.append(
+            Finding(
+                kind="pull_request",
+                item=f"#{pull['number']}",
+                title=pull["title"],
+                url=pull["html_url"],
+                severity=severity,
+                action=action,
+                evidence=evidence,
+            )
+        )
+
+    return findings
+
+
+def summarize_workflows(workflow_runs: list[dict[str, Any]]) -> list[Finding]:
+    findings: list[Finding] = []
+    for run in workflow_runs:
+        conclusion = run.get("conclusion")
+        if conclusion not in {"failure", "timed_out", "cancelled", "action_required"}:
+            continue
+
+        findings.append(
+            Finding(
+                kind="workflow_run",
+                item=f"run {run['id']}",
+                title=run.get("display_title") or run.get("name") or "Workflow run",
+                url=run["html_url"],
+                severity="high" if conclusion == "failure" else "medium",
+                action="needs_human",
+                evidence=[
+                    f"Workflow `{run.get('name', 'unknown')}` concluded with `{conclusion}`.",
+                    f"Head branch `{run.get('head_branch')}` at `{run.get('head_sha', '')[:12]}`.",
+                ],
+            )
+        )
+    return findings
+
+
+def record_payload(
+    repo: str, generated_at: str, finding: Finding, source_hash: str
+) -> dict[str, Any]:
+    return {
+        "repo": repo,
+        "generated_at": generated_at,
+        "kind": finding.kind,
+        "item": finding.item,
+        "title": finding.title,
+        "url": finding.url,
+        "severity": finding.severity,
+        "action": finding.action,
+        "confidence": "medium",
+        "source_hash": source_hash,
+        "evidence": finding.evidence,
+        "allowed_mutation": "none",
+    }
+
+
+def write_records(
+    output: Path, repo: str, generated_at: str, findings: list[Finding], state: dict[str, Any]
+) -> None:
+    source_hash = stable_hash(state)
+    records_dir = output / "records" / repo.replace("/", "__")
+    records_dir.mkdir(parents=True, exist_ok=True)
+
+    for finding in findings:
+        item_slug = finding.item.replace("#", "issue-").replace(" ", "-")
+        record = record_payload(repo, generated_at, finding, source_hash)
+        write_json(records_dir / f"{finding.kind}-{item_slug}.json", record)
+
+
+def render_dashboard(
+    repo: str, generated_at: str, findings: list[Finding], state: dict[str, Any]
+) -> str:
+    repo_info = state["repo"]
+    issue_count = len(state["issues"])
+    pull_count = len(state["pulls"])
+    failed_runs = [
+        run
+        for run in state["workflow_runs"]
+        if run.get("conclusion") in {"failure", "timed_out", "cancelled", "action_required"}
+    ]
+
+    lines = [
+        f"# Repository Watch Dashboard: {repo}",
+        "",
+        f"- Generated: `{generated_at}`",
+        f"- Repository: [{repo}]({repo_info['html_url']})",
+        f"- Default branch: `{repo_info.get('default_branch', 'unknown')}`",
+        f"- Open issues sampled: `{issue_count}`",
+        f"- Open PRs sampled: `{pull_count}`",
+        f"- Recent failed/problem workflow runs: `{len(failed_runs)}`",
+        f"- Findings: `{len(findings)}`",
+        "",
+        "## Findings",
+        "",
+    ]
+
+    if not findings:
+        lines.append("No monitor findings in the sampled repository state.")
+    else:
+        for finding in sorted(findings, key=lambda item: SEVERITY_ORDER[item.severity]):
+            lines.extend(
+                [
+                    f"### {finding.severity.upper()} {finding.kind} {finding.item}: {finding.title}",
+                    "",
+                    f"- Action: `{finding.action}`",
+                    f"- URL: {finding.url}",
+                    "- Evidence:",
+                ]
+            )
+            lines.extend(f"  - {evidence}" for evidence in finding.evidence)
+            lines.append("")
+
+    lines.extend(
+        [
+            "## Operating Rules",
+            "",
+            "- This monitor is read-only.",
+            "- Review records are durable evidence, not automatic GitHub actions.",
+            "- Any future write mode should re-fetch live state and edit one marker-backed comment per item.",
+        ]
+    )
+    return "\n".join(lines) + "\n"
+
+
+def run(repo: str, output: Path, limit: int) -> int:
+    generated_at = utc_now().isoformat(timespec="seconds")
+    token = os.environ.get("GITHUB_TOKEN")
+    client = GitHubClient(token=token)
+    state = fetch_repo_state(client, repo, limit)
+
+    findings = [
+        *classify_issues(state["issues"], utc_now()),
+        *classify_pulls(state["pulls"], state["workflow_runs"]),
+        *summarize_workflows(state["workflow_runs"]),
+    ]
+
+    write_json(output / "state" / "latest.json", state)
+    write_records(output, repo, generated_at, findings, state)
+    dashboard = render_dashboard(repo, generated_at, findings, state)
+    dashboard_path = output / "dashboard.md"
+    dashboard_path.parent.mkdir(parents=True, exist_ok=True)
+    dashboard_path.write_text(dashboard, encoding="utf-8")
+
+    print(f"Wrote {dashboard_path} with {len(findings)} findings.")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", default=DEFAULT_REPO, help="Repository in owner/name form.")
+    parser.add_argument("--output", default=".repo-watch", type=Path, help="Output directory.")
+    parser.add_argument("--limit", default=50, type=int, help="Maximum issues/PRs/runs to sample.")
+    args = parser.parse_args(argv)
+
+    try:
+        return run(args.repo, args.output, args.limit)
+    except RuntimeError as exc:
+        print(f"repo-watch: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/repo_watch.py
+++ b/tools/repo_watch.py
@@ -24,6 +24,7 @@ from urllib.request import Request, urlopen
 GITHUB_API = "https://api.github.com"
 DEFAULT_REPO = "RenierM26/pyEzvizApi"
 SEVERITY_ORDER = {"high": 0, "medium": 1, "low": 2, "info": 3}
+PROBLEM_CONCLUSIONS = {"failure", "timed_out", "cancelled", "action_required"}
 
 
 @dataclass(frozen=True)
@@ -92,15 +93,27 @@ def fetch_repo_state(client: GitHubClient, repo: str, limit: int) -> dict[str, A
         f"{owner_repo}/pulls",
         {"state": "open", "per_page": limit, "sort": "updated", "direction": "desc"},
     )
-    runs = client.get(
+    recent_runs = client.get(
         f"{owner_repo}/actions/runs",
         {"per_page": limit, "status": "completed"},
     )
+    workflow_runs_by_head: dict[str, list[dict[str, Any]]] = {}
+    for pull in pulls:
+        head_sha = pull.get("head", {}).get("sha")
+        if not head_sha:
+            continue
+        runs = client.get(
+            f"{owner_repo}/actions/runs",
+            {"head_sha": head_sha, "per_page": limit, "status": "completed"},
+        )
+        workflow_runs_by_head[head_sha] = runs.get("workflow_runs", [])
+
     return {
         "repo": repo_info,
         "issues": [item for item in issues if "pull_request" not in item],
         "pulls": pulls,
-        "workflow_runs": runs.get("workflow_runs", []),
+        "workflow_runs": recent_runs.get("workflow_runs", []),
+        "workflow_runs_by_head": workflow_runs_by_head,
     }
 
 
@@ -144,19 +157,9 @@ def classify_issues(issues: list[dict[str, Any]], now: datetime) -> list[Finding
 
 
 def classify_pulls(
-    pulls: list[dict[str, Any]], workflow_runs: list[dict[str, Any]]
+    pulls: list[dict[str, Any]], workflow_runs_by_head: dict[str, list[dict[str, Any]]]
 ) -> list[Finding]:
     findings: list[Finding] = []
-    latest_runs_by_head_workflow: dict[tuple[str, str], dict[str, Any]] = {}
-    for run in workflow_runs:
-        head_sha = run.get("head_sha")
-        if not head_sha:
-            continue
-        workflow_name = run.get("name") or str(run["id"])
-        key = (head_sha, workflow_name)
-        current = latest_runs_by_head_workflow.get(key)
-        if current is None or parse_timestamp(run["updated_at"]) > parse_timestamp(current["updated_at"]):
-            latest_runs_by_head_workflow[key] = run
 
     for pull in pulls:
         labels = {label["name"].lower() for label in pull.get("labels", [])}
@@ -164,13 +167,17 @@ def classify_pulls(
         severity = "info"
         action = "keep_open"
         head_sha = pull.get("head", {}).get("sha")
-        latest_runs = [
-            run for (sha, _workflow), run in latest_runs_by_head_workflow.items() if sha == head_sha
-        ]
+        latest_runs_by_workflow: dict[str, dict[str, Any]] = {}
+        for run in workflow_runs_by_head.get(head_sha, []) if head_sha else []:
+            workflow_id = str(run.get("workflow_id") or run["id"])
+            current = latest_runs_by_workflow.get(workflow_id)
+            if current is None or parse_timestamp(run["updated_at"]) > parse_timestamp(
+                current["updated_at"]
+            ):
+                latest_runs_by_workflow[workflow_id] = run
+        latest_runs = list(latest_runs_by_workflow.values())
         failing_runs = [
-            run
-            for run in latest_runs
-            if run.get("conclusion") in {"failure", "timed_out", "cancelled", "action_required"}
+            run for run in latest_runs if run.get("conclusion") in PROBLEM_CONCLUSIONS
         ]
 
         if pull.get("draft"):
@@ -331,7 +338,7 @@ def run(repo: str, output: Path, limit: int) -> int:
 
     findings = [
         *classify_issues(state["issues"], utc_now()),
-        *classify_pulls(state["pulls"], state["workflow_runs"]),
+        *classify_pulls(state["pulls"], state["workflow_runs_by_head"]),
         *summarize_workflows(state["workflow_runs"]),
     ]
 

--- a/tools/repo_watch.py
+++ b/tools/repo_watch.py
@@ -147,11 +147,14 @@ def classify_pulls(
     pulls: list[dict[str, Any]], workflow_runs: list[dict[str, Any]]
 ) -> list[Finding]:
     findings: list[Finding] = []
-    failed_heads = {
-        run["head_sha"]
-        for run in workflow_runs
-        if run.get("conclusion") in {"failure", "timed_out", "cancelled", "action_required"}
-    }
+    latest_runs_by_head: dict[str, dict[str, Any]] = {}
+    for run in workflow_runs:
+        head_sha = run.get("head_sha")
+        if not head_sha:
+            continue
+        current = latest_runs_by_head.get(head_sha)
+        if current is None or parse_timestamp(run["updated_at"]) > parse_timestamp(current["updated_at"]):
+            latest_runs_by_head[head_sha] = run
 
     for pull in pulls:
         labels = {label["name"].lower() for label in pull.get("labels", [])}
@@ -159,13 +162,22 @@ def classify_pulls(
         severity = "info"
         action = "keep_open"
         head_sha = pull.get("head", {}).get("sha")
+        latest_run = latest_runs_by_head.get(head_sha) if head_sha else None
 
         if pull.get("draft"):
             evidence.append("PR is currently marked as draft.")
             action = "keep_open"
 
-        if head_sha in failed_heads:
-            evidence.append("Latest observed workflow run for this head SHA did not pass.")
+        if latest_run and latest_run.get("conclusion") in {
+            "failure",
+            "timed_out",
+            "cancelled",
+            "action_required",
+        }:
+            evidence.append(
+                f"Latest observed workflow run `{latest_run.get('name', 'unknown')}` "
+                f"for this head SHA concluded with `{latest_run['conclusion']}`."
+            )
             severity = "high"
             action = "ci_failure_summary"
 

--- a/tools/repo_watch.py
+++ b/tools/repo_watch.py
@@ -147,14 +147,16 @@ def classify_pulls(
     pulls: list[dict[str, Any]], workflow_runs: list[dict[str, Any]]
 ) -> list[Finding]:
     findings: list[Finding] = []
-    latest_runs_by_head: dict[str, dict[str, Any]] = {}
+    latest_runs_by_head_workflow: dict[tuple[str, str], dict[str, Any]] = {}
     for run in workflow_runs:
         head_sha = run.get("head_sha")
         if not head_sha:
             continue
-        current = latest_runs_by_head.get(head_sha)
+        workflow_name = run.get("name") or str(run["id"])
+        key = (head_sha, workflow_name)
+        current = latest_runs_by_head_workflow.get(key)
         if current is None or parse_timestamp(run["updated_at"]) > parse_timestamp(current["updated_at"]):
-            latest_runs_by_head[head_sha] = run
+            latest_runs_by_head_workflow[key] = run
 
     for pull in pulls:
         labels = {label["name"].lower() for label in pull.get("labels", [])}
@@ -162,21 +164,27 @@ def classify_pulls(
         severity = "info"
         action = "keep_open"
         head_sha = pull.get("head", {}).get("sha")
-        latest_run = latest_runs_by_head.get(head_sha) if head_sha else None
+        latest_runs = [
+            run for (sha, _workflow), run in latest_runs_by_head_workflow.items() if sha == head_sha
+        ]
+        failing_runs = [
+            run
+            for run in latest_runs
+            if run.get("conclusion") in {"failure", "timed_out", "cancelled", "action_required"}
+        ]
 
         if pull.get("draft"):
             evidence.append("PR is currently marked as draft.")
             action = "keep_open"
 
-        if latest_run and latest_run.get("conclusion") in {
-            "failure",
-            "timed_out",
-            "cancelled",
-            "action_required",
-        }:
+        if failing_runs:
             evidence.append(
-                f"Latest observed workflow run `{latest_run.get('name', 'unknown')}` "
-                f"for this head SHA concluded with `{latest_run['conclusion']}`."
+                "Latest observed workflow runs for this head SHA did not all pass: "
+                + ", ".join(
+                    f"`{run.get('name', 'unknown')}` concluded with `{run['conclusion']}`"
+                    for run in sorted(failing_runs, key=lambda item: item.get("name") or "")
+                )
+                + "."
             )
             severity = "high"
             action = "ci_failure_summary"


### PR DESCRIPTION
## Summary

Adds a read-only, ClawSweeper-inspired repository monitor for pyEzvizApi.

The monitor samples live GitHub state, writes durable JSON records, and publishes a compact dashboard without mutating GitHub. A scheduled GitHub Actions workflow runs it every 6 hours and uploads the generated state as an artifact.

## Safety model

- Read-only GitHub permissions in the workflow
- No comments, labels, closes, merges, or pushes from the monitor
- Durable records include evidence and source hash
- Documentation describes the guarded promotion path before any future write mode

## Verification

- `python -m ruff check tools/repo_watch.py`
- `python -m py_compile tools/repo_watch.py`
- Live run against `RenierM26/pyEzvizApi` produced a dashboard with current findings
