### PR TITLE
Use terminal bind codes for remote unlock

### DIFF
--- a/pyezvizapi/api_endpoints.py
+++ b/pyezvizapi/api_endpoints.py
@@ -7,6 +7,7 @@ API_ENDPOINT_LOGIN = "/v3/users/login/v5"
 API_ENDPOINT_LOGOUT = "/v3/users/logout/v2"
 API_ENDPOINT_REFRESH_SESSION_ID = "/v3/apigateway/login"
 API_ENDPOINT_SERVER_INFO = "/v3/configurations/system/info"
+API_ENDPOINT_TERMINAL_INFO = "/v3/terminals"
 
 API_ENDPOINT_USER_ID = "/v3/userdevices/v1/token"
 API_ENDPOINT_GROUP_DEFENCE_MODE = "/v3/userdevices/v1/group/defenceMode"

--- a/pyezvizapi/client.py
+++ b/pyezvizapi/client.py
@@ -93,6 +93,7 @@ from .api_endpoints import (
     API_ENDPOINT_SWITCH_OTHER,
     API_ENDPOINT_SWITCH_SOUND_ALARM,
     API_ENDPOINT_SWITCH_STATUS,
+    API_ENDPOINT_TERMINAL_INFO,
     API_ENDPOINT_TIME_PLAN_INFOS,
     API_ENDPOINT_UNIFIEDMSG_LIST_GET,
     API_ENDPOINT_UPGRADE_DEVICE,
@@ -2862,6 +2863,59 @@ class EzvizClient:
         self._ensure_ok(json_output, "Could not get door lock users")
         return json_output
 
+    def get_terminals(
+        self,
+        *,
+        limit: int = 20,
+        offset: int = 0,
+        max_retries: int = 0,
+    ) -> JsonDict:
+        """Retrieve account terminal information."""
+
+        return self._request_json(
+            "GET",
+            API_ENDPOINT_TERMINAL_INFO,
+            params={"limit": limit, "offset": offset},
+            retry_401=True,
+            max_retries=max_retries,
+        )
+
+    def get_latest_terminal_bind(
+        self,
+        *,
+        limit: int = 20,
+        offset: int = 0,
+        max_retries: int = 0,
+    ) -> tuple[str, str]:
+        """Return the latest terminal bind code and terminal user name."""
+
+        json_output = self.get_terminals(
+            limit=limit,
+            offset=offset,
+            max_retries=max_retries,
+        )
+        terminals = json_output.get("terminals")
+        if not isinstance(terminals, list) or not terminals:
+            raise PyEzvizError("No terminal information found")
+
+        terminal_items = [item for item in terminals if isinstance(item, Mapping)]
+        if not terminal_items:
+            raise PyEzvizError("No usable terminal information found")
+
+        terminal = max(
+            terminal_items,
+            key=lambda item: str(
+                item.get("lastModifytime") or item.get("lastModifyTime") or ""
+            ),
+        )
+        sign = terminal.get("sign")
+        terminal_user_id = terminal.get("userId")
+        if sign is None or terminal_user_id is None:
+            raise PyEzvizError("Latest terminal is missing bind information")
+
+        user_name = terminal.get("name") or terminal.get("terminalName") or terminal_user_id
+        return f"{sign}{terminal_user_id}", str(user_name)
+
     def remote_unlock(
         self,
         serial: str,
@@ -2872,6 +2926,9 @@ class EzvizClient:
         local_index: str | int | None = None,
         stream_token: str | None = None,
         lock_type: str | None = None,
+        bind_code: str | None = None,
+        terminal_name: str | None = None,
+        use_terminal_bind: bool = True,
     ) -> bool:
         """Sends a remote command to unlock a specific lock.
 
@@ -2886,6 +2943,12 @@ class EzvizClient:
             stream_token (str, optional): Stream token associated with the lock if
                 provided by the API. Defaults to empty string when omitted.
             lock_type (str, optional): Optional lock type hint used by some devices.
+            bind_code (str, optional): Explicit bind code. When omitted, the latest
+                terminal bind code is used if available, otherwise the legacy
+                ``FEATURE_CODE + user_id`` bind code is used.
+            terminal_name (str, optional): User name associated with ``bind_code``.
+            use_terminal_bind (bool): Whether to try terminal-derived bind codes
+                before falling back to the legacy bind code.
 
         Raises:
             PyEzvizError: If max retries are exceeded or if the response indicates failure.
@@ -2897,11 +2960,26 @@ class EzvizClient:
         """
         route_resource = resource_id or "Video"
         route_index = str(local_index if local_index is not None else 1)
+        effective_bind_code = bind_code
+        effective_user_name = terminal_name or user_id
+        if effective_bind_code is None and use_terminal_bind:
+            try:
+                effective_bind_code, effective_user_name = self.get_latest_terminal_bind()
+            except (HTTPError, PyEzvizError) as err:
+                _LOGGER.debug(
+                    "Terminal bind unavailable for %s, using legacy bind code: %s",
+                    serial,
+                    err,
+                )
+
+        if effective_bind_code is None:
+            effective_bind_code = f"{FEATURE_CODE}{user_id}"
+
         un_lock_info: dict[str, Any] = {
-            "bindCode": f"{FEATURE_CODE}{user_id}",
+            "bindCode": effective_bind_code,
             "lockNo": lock_no,
             "streamToken": stream_token or "",
-            "userName": user_id,
+            "userName": effective_user_name,
         }
         if lock_type:
             un_lock_info["type"] = lock_type

--- a/pyezvizapi/client.py
+++ b/pyezvizapi/client.py
@@ -2885,6 +2885,7 @@ class EzvizClient:
         *,
         limit: int = 20,
         offset: int = 0,
+        terminal_name: str | None = "Hassio",
         max_retries: int = 0,
     ) -> tuple[str, str]:
         """Return the latest terminal bind code and terminal user name."""
@@ -2907,6 +2908,17 @@ class EzvizClient:
         ]
         if not terminal_items:
             raise PyEzvizError("No terminal bind information found")
+
+        if terminal_name:
+            expected_name = terminal_name.casefold()
+            terminal_items = [
+                item
+                for item in terminal_items
+                if str(item.get("name") or item.get("terminalName") or "").casefold()
+                == expected_name
+            ]
+            if not terminal_items:
+                raise PyEzvizError(f"No terminal bind information found for {terminal_name}")
 
         terminal = max(
             terminal_items,

--- a/pyezvizapi/client.py
+++ b/pyezvizapi/client.py
@@ -2942,7 +2942,7 @@ class EzvizClient:
         stream_token: str | None = None,
         lock_type: str | None = None,
         bind_code: str | None = None,
-        terminal_name: str | None = None,
+        terminal_filter_name: str | None = "Hassio",
         use_terminal_bind: bool = True,
     ) -> bool:
         """Sends a remote command to unlock a specific lock.
@@ -2961,7 +2961,10 @@ class EzvizClient:
             bind_code (str, optional): Explicit bind code. When omitted, the latest
                 terminal bind code is used if available, otherwise the legacy
                 ``FEATURE_CODE + user_id`` bind code is used.
-            terminal_name (str, optional): User name associated with ``bind_code``.
+            terminal_filter_name (str, optional): Terminal name to prefer when
+                resolving an implicit bind code. Defaults to ``"Hassio"`` to match
+                the library login terminal. Pass ``None`` to use the newest valid
+                terminal regardless of name.
             use_terminal_bind (bool): Whether to try terminal-derived bind codes
                 before falling back to the legacy bind code.
 
@@ -2976,10 +2979,12 @@ class EzvizClient:
         route_resource = resource_id or "Video"
         route_index = str(local_index if local_index is not None else 1)
         effective_bind_code = bind_code
-        effective_user_name = terminal_name or user_id
+        effective_user_name = user_id
         if effective_bind_code is None and use_terminal_bind:
             try:
-                effective_bind_code, effective_user_name = self.get_latest_terminal_bind()
+                effective_bind_code, effective_user_name = self.get_latest_terminal_bind(
+                    terminal_name=terminal_filter_name
+                )
             except (requests.RequestException, HTTPError, PyEzvizError) as err:
                 _LOGGER.debug(
                     "Terminal bind unavailable for %s, using legacy bind code: %s",

--- a/pyezvizapi/client.py
+++ b/pyezvizapi/client.py
@@ -2898,9 +2898,13 @@ class EzvizClient:
         if not isinstance(terminals, list) or not terminals:
             raise PyEzvizError("No terminal information found")
 
-        terminal_items = [item for item in terminals if isinstance(item, Mapping)]
+        terminal_items = [
+            item
+            for item in terminals
+            if isinstance(item, Mapping) and item.get("sign") is not None and item.get("userId") is not None
+        ]
         if not terminal_items:
-            raise PyEzvizError("No usable terminal information found")
+            raise PyEzvizError("No terminal bind information found")
 
         terminal = max(
             terminal_items,
@@ -2908,11 +2912,8 @@ class EzvizClient:
                 item.get("lastModifytime") or item.get("lastModifyTime") or ""
             ),
         )
-        sign = terminal.get("sign")
-        terminal_user_id = terminal.get("userId")
-        if sign is None or terminal_user_id is None:
-            raise PyEzvizError("Latest terminal is missing bind information")
-
+        sign = terminal["sign"]
+        terminal_user_id = terminal["userId"]
         user_name = terminal.get("name") or terminal.get("terminalName") or terminal_user_id
         return f"{sign}{terminal_user_id}", str(user_name)
 
@@ -2965,7 +2966,7 @@ class EzvizClient:
         if effective_bind_code is None and use_terminal_bind:
             try:
                 effective_bind_code, effective_user_name = self.get_latest_terminal_bind()
-            except (HTTPError, PyEzvizError) as err:
+            except (requests.RequestException, HTTPError, PyEzvizError) as err:
                 _LOGGER.debug(
                     "Terminal bind unavailable for %s, using legacy bind code: %s",
                     serial,

--- a/pyezvizapi/client.py
+++ b/pyezvizapi/client.py
@@ -2901,7 +2901,9 @@ class EzvizClient:
         terminal_items = [
             item
             for item in terminals
-            if isinstance(item, Mapping) and item.get("sign") is not None and item.get("userId") is not None
+            if isinstance(item, Mapping)
+            and str(item.get("sign") or "").strip()
+            and str(item.get("userId") or "").strip()
         ]
         if not terminal_items:
             raise PyEzvizError("No terminal bind information found")
@@ -2912,8 +2914,8 @@ class EzvizClient:
                 item.get("lastModifytime") or item.get("lastModifyTime") or ""
             ),
         )
-        sign = terminal["sign"]
-        terminal_user_id = terminal["userId"]
+        sign = str(terminal["sign"]).strip()
+        terminal_user_id = str(terminal["userId"]).strip()
         user_name = terminal.get("name") or terminal.get("terminalName") or terminal_user_id
         return f"{sign}{terminal_user_id}", str(user_name)
 

--- a/tests/fixtures/terminal_info_response.json
+++ b/tests/fixtures/terminal_info_response.json
@@ -1,0 +1,69 @@
+{
+  "meta": {
+    "code": 200,
+    "message": "success",
+    "moreInfo": null
+  },
+  "page": {
+    "limit": 20,
+    "offset": 0,
+    "total": 4,
+    "hasNext": false
+  },
+  "terminals": [
+    {
+      "appId": "ys7",
+      "clientType": 1,
+      "clientVersion": "6.10.0",
+      "deviceId": "fictional-device-hassio-older",
+      "deviceName": "Home Assistant older session",
+      "lastModifytime": "2025-01-01T00:00:00Z",
+      "name": "Hassio",
+      "osVersion": "Linux",
+      "sign": "11112222333344445555666677778888",
+      "terminalId": "fictional-terminal-hassio-older",
+      "terminalType": "HASSIO",
+      "userId": "fake-user-id-001"
+    },
+    {
+      "appId": "ys7",
+      "clientType": 1,
+      "clientVersion": "6.10.0",
+      "deviceId": "fictional-device-hassio-latest",
+      "deviceName": "Home Assistant latest session",
+      "lastModifytime": "2025-01-02T00:00:00Z",
+      "name": "Hassio",
+      "osVersion": "Linux",
+      "sign": "aaaabbbbccccddddeeeeffff00001111",
+      "terminalId": "fictional-terminal-hassio-latest",
+      "terminalType": "HASSIO",
+      "userId": "fake-user-id-002"
+    },
+    {
+      "appId": "ys7",
+      "clientType": 3,
+      "clientVersion": "6.12.0",
+      "deviceId": "fictional-device-phone-latest",
+      "deviceName": "User phone latest session",
+      "lastModifytime": "2025-01-03T00:00:00Z",
+      "name": "newer phone",
+      "osVersion": "iOS 18.0",
+      "sign": "99998888777766665555444433332222",
+      "terminalId": "fictional-terminal-phone-latest",
+      "terminalType": "IOS",
+      "userId": "fake-user-id-003"
+    },
+    {
+      "appId": "ys7",
+      "clientType": 1,
+      "clientVersion": "6.10.0",
+      "deviceId": "fictional-device-missing-bind",
+      "deviceName": "Terminal without bind fields",
+      "lastModifytime": "2025-01-04T00:00:00Z",
+      "name": "Hassio",
+      "osVersion": "Linux",
+      "terminalId": "fictional-terminal-missing-bind",
+      "terminalType": "HASSIO"
+    }
+  ]
+}

--- a/tests/test_http_helpers.py
+++ b/tests/test_http_helpers.py
@@ -2058,13 +2058,13 @@ def test_terminal_helpers_parse_latest_bind(monkeypatch) -> None:
             "meta": {"code": 200},
             "terminals": [
                 {
-                    "name": "older phone",
+                    "name": "Hassio",
                     "sign": "old-sign-",
                     "userId": "old-user",
                     "lastModifytime": "2025-01-01T00:00:00Z",
                 },
                 {
-                    "name": "latest phone",
+                    "name": "Hassio",
                     "sign": "new-sign-",
                     "userId": "new-user",
                     "lastModifytime": "2025-01-02T00:00:00Z",
@@ -2074,11 +2074,42 @@ def test_terminal_helpers_parse_latest_bind(monkeypatch) -> None:
 
     monkeypatch.setattr(client, "_request_json", fake_request_json)
 
-    assert client.get_latest_terminal_bind() == ("new-sign-new-user", "latest phone")
+    assert client.get_latest_terminal_bind() == ("new-sign-new-user", "Hassio")
     assert captured["method"] == "GET"
     assert captured["path"].endswith("/v3/terminals")
     assert captured["params"] == {"limit": 20, "offset": 0}
     assert captured["retry_401"] is True
+
+
+def test_terminal_helpers_prefer_hassio_terminal(monkeypatch) -> None:
+    client = _client()
+
+    def fake_request_json(method: str, path: str, **kwargs: Any) -> dict[str, Any]:
+        return {
+            "meta": {"code": 200},
+            "terminals": [
+                {
+                    "name": "Hassio",
+                    "sign": "hassio-sign-",
+                    "userId": "hassio-user",
+                    "lastModifytime": "2025-01-01T00:00:00Z",
+                },
+                {
+                    "name": "newer phone",
+                    "sign": "phone-sign-",
+                    "userId": "phone-user",
+                    "lastModifytime": "2025-01-02T00:00:00Z",
+                },
+            ],
+        }
+
+    monkeypatch.setattr(client, "_request_json", fake_request_json)
+
+    assert client.get_latest_terminal_bind() == ("hassio-sign-hassio-user", "Hassio")
+    assert client.get_latest_terminal_bind(terminal_name=None) == (
+        "phone-sign-phone-user",
+        "newer phone",
+    )
 
 
 def test_terminal_helpers_ignore_latest_terminal_without_bind_fields(monkeypatch) -> None:
@@ -2089,7 +2120,7 @@ def test_terminal_helpers_ignore_latest_terminal_without_bind_fields(monkeypatch
             "meta": {"code": 200},
             "terminals": [
                 {
-                    "name": "valid older phone",
+                    "name": "Hassio",
                     "sign": "valid-sign-",
                     "userId": "valid-user",
                     "lastModifytime": "2025-01-01T00:00:00Z",
@@ -2103,7 +2134,7 @@ def test_terminal_helpers_ignore_latest_terminal_without_bind_fields(monkeypatch
 
     monkeypatch.setattr(client, "_request_json", fake_request_json)
 
-    assert client.get_latest_terminal_bind() == ("valid-sign-valid-user", "valid older phone")
+    assert client.get_latest_terminal_bind() == ("valid-sign-valid-user", "Hassio")
 
 
 def test_terminal_helpers_ignore_empty_bind_fields(monkeypatch) -> None:
@@ -2114,7 +2145,7 @@ def test_terminal_helpers_ignore_empty_bind_fields(monkeypatch) -> None:
             "meta": {"code": 200},
             "terminals": [
                 {
-                    "name": "valid phone",
+                    "name": "Hassio",
                     "sign": " valid-sign- ",
                     "userId": " valid-user ",
                     "lastModifytime": "2025-01-01T00:00:00Z",
@@ -2130,7 +2161,7 @@ def test_terminal_helpers_ignore_empty_bind_fields(monkeypatch) -> None:
 
     monkeypatch.setattr(client, "_request_json", fake_request_json)
 
-    assert client.get_latest_terminal_bind() == ("valid-sign-valid-user", "valid phone")
+    assert client.get_latest_terminal_bind() == ("valid-sign-valid-user", "Hassio")
 
 
 def test_remote_unlock_uses_terminal_bind_when_available(monkeypatch) -> None:
@@ -2144,7 +2175,7 @@ def test_remote_unlock_uses_terminal_bind_when_available(monkeypatch) -> None:
                 "meta": {"code": 200},
                 "terminals": [
                     {
-                        "name": "phone",
+                        "name": "Hassio",
                         "sign": "terminal-sign-",
                         "userId": "terminal-user",
                         "lastModifytime": "2025-01-02T00:00:00Z",
@@ -2164,7 +2195,7 @@ def test_remote_unlock_uses_terminal_bind_when_available(monkeypatch) -> None:
             "bindCode": "terminal-sign-terminal-user",
             "lockNo": 2,
             "streamToken": "",
-            "userName": "phone",
+            "userName": "Hassio",
         }
     }
 

--- a/tests/test_http_helpers.py
+++ b/tests/test_http_helpers.py
@@ -2106,6 +2106,33 @@ def test_terminal_helpers_ignore_latest_terminal_without_bind_fields(monkeypatch
     assert client.get_latest_terminal_bind() == ("valid-sign-valid-user", "valid older phone")
 
 
+def test_terminal_helpers_ignore_empty_bind_fields(monkeypatch) -> None:
+    client = _client()
+
+    def fake_request_json(method: str, path: str, **kwargs: Any) -> dict[str, Any]:
+        return {
+            "meta": {"code": 200},
+            "terminals": [
+                {
+                    "name": "valid phone",
+                    "sign": " valid-sign- ",
+                    "userId": " valid-user ",
+                    "lastModifytime": "2025-01-01T00:00:00Z",
+                },
+                {
+                    "name": "empty latest phone",
+                    "sign": "",
+                    "userId": " ",
+                    "lastModifytime": "2025-01-02T00:00:00Z",
+                },
+            ],
+        }
+
+    monkeypatch.setattr(client, "_request_json", fake_request_json)
+
+    assert client.get_latest_terminal_bind() == ("valid-sign-valid-user", "valid phone")
+
+
 def test_remote_unlock_uses_terminal_bind_when_available(monkeypatch) -> None:
     client = _client()
     calls: list[dict[str, Any]] = []

--- a/tests/test_http_helpers.py
+++ b/tests/test_http_helpers.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import datetime as dt
+import json
+from pathlib import Path
 from typing import Any, cast
 
 import pytest
@@ -26,6 +28,11 @@ def _client() -> EzvizClient:
         token={"session_id": "session", "api_url": "apiieu.ezvizlife.com"},
         timeout=1,
     )
+
+
+def _fixture(name: str) -> dict[str, Any]:
+    path = Path(__file__).with_name("fixtures") / name
+    return cast(dict[str, Any], json.loads(path.read_text(encoding="utf-8")))
 
 
 def _response(*, status_code: int = 200, text: str = '{"meta": {"code": 200}}') -> requests.Response:
@@ -2054,27 +2061,14 @@ def test_terminal_helpers_parse_latest_bind(monkeypatch) -> None:
 
     def fake_request_json(method: str, path: str, **kwargs: Any) -> dict[str, Any]:
         captured.update({"method": method, "path": path, **kwargs})
-        return {
-            "meta": {"code": 200},
-            "terminals": [
-                {
-                    "name": "Hassio",
-                    "sign": "old-sign-",
-                    "userId": "old-user",
-                    "lastModifytime": "2025-01-01T00:00:00Z",
-                },
-                {
-                    "name": "Hassio",
-                    "sign": "new-sign-",
-                    "userId": "new-user",
-                    "lastModifytime": "2025-01-02T00:00:00Z",
-                },
-            ],
-        }
+        return _fixture("terminal_info_response.json")
 
     monkeypatch.setattr(client, "_request_json", fake_request_json)
 
-    assert client.get_latest_terminal_bind() == ("new-sign-new-user", "Hassio")
+    assert client.get_latest_terminal_bind() == (
+        "aaaabbbbccccddddeeeeffff00001111fake-user-id-002",
+        "Hassio",
+    )
     assert captured["method"] == "GET"
     assert captured["path"].endswith("/v3/terminals")
     assert captured["params"] == {"limit": 20, "offset": 0}
@@ -2085,29 +2079,16 @@ def test_terminal_helpers_prefer_hassio_terminal(monkeypatch) -> None:
     client = _client()
 
     def fake_request_json(method: str, path: str, **kwargs: Any) -> dict[str, Any]:
-        return {
-            "meta": {"code": 200},
-            "terminals": [
-                {
-                    "name": "Hassio",
-                    "sign": "hassio-sign-",
-                    "userId": "hassio-user",
-                    "lastModifytime": "2025-01-01T00:00:00Z",
-                },
-                {
-                    "name": "newer phone",
-                    "sign": "phone-sign-",
-                    "userId": "phone-user",
-                    "lastModifytime": "2025-01-02T00:00:00Z",
-                },
-            ],
-        }
+        return _fixture("terminal_info_response.json")
 
     monkeypatch.setattr(client, "_request_json", fake_request_json)
 
-    assert client.get_latest_terminal_bind() == ("hassio-sign-hassio-user", "Hassio")
+    assert client.get_latest_terminal_bind() == (
+        "aaaabbbbccccddddeeeeffff00001111fake-user-id-002",
+        "Hassio",
+    )
     assert client.get_latest_terminal_bind(terminal_name=None) == (
-        "phone-sign-phone-user",
+        "99998888777766665555444433332222fake-user-id-003",
         "newer phone",
     )
 
@@ -2116,21 +2097,20 @@ def test_terminal_helpers_ignore_latest_terminal_without_bind_fields(monkeypatch
     client = _client()
 
     def fake_request_json(method: str, path: str, **kwargs: Any) -> dict[str, Any]:
-        return {
-            "meta": {"code": 200},
-            "terminals": [
-                {
-                    "name": "Hassio",
-                    "sign": "valid-sign-",
-                    "userId": "valid-user",
-                    "lastModifytime": "2025-01-01T00:00:00Z",
-                },
-                {
-                    "name": "invalid latest phone",
-                    "lastModifytime": "2025-01-02T00:00:00Z",
-                },
-            ],
-        }
+        payload = _fixture("terminal_info_response.json")
+        payload["terminals"] = [
+            {
+                "name": "Hassio",
+                "sign": "valid-sign-",
+                "userId": "valid-user",
+                "lastModifytime": "2025-01-01T00:00:00Z",
+            },
+            {
+                "name": "Hassio",
+                "lastModifytime": "2025-01-02T00:00:00Z",
+            },
+        ]
+        return payload
 
     monkeypatch.setattr(client, "_request_json", fake_request_json)
 
@@ -2141,23 +2121,22 @@ def test_terminal_helpers_ignore_empty_bind_fields(monkeypatch) -> None:
     client = _client()
 
     def fake_request_json(method: str, path: str, **kwargs: Any) -> dict[str, Any]:
-        return {
-            "meta": {"code": 200},
-            "terminals": [
-                {
-                    "name": "Hassio",
-                    "sign": " valid-sign- ",
-                    "userId": " valid-user ",
-                    "lastModifytime": "2025-01-01T00:00:00Z",
-                },
-                {
-                    "name": "empty latest phone",
-                    "sign": "",
-                    "userId": " ",
-                    "lastModifytime": "2025-01-02T00:00:00Z",
-                },
-            ],
-        }
+        payload = _fixture("terminal_info_response.json")
+        payload["terminals"] = [
+            {
+                "name": "Hassio",
+                "sign": " valid-sign- ",
+                "userId": " valid-user ",
+                "lastModifytime": "2025-01-01T00:00:00Z",
+            },
+            {
+                "name": "Hassio",
+                "sign": "",
+                "userId": " ",
+                "lastModifytime": "2025-01-02T00:00:00Z",
+            },
+        ]
+        return payload
 
     monkeypatch.setattr(client, "_request_json", fake_request_json)
 
@@ -2171,17 +2150,16 @@ def test_remote_unlock_uses_terminal_bind_when_available(monkeypatch) -> None:
     def fake_request_json(method: str, path: str, **kwargs: Any) -> dict[str, Any]:
         calls.append({"method": method, "path": path, **kwargs})
         if path.endswith("/v3/terminals"):
-            return {
-                "meta": {"code": 200},
-                "terminals": [
-                    {
-                        "name": "Hassio",
-                        "sign": "terminal-sign-",
-                        "userId": "terminal-user",
-                        "lastModifytime": "2025-01-02T00:00:00Z",
-                    }
-                ],
-            }
+            payload = _fixture("terminal_info_response.json")
+            payload["terminals"] = [
+                {
+                    "name": "Hassio",
+                    "sign": "terminal-sign-",
+                    "userId": "terminal-user",
+                    "lastModifytime": "2025-01-02T00:00:00Z",
+                }
+            ]
+            return payload
         return {"meta": {"code": 200}}
 
     monkeypatch.setattr(client, "_request_json", fake_request_json)

--- a/tests/test_http_helpers.py
+++ b/tests/test_http_helpers.py
@@ -2178,6 +2178,38 @@ def test_remote_unlock_uses_terminal_bind_when_available(monkeypatch) -> None:
     }
 
 
+def test_remote_unlock_can_use_latest_terminal_without_name_filter(monkeypatch) -> None:
+    client = _client()
+    calls: list[dict[str, Any]] = []
+
+    def fake_request_json(method: str, path: str, **kwargs: Any) -> dict[str, Any]:
+        calls.append({"method": method, "path": path, **kwargs})
+        if path.endswith("/v3/terminals"):
+            return _fixture("terminal_info_response.json")
+        return {"meta": {"code": 200}}
+
+    monkeypatch.setattr(client, "_request_json", fake_request_json)
+
+    assert (
+        client.remote_unlock(
+            "LOCK123",
+            "legacy-user",
+            2,
+            terminal_filter_name=None,
+        )
+        is True
+    )
+    assert calls[1]["method"] == "PUT"
+    assert calls[1]["json_body"] == {
+        "unLockInfo": {
+            "bindCode": "99998888777766665555444433332222fake-user-id-003",
+            "lockNo": 2,
+            "streamToken": "",
+            "userName": "newer phone",
+        }
+    }
+
+
 def test_remote_unlock_falls_back_when_terminal_lookup_request_fails(monkeypatch) -> None:
     client = _client()
     calls: list[dict[str, Any]] = []

--- a/tests/test_http_helpers.py
+++ b/tests/test_http_helpers.py
@@ -2011,6 +2011,7 @@ def test_door_lock_and_remote_lock_helpers_build_requests(monkeypatch) -> None:
         local_index=2,
         stream_token="stream-1",
         lock_type="fingerprint",
+        use_terminal_bind=False,
     ) is True
     assert client.remote_lock("LOCK123", "user-1", 7) is True
     assert client.get_remote_unbind_progress("LOCK123", max_retries=2)["meta"]["code"] == 200
@@ -2045,6 +2046,75 @@ def test_door_lock_and_remote_lock_helpers_build_requests(monkeypatch) -> None:
     assert calls[3]["method"] == "GET"
     assert calls[3]["path"].endswith("LOCK123/progress")
     assert calls[3]["max_retries"] == 2
+
+
+def test_terminal_helpers_parse_latest_bind(monkeypatch) -> None:
+    client = _client()
+    captured: dict[str, Any] = {}
+
+    def fake_request_json(method: str, path: str, **kwargs: Any) -> dict[str, Any]:
+        captured.update({"method": method, "path": path, **kwargs})
+        return {
+            "meta": {"code": 200},
+            "terminals": [
+                {
+                    "name": "older phone",
+                    "sign": "old-sign-",
+                    "userId": "old-user",
+                    "lastModifytime": "2025-01-01T00:00:00Z",
+                },
+                {
+                    "name": "latest phone",
+                    "sign": "new-sign-",
+                    "userId": "new-user",
+                    "lastModifytime": "2025-01-02T00:00:00Z",
+                },
+            ],
+        }
+
+    monkeypatch.setattr(client, "_request_json", fake_request_json)
+
+    assert client.get_latest_terminal_bind() == ("new-sign-new-user", "latest phone")
+    assert captured["method"] == "GET"
+    assert captured["path"].endswith("/v3/terminals")
+    assert captured["params"] == {"limit": 20, "offset": 0}
+    assert captured["retry_401"] is True
+
+
+def test_remote_unlock_uses_terminal_bind_when_available(monkeypatch) -> None:
+    client = _client()
+    calls: list[dict[str, Any]] = []
+
+    def fake_request_json(method: str, path: str, **kwargs: Any) -> dict[str, Any]:
+        calls.append({"method": method, "path": path, **kwargs})
+        if path.endswith("/v3/terminals"):
+            return {
+                "meta": {"code": 200},
+                "terminals": [
+                    {
+                        "name": "phone",
+                        "sign": "terminal-sign-",
+                        "userId": "terminal-user",
+                        "lastModifytime": "2025-01-02T00:00:00Z",
+                    }
+                ],
+            }
+        return {"meta": {"code": 200}}
+
+    monkeypatch.setattr(client, "_request_json", fake_request_json)
+
+    assert client.remote_unlock("LOCK123", "legacy-user", 2) is True
+    assert calls[0]["method"] == "GET"
+    assert calls[0]["path"].endswith("/v3/terminals")
+    assert calls[1]["method"] == "PUT"
+    assert calls[1]["json_body"] == {
+        "unLockInfo": {
+            "bindCode": "terminal-sign-terminal-user",
+            "lockNo": 2,
+            "streamToken": "",
+            "userName": "phone",
+        }
+    }
 
 
 def test_door_lock_helpers_raise_contextual_errors(monkeypatch) -> None:

--- a/tests/test_http_helpers.py
+++ b/tests/test_http_helpers.py
@@ -2081,6 +2081,31 @@ def test_terminal_helpers_parse_latest_bind(monkeypatch) -> None:
     assert captured["retry_401"] is True
 
 
+def test_terminal_helpers_ignore_latest_terminal_without_bind_fields(monkeypatch) -> None:
+    client = _client()
+
+    def fake_request_json(method: str, path: str, **kwargs: Any) -> dict[str, Any]:
+        return {
+            "meta": {"code": 200},
+            "terminals": [
+                {
+                    "name": "valid older phone",
+                    "sign": "valid-sign-",
+                    "userId": "valid-user",
+                    "lastModifytime": "2025-01-01T00:00:00Z",
+                },
+                {
+                    "name": "invalid latest phone",
+                    "lastModifytime": "2025-01-02T00:00:00Z",
+                },
+            ],
+        }
+
+    monkeypatch.setattr(client, "_request_json", fake_request_json)
+
+    assert client.get_latest_terminal_bind() == ("valid-sign-valid-user", "valid older phone")
+
+
 def test_remote_unlock_uses_terminal_bind_when_available(monkeypatch) -> None:
     client = _client()
     calls: list[dict[str, Any]] = []
@@ -2113,6 +2138,32 @@ def test_remote_unlock_uses_terminal_bind_when_available(monkeypatch) -> None:
             "lockNo": 2,
             "streamToken": "",
             "userName": "phone",
+        }
+    }
+
+
+def test_remote_unlock_falls_back_when_terminal_lookup_request_fails(monkeypatch) -> None:
+    client = _client()
+    calls: list[dict[str, Any]] = []
+
+    def fake_request_json(method: str, path: str, **kwargs: Any) -> dict[str, Any]:
+        calls.append({"method": method, "path": path, **kwargs})
+        if path.endswith("/v3/terminals"):
+            raise requests.Timeout("timed out")
+        return {"meta": {"code": 200}}
+
+    monkeypatch.setattr(client, "_request_json", fake_request_json)
+
+    assert client.remote_unlock("LOCK123", "legacy-user", 2) is True
+    assert calls[0]["method"] == "GET"
+    assert calls[0]["path"].endswith("/v3/terminals")
+    assert calls[1]["method"] == "PUT"
+    assert calls[1]["json_body"] == {
+        "unLockInfo": {
+            "bindCode": f"{FEATURE_CODE}legacy-user",
+            "lockNo": 2,
+            "streamToken": "",
+            "userName": "legacy-user",
         }
     }
 


### PR DESCRIPTION
## Summary
- add a terminal-info API helper for `/v3/terminals`
- derive remote unlock bind codes from the latest terminal when available
- keep the existing `remote_unlock()` API and route parameters backward-compatible
- fall back to the legacy `FEATURE_CODE + user_id` bind code if terminal info is unavailable

This is a cleaned-up replacement for the useful part of #43 without hardcoded mobile headers, print debugging, or signature-breaking changes.

## Tests
- `python -m ruff check pyezvizapi/api_endpoints.py pyezvizapi/client.py tests/test_http_helpers.py`
- `.venv/bin/python -m pytest tests/test_http_helpers.py tests/test_camera_control.py tests/test_auth.py tests/test_cli.py -q`