### PR TITLE
Update changelog for terminal bind unlock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This project follows [Semantic Versioning](https://semver.org/) for published re
 
 ## Unreleased
 
+### Changed
+
+- Updated remote unlock to prefer terminal-derived bind codes from the EZVIZ terminals API while preserving legacy bind-code fallback behavior.
+
 ## v1.0.4.7 - 2026-04-27
 
 ### Added


### PR DESCRIPTION
## Summary
- add an Unreleased changelog entry for terminal-derived remote unlock bind codes
- note that the legacy bind-code fallback remains preserved

## Tests
- `git diff --check`
- `python -m ruff check CHANGELOG.md`