### PR TITLE
Fix off-by-one in set_floodlight_brightness: accept luminance=100

### DIFF
--- a/pyezvizapi/client.py
+++ b/pyezvizapi/client.py
@@ -3574,7 +3574,7 @@ class EzvizClient:
         if max_retries > MAX_RETRIES:
             raise PyEzvizError("Can't gather proper data. Max retries exceeded.")
 
-        if luminance not in range(1, 100):
+        if luminance not in range(1, 101):
             raise PyEzvizError(
                 "Range of luminance is 1-100, got " + str(luminance) + "."
             )

--- a/tests/test_floodlight_brightness.py
+++ b/tests/test_floodlight_brightness.py
@@ -1,0 +1,55 @@
+"""Tests for set_floodlight_brightness luminance validation."""
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from pyezvizapi.client import EzvizClient
+from pyezvizapi.exceptions import PyEzvizError
+
+
+def _client() -> EzvizClient:
+    return EzvizClient(
+        token={"session_id": "session", "api_url": "apiieu.ezvizlife.com"},
+        timeout=1,
+    )
+
+
+def _ok_response(*_a: Any, **_kw: Any) -> dict[str, Any]:
+    return {"meta": {"code": 200}, "resultCode": "0"}
+
+
+@pytest.mark.parametrize("luminance", [1, 50, 99, 100])
+def test_set_floodlight_brightness_accepts_valid_range(luminance: int) -> None:
+    """Luminance values 1-100 (inclusive) must be accepted.
+
+    Regression test for an off-by-one in the validation:
+    range(1, 100) excluded 100 even though the docstring/error message
+    documented 1-100 as the valid range. Some camera models switch to
+    colour night-vision only at exactly 100, so rejecting 100 was a
+    real user-facing regression.
+    """
+    client = _client()
+    with patch.object(EzvizClient, "_request_json", side_effect=_ok_response):
+        assert client.set_floodlight_brightness(
+            serial="ABC123",
+            luminance=luminance,
+            channelno=1,
+        ) is True
+
+
+@pytest.mark.parametrize("luminance", [-1, 0, 101, 200])
+def test_set_floodlight_brightness_rejects_out_of_range(luminance: int) -> None:
+    """Luminance values outside 1-100 must raise PyEzvizError."""
+    client = _client()
+    with (
+        patch.object(EzvizClient, "_request_json", side_effect=_ok_response),
+        pytest.raises(PyEzvizError, match="Range of luminance"),
+    ):
+        client.set_floodlight_brightness(
+            serial="ABC123",
+            luminance=luminance,
+            channelno=1,
+        )

--- a/tests/test_http_helpers.py
+++ b/tests/test_http_helpers.py
@@ -1717,7 +1717,7 @@ def test_set_floodlight_brightness_validates_range_and_retries() -> None:
         client.set_floodlight_brightness("CAM123", luminance=0)
 
     with pytest.raises(PyEzvizError, match="Range of luminance"):
-        client.set_floodlight_brightness("CAM123", luminance=100)
+        client.set_floodlight_brightness("CAM123", luminance=101)
 
     with pytest.raises(PyEzvizError, match="Max retries exceeded"):
         client.set_floodlight_brightness("CAM123", max_retries=99)


### PR DESCRIPTION
## Summary

- `set_floodlight_brightness` rejects `luminance=100` due to `range(1, 100)` excluding the upper bound. The error message claims the valid range is "1-100" inclusive, so the validation contradicts itself.
- This affects the Home Assistant EZVIZ light integration. At the maximum brightness slider position HA sends `ATTR_BRIGHTNESS=255`, which `ranged_value_to_percentage((1, 255), 255)` converts to **100** (HA's own docstring confirms this exact example: `"(1,255), 255: 100"`). HA then calls `set_floodlight_brightness(serial, 100)`, which raises `PyEzvizError`. HA wraps it as `HomeAssistantError("Failed to turn on light …")`, and the user sees a failure when trying to set the slider to max.
- The EZVIZ cloud API itself accepts 100 cleanly — verified live on 11 LC3 floodlight cameras after applying the fix.
- 100 has user-visible functional meaning on LC3 floodlight cameras: full colour night vision is only triggered at exactly 100. At 99 the camera stays in regular night-vision mode, so users currently can't reach colour mode through HA at all.
- One-character fix in `pyezvizapi/client.py`: `range(1, 100)` → `range(1, 101)` so the validation matches the documented range.
- New parametrised tests in `tests/test_floodlight_brightness.py` cover 1, 50, 99, 100 (accepted) and -1, 0, 101, 200 (rejected).
- Updated existing test in `tests/test_http_helpers.py` from `luminance=100` (which was codifying the off-by-one) to `luminance=101` so it still verifies out-of-range rejection without contradicting the 1-100 range advertised in the error message.

## Validation

All run locally on Python 3.12:

- [x] `ruff check .`
- [x] `codespell pyezvizapi tests README.md pyproject.toml .github`
- [x] `pip-audit --progress-spinner off`
- [x] `mypy --install-types --non-interactive .`
- [x] `pyright pyezvizapi`
- [x] `pytest --cov=pyezvizapi --cov-report=term-missing --cov-report=xml --cov-fail-under=85` — 250 passed, 86.45% coverage
- [x] `python -m build`
- [x] `twine check dist/*`
- [x] `python -m pip check`

## Compatibility

- [x] Tests are offline and do not require EZVIZ credentials, real cameras, cloud calls, or live network access.
- [x] Home Assistant compatibility: this fix unblocks a currently-broken HA flow (max brightness slider). Callers passing 1-99 see no change; the only behavioural shift is 100 now succeeds instead of raising.
- [x] Generated artifacts were removed before commit (`dist`, `build`, `*.egg-info`, caches, coverage files).