### PR TITLE
Add VTDU stream protocol helpers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,11 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# APK reverse engineering lab artifacts
+/discovery/apk/in/*
+!/discovery/apk/in/.gitkeep
+/discovery/apk/out/*
+!/discovery/apk/out/.gitkeep
+/discovery/apk/work/*
+!/discovery/apk/work/.gitkeep

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ This project follows [Semantic Versioning](https://semver.org/) for published re
 ### Added
 
 - Added cloud stream bootstrap helpers for VTM pagelist metadata, VTDU token retrieval, VTM/VTDU packet framing, `ysproto` URL handling, limited stream protobuf parsing, RTP payload extraction, and transport detection.
+- Added VTM server public-key extraction plus native VTDU protobuf helpers for `GetVtduInfo`, `StartStream`, `PeerStream`, and `StopStream` stream-control messages.
+- Added a Docker-based APK reverse-engineering lab and EZVIZ VTDU/VTM streaming notes to support future stream protocol work.
 - Added sanitized full pagelist fixture coverage for `get_device_infos()` and `load_devices(refresh=False)` so the parser is tested against a realistic cloud response without live EZVIZ credentials.
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@ This project follows [Semantic Versioning](https://semver.org/) for published re
 
 - Added cloud stream bootstrap helpers for VTM pagelist metadata, VTDU token retrieval, VTM/VTDU packet framing, `ysproto` URL handling, limited stream protobuf parsing, RTP payload extraction, and transport detection.
 - Added VTM server public-key extraction plus native VTDU protobuf helpers for `GetVtduInfo`, `StartStream`, `PeerStream`, and `StopStream` stream-control messages.
-- Added a Docker-based APK reverse-engineering lab and EZVIZ VTDU/VTM streaming notes to support future stream protocol work.
 - Added sanitized full pagelist fixture coverage for `get_device_infos()` and `load_devices(refresh=False)` so the parser is tested against a realistic cloud response without live EZVIZ credentials.
 
 ### Changed

--- a/pyezvizapi/cloud_stream.py
+++ b/pyezvizapi/cloud_stream.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import base64
+import binascii
+from dataclasses import dataclass
 import json
 from typing import Any, TypedDict, cast
 from urllib.parse import urlparse
@@ -21,6 +23,15 @@ class VtduTokenResponse(TypedDict, total=False):
     msg: str
     tokens: list[str]
     retcode: int
+
+
+@dataclass(frozen=True)
+class VtmServerPublicKey:
+    """VTM server public key material from pagelist metadata."""
+
+    version: int
+    key: str
+    key_bytes: bytes
 
 
 def get_vtdu_token_v2(client: Any, max_retries: int = 0) -> VtduTokenResponse:
@@ -127,9 +138,36 @@ def get_cloud_stream_info(
     return {
         "resource": resource,
         "vtm": vtm,
+        "vtm_public_key": parse_vtm_server_public_key(vtm),
         "vtdu_token": vtdu_token,
         "stream_url": stream_url,
     }
+
+
+def parse_vtm_server_public_key(vtm: JsonDict) -> VtmServerPublicKey | None:
+    """Return decoded VTM server public key metadata when present."""
+
+    public_key = vtm.get("publicKey")
+    if not isinstance(public_key, dict):
+        return None
+
+    key = public_key.get("key")
+    version = public_key.get("version")
+    if not isinstance(key, str) or not key:
+        return None
+    if not isinstance(version, (int, str)) or not str(version).isdigit():
+        raise PyEzvizError("VTM public key version is invalid")
+
+    try:
+        key_bytes = base64.b64decode(key, validate=True)
+    except (ValueError, binascii.Error) as err:
+        raise PyEzvizError("VTM public key is not valid base64") from err
+
+    return VtmServerPublicKey(
+        version=int(version),
+        key=key,
+        key_bytes=key_bytes,
+    )
 
 
 def _find_vtm_resource(

--- a/pyezvizapi/stream.py
+++ b/pyezvizapi/stream.py
@@ -80,6 +80,38 @@ class StreamInfoResponse:
     aesmd5: str | None = None
     udptransinfo: str | None = None
     peerpbkey: str | None = None
+    pdslist: tuple[bytes, ...] = ()
+    srvipv6_addr: str | None = None
+
+
+@dataclass(frozen=True)
+class VtduInfoResponse:
+    """Decoded fields from a GetVtduInfoRsp protobuf body."""
+
+    result: int | None = None
+    host: str | None = None
+    port: int | None = None
+    streamkey: str | None = None
+    peerhost: str | None = None
+    peerport: int | None = None
+    srvinfo: str | None = None
+
+
+@dataclass(frozen=True)
+class VtduStreamResponse:
+    """Decoded fields shared by StartStreamRsp and PeerStreamRsp."""
+
+    result: int | None = None
+    streamhead: str | None = None
+    streamssn: str | None = None
+    datakey: int | None = None
+
+
+@dataclass(frozen=True)
+class StopStreamResponse:
+    """Decoded fields from a StopStreamRsp protobuf body."""
+
+    result: int | None = None
 
 
 def encode_vtm_packet(
@@ -224,45 +256,145 @@ def build_stream_keepalive_request(stream_ssn: str) -> bytes:
     return _proto_bytes(1, stream_ssn.encode())
 
 
+def build_get_vtdu_info_request(
+    serial: str,
+    vtdu_token: str,
+    *,
+    channel: int = 1,
+    stream_type: int = 1,
+    business_type: int = 0,
+    client_isp_type: int = 0,
+    is_proxy: bool = False,
+) -> bytes:
+    """Encode the native GetVtduInfoReq protobuf."""
+
+    return b"".join(
+        (
+            _proto_string(1, serial),
+            _proto_varint(2, channel),
+            _proto_varint(3, stream_type),
+            _proto_varint(4, client_isp_type),
+            _proto_varint(5, business_type),
+            _proto_string(6, vtdu_token),
+            _proto_varint(7, int(is_proxy)),
+        )
+    )
+
+
+def build_start_stream_request(
+    serial: str,
+    vtdu_token: str,
+    stream_key: str,
+    *,
+    channel: int = 1,
+    stream_type: int = 1,
+    business_type: int = 0,
+    client_type: int = 9,
+    peer_host: str | None = None,
+    peer_port: int | None = None,
+) -> bytes:
+    """Encode the native StartStreamReq protobuf."""
+
+    parts = [
+        _proto_string(1, serial),
+        _proto_varint(2, channel),
+        _proto_varint(3, stream_type),
+        _proto_varint(4, business_type),
+        _proto_string(5, vtdu_token),
+        _proto_varint(6, client_type),
+        _proto_string(7, stream_key),
+    ]
+    if peer_host:
+        parts.append(_proto_string(8, peer_host))
+    if peer_port is not None:
+        parts.append(_proto_varint(9, peer_port))
+    return b"".join(parts)
+
+
+def build_peer_stream_request(
+    serial: str,
+    vtdu_token: str,
+    *,
+    channel: int = 1,
+    stream_type: int = 1,
+    business_type: int = 0,
+) -> bytes:
+    """Encode the native PeerStreamReq protobuf."""
+
+    return b"".join(
+        (
+            _proto_string(1, serial),
+            _proto_varint(2, channel),
+            _proto_varint(3, stream_type),
+            _proto_varint(4, business_type),
+            _proto_string(5, vtdu_token),
+        )
+    )
+
+
+def build_stop_stream_request(stream_ssn: str, *, ssn_info: str | None = None) -> bytes:
+    """Encode the native StopStreamReq protobuf."""
+
+    parts = [_proto_string(1, stream_ssn)]
+    if ssn_info:
+        parts.append(_proto_string(2, ssn_info))
+    return b"".join(parts)
+
+
 def parse_stream_info_response(data: bytes) -> StreamInfoResponse:
     """Decode known scalar fields from a StreamInfoRsp protobuf body."""
 
-    values: dict[int, int | str] = {}
-    pos = 0
-    while pos < len(data):
-        key, pos = _read_varint(data, pos)
-        field = key >> 3
-        wire_type = key & 0x07
-        if wire_type == 0:
-            value, pos = _read_varint(data, pos)
-            values[field] = value
-            continue
-        if wire_type == 2:
-            length, pos = _read_varint(data, pos)
-            if pos + length > len(data):
-                raise PyEzvizError(
-                    "StreamInfoRsp length-delimited field exceeds payload"
-                )
-            raw = data[pos : pos + length]
-            pos += length
-            if field != 12:
-                values[field] = raw.decode("utf-8", errors="replace")
-            continue
-        raise PyEzvizError(f"Unsupported StreamInfoRsp wire type: {wire_type}")
+    fields = _read_proto_fields(data, "StreamInfoRsp")
 
     return StreamInfoResponse(
-        result=_maybe_int(values.get(1)),
-        datakey=_maybe_int(values.get(2)),
-        streamhead=_maybe_str(values.get(3)),
-        streamssn=_maybe_str(values.get(4)),
-        vtmstreamkey=_maybe_str(values.get(5)),
-        serverinfo=_maybe_str(values.get(6)),
-        streamurl=_maybe_str(values.get(7)),
-        srvinfo=_maybe_str(values.get(8)),
-        aesmd5=_maybe_str(values.get(9)),
-        udptransinfo=_maybe_str(values.get(10)),
-        peerpbkey=_maybe_str(values.get(11)),
+        result=_proto_last_int(fields, 1),
+        datakey=_proto_last_int(fields, 2),
+        streamhead=_proto_last_str(fields, 3),
+        streamssn=_proto_last_str(fields, 4),
+        vtmstreamkey=_proto_last_str(fields, 5),
+        serverinfo=_proto_last_str(fields, 6),
+        streamurl=_proto_last_str(fields, 7),
+        srvinfo=_proto_last_str(fields, 8),
+        aesmd5=_proto_last_str(fields, 9),
+        udptransinfo=_proto_last_str(fields, 10),
+        peerpbkey=_proto_last_str(fields, 11),
+        pdslist=tuple(_proto_bytes_values(fields, 12)),
+        srvipv6_addr=_proto_last_str(fields, 13),
     )
+
+
+def parse_get_vtdu_info_response(data: bytes) -> VtduInfoResponse:
+    """Decode known scalar fields from a GetVtduInfoRsp protobuf body."""
+
+    fields = _read_proto_fields(data, "GetVtduInfoRsp")
+    return VtduInfoResponse(
+        result=_proto_last_int(fields, 1),
+        host=_proto_last_str(fields, 2),
+        port=_proto_last_int(fields, 3),
+        streamkey=_proto_last_str(fields, 4),
+        peerhost=_proto_last_str(fields, 5),
+        peerport=_proto_last_int(fields, 6),
+        srvinfo=_proto_last_str(fields, 7),
+    )
+
+
+def parse_start_stream_response(data: bytes) -> VtduStreamResponse:
+    """Decode known scalar fields from a StartStreamRsp protobuf body."""
+
+    return _parse_vtdu_stream_response(data, "StartStreamRsp")
+
+
+def parse_peer_stream_response(data: bytes) -> VtduStreamResponse:
+    """Decode known scalar fields from a PeerStreamRsp protobuf body."""
+
+    return _parse_vtdu_stream_response(data, "PeerStreamRsp")
+
+
+def parse_stop_stream_response(data: bytes) -> StopStreamResponse:
+    """Decode known scalar fields from a StopStreamRsp protobuf body."""
+
+    fields = _read_proto_fields(data, "StopStreamRsp")
+    return StopStreamResponse(result=_proto_last_int(fields, 1))
 
 
 def detect_transport(data: bytes) -> StreamTransport:
@@ -345,6 +477,65 @@ def _proto_bytes(field: int, value: bytes) -> bytes:
 
 def _proto_string(field: int, value: str) -> bytes:
     return _proto_bytes(field, value.encode())
+
+
+ProtoValue = int | bytes
+
+
+def _read_proto_fields(data: bytes, message_name: str) -> dict[int, list[ProtoValue]]:
+    values: dict[int, list[ProtoValue]] = {}
+    pos = 0
+    while pos < len(data):
+        key, pos = _read_varint(data, pos)
+        field = key >> 3
+        wire_type = key & 0x07
+        if wire_type == 0:
+            value, pos = _read_varint(data, pos)
+            values.setdefault(field, []).append(value)
+            continue
+        if wire_type == 2:
+            length, pos = _read_varint(data, pos)
+            if pos + length > len(data):
+                raise PyEzvizError(
+                    f"{message_name} length-delimited field exceeds payload"
+                )
+            values.setdefault(field, []).append(data[pos : pos + length])
+            pos += length
+            continue
+        raise PyEzvizError(f"Unsupported {message_name} wire type: {wire_type}")
+    return values
+
+
+def _proto_last_int(fields: dict[int, list[ProtoValue]], field: int) -> int | None:
+    values = fields.get(field)
+    if not values:
+        return None
+    value = values[-1]
+    return value if isinstance(value, int) else None
+
+
+def _proto_last_str(fields: dict[int, list[ProtoValue]], field: int) -> str | None:
+    values = fields.get(field)
+    if not values:
+        return None
+    value = values[-1]
+    if isinstance(value, int):
+        return None
+    return value.decode("utf-8", errors="replace")
+
+
+def _proto_bytes_values(fields: dict[int, list[ProtoValue]], field: int) -> list[bytes]:
+    return [value for value in fields.get(field, []) if isinstance(value, bytes)]
+
+
+def _parse_vtdu_stream_response(data: bytes, message_name: str) -> VtduStreamResponse:
+    fields = _read_proto_fields(data, message_name)
+    return VtduStreamResponse(
+        result=_proto_last_int(fields, 1),
+        streamhead=_proto_last_str(fields, 2),
+        streamssn=_proto_last_str(fields, 3),
+        datakey=_proto_last_int(fields, 4),
+    )
 
 
 def _encode_varint(value: int) -> bytes:

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -14,21 +14,35 @@ from pyezvizapi.stream import (
     StreamTransport,
     VtmChannel,
     VtmMessageCode,
+    build_get_vtdu_info_request,
+    build_peer_stream_request,
+    build_start_stream_request,
+    build_stop_stream_request,
     build_stream_info_request,
     build_stream_keepalive_request,
     build_vtm_url,
     decode_vtm_packet,
     detect_transport,
     encode_vtm_packet,
+    parse_get_vtdu_info_response,
+    parse_peer_stream_response,
+    parse_start_stream_response,
+    parse_stop_stream_response,
     parse_stream_info_response,
     parse_vtm_url,
     rtp_payload,
 )
 
 BODY = b"abc"
+CAMERA_SERIAL_BYTES = b"CAM123"
 KEEPALIVE_REQ = b"\x0a\x07ssn-123"
+PEER_HOST_BYTES = b"peerhost"
+PUBLIC_KEY_BYTES = b"pub"
+STOP_STREAM_REQ = b"\x0a\x07ssn-123\x12\x04info"
 STREAM_URL = b"ysproto://vtm:8554/live"
 STREAM_KEY = b"key-1"
+STREAM_KEY_BYTES = b"stream-key"
+VTDU_TOKEN_BYTES = b"token-1"
 
 
 def _jwt(payload: dict[str, Any]) -> str:
@@ -190,7 +204,14 @@ def test_parse_vtm_url_normalizes_invalid_ports(url: str) -> None:
 
 
 def test_stream_info_protobuf_helpers_decode_known_fields() -> None:
-    rsp = b"\x08\x00\x22\x07ssn-123\x2a\x05key-1\x3a\x18ysproto://vtdu:8554/live"
+    rsp = (
+        b"\x08\x00"
+        b"\x22\x07ssn-123"
+        b"\x2a\x05key-1"
+        b"\x3a\x18ysproto://vtdu:8554/live"
+        b"\x62\x04pds1"
+        b"\x6a\x03::1"
+    )
 
     decoded = parse_stream_info_response(rsp)
 
@@ -198,6 +219,8 @@ def test_stream_info_protobuf_helpers_decode_known_fields() -> None:
     assert decoded.streamssn == "ssn-123"
     assert decoded.vtmstreamkey == "key-1"
     assert decoded.streamurl == "ysproto://vtdu:8554/live"
+    assert decoded.pdslist == (b"pds1",)
+    assert decoded.srvipv6_addr == "::1"
 
     req = build_stream_info_request(STREAM_URL.decode(), vtm_stream_key=STREAM_KEY.decode())
     keepalive = build_stream_keepalive_request("ssn-123")
@@ -205,6 +228,79 @@ def test_stream_info_protobuf_helpers_decode_known_fields() -> None:
     assert STREAM_URL in req
     assert STREAM_KEY in req
     assert keepalive == KEEPALIVE_REQ
+
+
+def test_vtdu_info_protobuf_helpers_decode_known_fields() -> None:
+    req = build_get_vtdu_info_request(
+        "CAM123",
+        "token-1",
+        channel=2,
+        stream_type=1,
+        business_type=4,
+        client_isp_type=3,
+        is_proxy=True,
+    )
+    rsp = (
+        b"\x08\x00"
+        b"\x12\x031.2"
+        b"\x18\xea\x42"
+        b"\x22\x0astream-key"
+        b"\x2a\x08peerhost"
+        b"\x30\xd2\x4a"
+        b"\x3a\x07srvinfo"
+    )
+
+    decoded = parse_get_vtdu_info_response(rsp)
+
+    assert CAMERA_SERIAL_BYTES in req
+    assert VTDU_TOKEN_BYTES in req
+    assert decoded.result == 0
+    assert decoded.host == "1.2"
+    assert decoded.port == 8554
+    assert decoded.streamkey == "stream-key"
+    assert decoded.peerhost == "peerhost"
+    assert decoded.peerport == 9554
+    assert decoded.srvinfo == "srvinfo"
+
+
+def test_start_peer_and_stop_stream_protobuf_helpers() -> None:
+    start_req = build_start_stream_request(
+        "CAM123",
+        "token-1",
+        "stream-key",
+        channel=2,
+        stream_type=1,
+        business_type=4,
+        client_type=9,
+        peer_host="peerhost",
+        peer_port=9554,
+    )
+    peer_req = build_peer_stream_request(
+        "CAM123",
+        "token-1",
+        channel=2,
+        stream_type=1,
+        business_type=4,
+    )
+    stop_req = build_stop_stream_request("ssn-123", ssn_info="info")
+
+    start_rsp = parse_start_stream_response(
+        b"\x08\x00\x12\x06header\x1a\x07ssn-123\x20\x07"
+    )
+    peer_rsp = parse_peer_stream_response(
+        b"\x08\x00\x12\x06header\x1a\x07ssn-123\x20\x08"
+    )
+    stop_rsp = parse_stop_stream_response(b"\x08\x00")
+
+    assert STREAM_KEY_BYTES in start_req
+    assert PEER_HOST_BYTES in start_req
+    assert CAMERA_SERIAL_BYTES in peer_req
+    assert stop_req == STOP_STREAM_REQ
+    assert start_rsp.streamssn == "ssn-123"
+    assert start_rsp.datakey == 7
+    assert peer_rsp.streamhead == "header"
+    assert peer_rsp.datakey == 8
+    assert stop_rsp.result == 0
 
 
 def test_stream_info_response_rejects_truncated_length_delimited_field() -> None:
@@ -241,7 +337,7 @@ def test_get_vtdu_token_v2_uses_auth_addr_and_session_sign(monkeypatch) -> None:
 
     monkeypatch.setattr(client, "_http_request", fake_http_request)
 
-    assert get_vtdu_token_v2(client)["tokens"] == ["token-1"]
+    assert get_vtdu_token_v2(client).get("tokens") == ["token-1"]
     assert calls[0]["url"] == "https://auth.example.test/vtdutoken2"
     assert calls[0]["params"]["ssid"] == client.export_token()["session_id"]
     assert calls[0]["params"]["sign"] == "sign-value"
@@ -276,7 +372,7 @@ def test_get_vtdu_token_v2_recomputes_auth_after_login(monkeypatch) -> None:
     monkeypatch.setattr(client, "_http_request", fake_http_request)
     monkeypatch.setattr(client, "login", fake_login)
 
-    assert get_vtdu_token_v2(client)["tokens"] == ["token-2"]
+    assert get_vtdu_token_v2(client).get("tokens") == ["token-2"]
     assert len(calls) == 2
     assert calls[0]["params"]["sign"] == "sign-value"
     assert calls[1]["params"]["ssid"] == client.export_token()["session_id"]
@@ -323,7 +419,7 @@ def test_get_cloud_stream_info_builds_bootstrap(monkeypatch) -> None:
                 "Video": {
                     "externalIp": "1.2.3.4",
                     "port": 8554,
-                    "publicKey": {"key": "pub"},
+                    "publicKey": {"version": "2", "key": "cHVi"},
                 }
             },
         },
@@ -338,6 +434,8 @@ def test_get_cloud_stream_info_builds_bootstrap(monkeypatch) -> None:
     assert info["vtdu_token"] == "token-1"
     assert info["resource"]["resourceId"] == "Video"
     assert info["vtm"]["externalIp"] == "1.2.3.4"
+    assert info["vtm_public_key"].version == 2
+    assert info["vtm_public_key"].key_bytes == PUBLIC_KEY_BYTES
     assert parse_vtm_url(info["stream_url"])[3]["chn"] == "2"
 
 


### PR DESCRIPTION
## Summary
- expose VTM server public key metadata from cloud stream bootstrap responses
- add native VTDU protobuf builders/parsers for GetVtduInfo, StartStream, PeerStream, StopStream, and extended StreamInfo fields
- add focused tests covering the decoded native field mappings found in the Android APK

## Notes
This is the next Python-facing slice of the EZVIZ streaming work. It does not yet implement ECDH encrypted channels or the VTDU RTP mux/demux layer; those remain the next steps before full video playback can be completed.

## Validation
- `pytest tests/test_stream.py`
- `ruff check .`
- `mypy pyezvizapi`
- `pyright pyezvizapi`
- full local suite: `pytest` passed before publishing this branch
