### PR TITLE
Improve Retrofit endpoint coverage detection

### DIFF
--- a/tests/test_retrofit_endpoint_extractor.py
+++ b/tests/test_retrofit_endpoint_extractor.py
@@ -38,8 +38,39 @@ def test_known_paths_match_exact_and_composed_fragments(tmp_path: Path) -> None:
 
     assert extractor.is_implemented("/v3/streaming/vtm/{deviceSerial}/{channelNo}", known_paths)
     assert extractor.is_implemented("/v3/devices/{deviceSerial}/ptzControl", known_paths)
-    assert extractor.is_implemented("/v3/devices/encryptedInfo/risk", known_paths)
     assert not extractor.is_implemented("/v3/devices/{deviceSerial}/unknown", known_paths)
+
+
+def test_known_paths_match_composed_python_endpoint_expressions(tmp_path: Path) -> None:
+    extractor = load_extractor()
+    api_endpoints = tmp_path / "api_endpoints.py"
+    api_endpoints.write_text(
+        "\n".join(
+            [
+                'API_ENDPOINT_DEVICES = "/v3/devices/"',
+                'API_ENDPOINT_PTZCONTROL = "/ptzControl"',
+                'API_ENDPOINT_VIDEO_ENCRYPT = "encryptedInfo/risk"',
+            ]
+        ),
+        encoding="utf-8",
+    )
+    client = tmp_path / "client.py"
+    client.write_text(
+        "\n".join(
+            [
+                "def routes(serial):",
+                '    literal = f"{API_ENDPOINT_DEVICES}{API_ENDPOINT_VIDEO_ENCRYPT}"',
+                '    dynamic = f"{API_ENDPOINT_DEVICES}{serial}{API_ENDPOINT_PTZCONTROL}"',
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    known_paths = extractor.load_known_paths(api_endpoints)
+
+    assert extractor.is_implemented("/v3/devices/encryptedInfo/risk", known_paths)
+    assert extractor.is_implemented("/v3/devices/{deviceSerial}/ptzControl", known_paths)
+    assert not extractor.is_implemented("/v3/devices/ptzControl", known_paths)
 
 
 def test_markdown_reports_composed_coverage(tmp_path: Path) -> None:

--- a/tests/test_retrofit_endpoint_extractor.py
+++ b/tests/test_retrofit_endpoint_extractor.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from importlib.machinery import SourceFileLoader
+from importlib.util import module_from_spec, spec_from_loader
+from pathlib import Path
+import sys
+from types import ModuleType
+
+SCRIPT = Path(__file__).resolve().parents[1] / "tools/apk-re/bin/extract-retrofit-endpoints"
+
+
+def load_extractor() -> ModuleType:
+    loader = SourceFileLoader("extract_retrofit_endpoints", str(SCRIPT))
+    spec = spec_from_loader(loader.name, loader)
+    assert spec is not None
+    module = module_from_spec(spec)
+    sys.modules[loader.name] = module
+    loader.exec_module(module)
+    return module
+
+
+def test_known_paths_match_exact_and_composed_fragments(tmp_path: Path) -> None:
+    extractor = load_extractor()
+    api_endpoints = tmp_path / "api_endpoints.py"
+    api_endpoints.write_text(
+        "\n".join(
+            [
+                'API_ENDPOINT_DEVICES = "/v3/devices/"',
+                'API_ENDPOINT_PTZCONTROL = "/ptzControl"',
+                'API_ENDPOINT_STREAMING_VTM = "/v3/streaming/vtm/{device_serial}/{channel_no}"',
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    known_paths = extractor.load_known_paths(api_endpoints)
+
+    assert extractor.is_implemented("/v3/streaming/vtm/{deviceSerial}/{channelNo}", known_paths)
+    assert extractor.is_implemented("/v3/devices/{deviceSerial}/ptzControl", known_paths)
+    assert not extractor.is_implemented("/v3/devices/{deviceSerial}/unknown", known_paths)
+
+
+def test_markdown_reports_composed_coverage(tmp_path: Path) -> None:
+    extractor = load_extractor()
+    api_endpoints = tmp_path / "api_endpoints.py"
+    api_endpoints.write_text(
+        "\n".join(
+            [
+                'API_ENDPOINT_DEVICES = "/v3/devices/"',
+                'API_ENDPOINT_PTZCONTROL = "/ptzControl"',
+            ]
+        ),
+        encoding="utf-8",
+    )
+    known_paths = extractor.load_known_paths(api_endpoints)
+    endpoints = [
+        extractor.Endpoint(
+            source="DeviceApi.java",
+            http_method="PUT",
+            path="/v3/devices/{deviceSerial}/ptzControl",
+            java_method="ptzControl",
+            params=("Path:deviceSerial",),
+        ),
+        extractor.Endpoint(
+            source="DeviceApi.java",
+            http_method="GET",
+            path="/v3/devices/{deviceSerial}/unknown",
+            java_method="unknown",
+            params=("Path:deviceSerial",),
+        ),
+    ]
+
+    report = extractor.markdown(endpoints, known_paths)
+
+    assert "- Paths detected in pyezvizapi: 1" in report
+    assert "| yes | PUT | `/v3/devices/{deviceSerial}/ptzControl`" in report
+    assert "| no | GET | `/v3/devices/{deviceSerial}/unknown`" in report

--- a/tests/test_retrofit_endpoint_extractor.py
+++ b/tests/test_retrofit_endpoint_extractor.py
@@ -27,6 +27,7 @@ def test_known_paths_match_exact_and_composed_fragments(tmp_path: Path) -> None:
             [
                 'API_ENDPOINT_DEVICES = "/v3/devices/"',
                 'API_ENDPOINT_PTZCONTROL = "/ptzControl"',
+                'API_ENDPOINT_VIDEO_ENCRYPT = "/encryptedInfo/risk"',
                 'API_ENDPOINT_STREAMING_VTM = "/v3/streaming/vtm/{device_serial}/{channel_no}"',
             ]
         ),
@@ -37,6 +38,7 @@ def test_known_paths_match_exact_and_composed_fragments(tmp_path: Path) -> None:
 
     assert extractor.is_implemented("/v3/streaming/vtm/{deviceSerial}/{channelNo}", known_paths)
     assert extractor.is_implemented("/v3/devices/{deviceSerial}/ptzControl", known_paths)
+    assert extractor.is_implemented("/v3/devices/encryptedInfo/risk", known_paths)
     assert not extractor.is_implemented("/v3/devices/{deviceSerial}/unknown", known_paths)
 
 

--- a/tools/apk-re/bin/extract-retrofit-endpoints
+++ b/tools/apk-re/bin/extract-retrofit-endpoints
@@ -44,6 +44,23 @@ def static_path_parts(path: str) -> tuple[str, ...]:
     return tuple(part for part in PATH_PARAM.split(normalize_path(path)) if part)
 
 
+def is_composed_from_fragments(path: str, fragments: frozenset[str]) -> bool:
+    normalized = normalize_path(path)
+    reachable: set[tuple[int, int]] = {(0, 0)}
+    for index in range(len(normalized) + 1):
+        counts = [count for position, count in reachable if position == index]
+        if not counts:
+            continue
+        for fragment in fragments:
+            candidates = [fragment]
+            if index > 0 and fragment.startswith("/"):
+                candidates.append(fragment[1:])
+            for candidate in candidates:
+                if candidate and normalized.startswith(candidate, index):
+                    reachable.add((index + len(candidate), max(counts) + 1))
+    return any(position == len(normalized) and count > 1 for position, count in reachable)
+
+
 def load_known_paths(path: Path | None) -> KnownApiPaths:
     if path is None or not path.exists():
         return KnownApiPaths(frozenset(), frozenset())
@@ -70,7 +87,9 @@ def is_implemented(path: str, known_paths: KnownApiPaths) -> bool:
     if path_key(path) in known_paths.exact:
         return True
     parts = static_path_parts(path)
-    return len(parts) > 1 and all(part in known_paths.fragments for part in parts)
+    if len(parts) > 1 and all(part in known_paths.fragments for part in parts):
+        return True
+    return is_composed_from_fragments(path, known_paths.fragments)
 
 
 def extract_params(signature: str) -> tuple[str, ...]:

--- a/tools/apk-re/bin/extract-retrofit-endpoints
+++ b/tools/apk-re/bin/extract-retrofit-endpoints
@@ -9,7 +9,7 @@ from dataclasses import dataclass
 from pathlib import Path
 import re
 
-HTTP_ANNOTATION = re.compile(r"@(GET|POST|PUT|DELETE|PATCH|HEAD)\((?:\"([^\"]*)\")?\)")
+HTTP_ANNOTATION = re.compile(r"@(GET|POST|PUT|DELETE|PATCH|HEAD)X((?:\"([^\"]*)\")?\)")
 METHOD_DECL = re.compile(r"\s*(?:[\w<>, ?.\[\]]+\s+)+(\w+)\((.*)\);")
 PARAM_ANNOTATION = re.compile(r"@(Field|Query|Path|Header|Body|Url|Part)\((?:\"([^\"]*)\")?\)")
 PATH_PARAM = re.compile(r"\{[^}/]+\}")
@@ -24,6 +24,12 @@ class Endpoint:
     params: tuple[str, ...]
 
 
+@dataclass(frozen=True)
+class KnownApiPaths:
+    exact: frozenset[str]
+    fragments: frozenset[str]
+
+
 def normalize_path(path: str) -> str:
     if not path:
         return "<dynamic-url>"
@@ -34,11 +40,16 @@ def path_key(path: str) -> str:
     return PATH_PARAM.sub("{}", normalize_path(path))
 
 
-def load_known_paths(path: Path | None) -> set[str]:
+def static_path_parts(path: str) -> tuple[str, ...]:
+    return tuple(part for part in PATH_PARAM.split(normalize_path(path)) if part)
+
+
+def load_known_paths(path: Path | None) -> KnownApiPaths:
     if path is None or not path.exists():
-        return set()
+        return KnownApiPaths(frozenset(), frozenset())
     tree = ast.parse(path.read_text(encoding="utf-8"))
-    constants: set[str] = set()
+    exact: set[str] = set()
+    fragments: set[str] = set()
     for node in tree.body:
         if not isinstance(node, ast.Assign):
             continue
@@ -49,8 +60,17 @@ def load_known_paths(path: Path | None) -> set[str]:
         except (ValueError, SyntaxError):
             continue
         if isinstance(value, str):
-            constants.add(path_key(value))
-    return constants
+            normalized = normalize_path(value)
+            exact.add(path_key(normalized))
+            fragments.add(normalized)
+    return KnownApiPaths(frozenset(exact), frozenset(fragments))
+
+
+def is_implemented(path: str, known_paths: KnownApiPaths) -> bool:
+    if path_key(path) in known_paths.exact:
+        return True
+    parts = static_path_parts(path)
+    return len(parts) > 1 and all(part in known_paths.fragments for part in parts)
 
 
 def extract_params(signature: str) -> tuple[str, ...]:
@@ -88,18 +108,18 @@ def extract_from_file(path: Path, root: Path) -> list[Endpoint]:
     return endpoints
 
 
-def markdown(endpoints: list[Endpoint], known_paths: set[str]) -> str:
+def markdown(endpoints: list[Endpoint], known_paths: KnownApiPaths) -> str:
     rows = [
         "# Retrofit Endpoint Inventory",
         "",
         f"- Extracted endpoints: {len(endpoints)}",
-        f"- Exact paths already present in pyezvizapi: {sum(1 for item in endpoints if path_key(item.path) in known_paths)}",
+        f"- Paths detected in pyezvizapi: {sum(1 for item in endpoints if is_implemented(item.path, known_paths))}",
         "",
         "| Implemented | Method | Path | Java method | Params | Source |",
         "| --- | --- | --- | --- | --- | --- |",
     ]
     for item in sorted(endpoints, key=lambda endpoint: (endpoint.path, endpoint.http_method, endpoint.source)):
-        implemented = "yes" if path_key(item.path) in known_paths else "no"
+        implemented = "yes" if is_implemented(item.path, known_paths) else "no"
         params = ", ".join(item.params)
         rows.append(
             f"| {implemented} | {item.http_method} | `{item.path}` | `{item.java_method}` | `{params}` | `{item.source}` |"

--- a/tools/apk-re/bin/extract-retrofit-endpoints
+++ b/tools/apk-re/bin/extract-retrofit-endpoints
@@ -44,42 +44,83 @@ def static_path_parts(path: str) -> tuple[str, ...]:
     return tuple(part for part in PATH_PARAM.split(normalize_path(path)) if part)
 
 
-def is_composed_from_fragments(path: str, fragments: frozenset[str]) -> bool:
-    normalized = normalize_path(path)
-    reachable: set[tuple[int, int]] = {(0, 0)}
-    for index in range(len(normalized) + 1):
-        counts = [count for position, count in reachable if position == index]
-        if not counts:
+def _path_expr_key(node: ast.AST, constants: dict[str, str]) -> tuple[str, bool] | None:
+    expression_path = None
+    uses_endpoint = False
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        expression_path = node.value
+    elif isinstance(node, ast.Name) and node.id.startswith("API_ENDPOINT_"):
+        expression_path = constants.get(node.id)
+        uses_endpoint = expression_path is not None
+    elif isinstance(node, ast.BinOp) and isinstance(node.op, ast.Add):
+        left = _path_expr_key(node.left, constants)
+        right = _path_expr_key(node.right, constants)
+        if left is not None and right is not None:
+            expression_path = f"{left[0]}{right[0]}"
+            uses_endpoint = left[1] or right[1]
+    elif isinstance(node, ast.JoinedStr):
+        parts: list[str] = []
+        for value in node.values:
+            if isinstance(value, ast.Constant) and isinstance(value.value, str):
+                parts.append(value.value)
+            elif isinstance(value, ast.FormattedValue):
+                resolved = _path_expr_key(value.value, constants)
+                if resolved is None:
+                    parts.append("{}")
+                else:
+                    parts.append(resolved[0])
+                    uses_endpoint = uses_endpoint or resolved[1]
+            else:
+                return None
+        expression_path = "".join(parts)
+    if expression_path is None:
+        return None
+    return expression_path, uses_endpoint
+
+
+def _load_expression_paths(root: Path, constants: dict[str, str]) -> set[str]:
+    paths: set[str] = set()
+    for py_file in root.glob("*.py"):
+        if py_file.name == "api_endpoints.py":
             continue
-        for fragment in fragments:
-            candidates = [fragment]
-            if index > 0 and fragment.startswith("/"):
-                candidates.append(fragment[1:])
-            for candidate in candidates:
-                if candidate and normalized.startswith(candidate, index):
-                    reachable.add((index + len(candidate), max(counts) + 1))
-    return any(position == len(normalized) and count > 1 for position, count in reachable)
+        tree = ast.parse(py_file.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            resolved = _path_expr_key(node, constants)
+            if resolved is not None:
+                expression_path, uses_endpoint = resolved
+                if uses_endpoint and "/" in expression_path:
+                    paths.add(path_key(expression_path))
+    return paths
 
 
 def load_known_paths(path: Path | None) -> KnownApiPaths:
     if path is None or not path.exists():
         return KnownApiPaths(frozenset(), frozenset())
     tree = ast.parse(path.read_text(encoding="utf-8"))
+    constants: dict[str, str] = {}
     exact: set[str] = set()
     fragments: set[str] = set()
     for node in tree.body:
         if not isinstance(node, ast.Assign):
             continue
-        if not any(isinstance(target, ast.Name) and target.id.startswith("API_ENDPOINT_") for target in node.targets):
+        targets = [
+            target.id
+            for target in node.targets
+            if isinstance(target, ast.Name) and target.id.startswith("API_ENDPOINT_")
+        ]
+        if not targets:
             continue
         try:
             value = ast.literal_eval(node.value)
         except (ValueError, SyntaxError):
             continue
         if isinstance(value, str):
+            for target in targets:
+                constants[target] = value
             normalized = normalize_path(value)
             exact.add(path_key(normalized))
             fragments.add(normalized)
+    exact.update(_load_expression_paths(path.parent, constants))
     return KnownApiPaths(frozenset(exact), frozenset(fragments))
 
 
@@ -87,9 +128,7 @@ def is_implemented(path: str, known_paths: KnownApiPaths) -> bool:
     if path_key(path) in known_paths.exact:
         return True
     parts = static_path_parts(path)
-    if len(parts) > 1 and all(part in known_paths.fragments for part in parts):
-        return True
-    return is_composed_from_fragments(path, known_paths.fragments)
+    return len(parts) > 1 and all(part in known_paths.fragments for part in parts)
 
 
 def extract_params(signature: str) -> tuple[str, ...]:

--- a/tools/apk-re/bin/extract-retrofit-endpoints
+++ b/tools/apk-re/bin/extract-retrofit-endpoints
@@ -9,7 +9,7 @@ from dataclasses import dataclass
 from pathlib import Path
 import re
 
-HTTP_ANNOTATION = re.compile(r"@(GET|POST|PUT|DELETE|PATCH|HEAD)X((?:\"([^\"]*)\")?\)")
+HTTP_ANNOTATION = re.compile(r"@(GET|POST|PUT|DELETE|PATCH|HEAD)\((?:\"([^\"]*)\")?\)")
 METHOD_DECL = re.compile(r"\s*(?:[\w<>, ?.\[\]]+\s+)+(\w+)\((.*)\);")
 PARAM_ANNOTATION = re.compile(r"@(Field|Query|Path|Header|Body|Url|Part)\((?:\"([^\"]*)\")?\)")
 PATH_PARAM = re.compile(r"\{[^}/]+\}")


### PR DESCRIPTION
## Summary
- Track exact API endpoint constants and actual Python-composed endpoint expressions in the Retrofit endpoint extractor.
- Mark APK-discovered paths such as `/v3/devices/{deviceSerial}/ptzControl` and literal composed paths such as `/v3/devices/encryptedInfo/risk` as implemented without treating arbitrary fragment concatenations like `/v3/devices/ptzControl` as covered.
- Add focused tests for exact placeholder normalization, composed endpoint matching, safe literal composed-path matching, and markdown reporting.

## Verification
- `.venv/bin/python -m ruff check .`
- `.venv/bin/python -m pytest`
- `.venv/bin/python -m mypy pyezvizapi`
- `tools/apk-re/bin/extract-retrofit-endpoints discovery/apk/out/ezviz-current/jadx/sources --known-api pyezvizapi/api_endpoints.py --output discovery/apk/out/ezviz-current/reports/retrofit-endpoints.md` reports 126 detected paths out of 435 extracted endpoints.