### PR TITLE
Add VTM trace harness and alarm image decrypt helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,18 +6,32 @@ This project follows [Semantic Versioning](https://semver.org/) for published re
 
 ## Unreleased
 
-## v1.0.4.8 - 2026-05-03
-
 ### Added
 
 - Added cloud stream bootstrap helpers for VTM pagelist metadata, VTDU token retrieval, VTM/VTDU packet framing, `ysproto` URL handling, limited stream protobuf parsing, RTP payload extraction, and transport detection.
 - Added VTM server public-key extraction plus native VTDU protobuf helpers for `GetVtduInfo`, `StartStream`, `PeerStream`, and `StopStream` stream-control messages.
+- Added a sanitized VTM trace harness and CLI command for live stream diagnostics without exposing packet bodies, tokens, or keys.
+- Added alarm image download/decrypt helper support for EZVIZ/Hik encrypted snapshot payloads.
+
+### Changed
+
+- Updated CI, CodeQL, and Dependency Review pull-request path filters so tests-only changes trigger the required checks, and excluded the captured pagelist fixture from Codespell because it preserves upstream cloud/device strings verbatim.
+
+### Fixed
+
+- Fixed VTM tracing to parse delayed `StreamInfoRsp` packets after earlier control packets so redirects are still followed.
+- Fixed encrypted alarm image detection to search the full payload for the encryption marker before deciding whether to decrypt.
+- Fixed VTDU token lookup when EZVIZ service URLs return a null `authAddr` by deriving the auth host from `api_url`.
+
+## v1.0.4.8 - 2026-05-03
+
+### Added
+
 - Added sanitized full pagelist fixture coverage for `get_device_infos()` and `load_devices(refresh=False)` so the parser is tested against a realistic cloud response without live EZVIZ credentials.
 
 ### Changed
 
 - Updated remote unlock to prefer terminal-derived bind codes from the EZVIZ terminals API while preserving legacy bind-code fallback behavior.
-- Updated CI, CodeQL, and Dependency Review pull-request path filters so tests-only changes trigger the required checks, and excluded the captured pagelist fixture from Codespell because it preserves upstream cloud/device strings verbatim.
 
 ### Fixed
 

--- a/pyezvizapi/__init__.py
+++ b/pyezvizapi/__init__.py
@@ -90,6 +90,7 @@ if TYPE_CHECKING:
         VtmMessageCode,
         VtmPacket,
         VtmStreamClient,
+        VtmTraceEvent,
         build_get_vtdu_info_request,
         build_peer_stream_request,
         build_start_stream_request,
@@ -108,6 +109,7 @@ if TYPE_CHECKING:
         parse_stream_info_response,
         parse_vtm_url,
         rtp_payload,
+        summarize_vtm_packet,
     )
     from .test_cam_rtsp import TestRTSPAuth
 
@@ -153,6 +155,7 @@ _EXPORTS = {
     "VtmMessageCode": "stream",
     "VtmPacket": "stream",
     "VtmStreamClient": "stream",
+    "VtmTraceEvent": "stream",
     "build_device_records_map": "models",
     "build_get_vtdu_info_request": "stream",
     "build_peer_stream_request": "stream",
@@ -199,6 +202,7 @@ _EXPORTS = {
     "port_security_port_enabled": "feature",
     "resolve_channel": "feature",
     "rtp_payload": "stream",
+    "summarize_vtm_packet": "stream",
     "supplement_light_available": "feature",
     "supplement_light_enabled": "feature",
     "supplement_light_params": "feature",

--- a/pyezvizapi/__main__.py
+++ b/pyezvizapi/__main__.py
@@ -14,6 +14,7 @@ from typing import Any, cast
 
 from .camera import EzvizCamera
 from .client import EzvizClient
+from .cloud_stream import open_cloud_stream
 from .constants import BatteryCameraWorkMode, DefenseModeType, DeviceSwitchType
 from .exceptions import EzvizAuthVerificationCode, PyEzvizError
 from .light_bulb import EzvizLightBulb
@@ -287,6 +288,57 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "--urls-only",
         action="store_true",
         help="Print only deviceSerial + media URLs instead of full metadata",
+    )
+
+    parser_stream = subparsers.add_parser(
+        "stream",
+        help="Experimental VTM cloud stream helpers",
+    )
+    subparsers_stream = parser_stream.add_subparsers(dest="stream_action")
+    parser_stream_trace = subparsers_stream.add_parser(
+        "trace",
+        help="Trace sanitized VTM packet metadata for a camera",
+    )
+    parser_stream_trace.add_argument("--serial", required=True, help="camera SERIAL")
+    parser_stream_trace.add_argument(
+        "--channel",
+        type=int,
+        default=None,
+        help="Camera channel/local index (default: first matching VTM resource)",
+    )
+    parser_stream_trace.add_argument(
+        "--max-packets",
+        type=int,
+        default=20,
+        help="Number of incoming VTM packets to summarize (default: 20)",
+    )
+    parser_stream_trace.add_argument(
+        "--timeout",
+        type=float,
+        default=10.0,
+        help="Socket timeout in seconds (default: 10)",
+    )
+    parser_stream_trace.add_argument(
+        "--client-type",
+        type=int,
+        default=9,
+        help="VTM client type used in the ysproto URL (default: 9)",
+    )
+    parser_stream_trace.add_argument(
+        "--token-index",
+        type=int,
+        default=0,
+        help="VTDU token index to use from /vtdutoken2 (default: 0)",
+    )
+    parser_stream_trace.add_argument(
+        "--no-refresh-vtm",
+        action="store_true",
+        help="Use pagelist VTM metadata without refreshing via /v3/streaming/vtm",
+    )
+    parser_stream_trace.add_argument(
+        "--json-lines",
+        action="store_true",
+        help="Print one JSON object per trace event instead of a JSON array",
     )
 
     return parser.parse_args(argv)
@@ -581,6 +633,35 @@ def _handle_mqtt(_: argparse.Namespace, client: EzvizClient) -> int:
     return 0
 
 
+def _handle_stream(args: argparse.Namespace, client: EzvizClient) -> int:
+    """Handle experimental stream helpers."""
+
+    if args.stream_action != "trace":
+        _LOGGER.error("Action not implemented, try running with -h switch for help")
+        return 2
+
+    with open_cloud_stream(
+        client,
+        args.serial,
+        channel=args.channel,
+        client_type=args.client_type,
+        token_index=args.token_index,
+        refresh_vtm=not args.no_refresh_vtm,
+        timeout=args.timeout,
+    ) as stream:
+        events = [
+            event.as_dict()
+            for event in stream.trace_packets(max_packets=args.max_packets)
+        ]
+
+    if args.json_lines:
+        for event in events:
+            sys.stdout.write(json.dumps(event, sort_keys=True) + "\n")
+    else:
+        _write_json(events)
+    return 0
+
+
 def _handle_camera(args: argparse.Namespace, client: EzvizClient) -> int:
     """Handle `camera` subcommands (status/move/unlock/switch/alarm/select)."""
     camera = EzvizCamera(client, args.serial)
@@ -705,6 +786,8 @@ def main(argv: list[str] | None = None) -> int:
             return _handle_home_defence_mode(args, client)
         if args.action == "mqtt":
             return _handle_mqtt(args, client)
+        if args.action == "stream":
+            return _handle_stream(args, client)
         if args.action == "camera":
             return _handle_camera(args, client)
         if args.action == "pagelist":

--- a/pyezvizapi/client.py
+++ b/pyezvizapi/client.py
@@ -114,6 +114,7 @@ from .constants import (
     DEFAULT_TIMEOUT,
     DEFAULT_UNIFIEDMSG_STYPE,
     FEATURE_CODE,
+    HIK_ENCRYPTION_HEADER,
     MAX_RETRIES,
     REQUEST_HEADER,
     DefenseModeType,
@@ -131,7 +132,7 @@ from .exceptions import (
 from .feature import optionals_mapping
 from .models import EzvizDeviceRecord, build_device_records_map
 from .mqtt import MQTTClient
-from .utils import convert_to_dict, deep_merge
+from .utils import convert_to_dict, decrypt_image, deep_merge
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -2649,6 +2650,46 @@ class EzvizClient:
             )
 
         raise PyEzvizError("Could not get camera encryption key: exceeded retries")
+
+    def download_alarm_image(
+        self,
+        image_url: str,
+        serial: str | None = None,
+        *,
+        encryption_key: str | None = None,
+        smscode: str | int | None = None,
+        decrypt: bool = True,
+        max_retries: int = 0,
+    ) -> bytes:
+        """Download an alarm image and decrypt EZVIZ/Hik encrypted payloads.
+
+        Encrypted alarm snapshots contain the ``hikencodepicture`` header. When
+        that header is present and no explicit ``encryption_key`` is supplied,
+        ``serial`` is used to fetch the camera encryption key from the EZVIZ API.
+        """
+
+        resp = self._http_request(
+            "GET",
+            image_url,
+            retry_401=False,
+            max_retries=0,
+        )
+        image_data = resp.content
+        if (
+            not decrypt
+            or not image_data
+            or HIK_ENCRYPTION_HEADER not in image_data[:256]
+        ):
+            return image_data
+
+        key = encryption_key
+        if key is None:
+            if not serial:
+                raise PyEzvizError(
+                    "Camera serial or encryption key is required to decrypt image"
+                )
+            key = self.get_cam_key(serial, smscode=smscode, max_retries=max_retries)
+        return decrypt_image(image_data, key)
 
     def get_cam_auth_code(
         self,

--- a/pyezvizapi/client.py
+++ b/pyezvizapi/client.py
@@ -2678,7 +2678,7 @@ class EzvizClient:
         if (
             not decrypt
             or not image_data
-            or HIK_ENCRYPTION_HEADER not in image_data[:256]
+            or HIK_ENCRYPTION_HEADER not in image_data
         ):
             return image_data
 

--- a/pyezvizapi/cloud_stream.py
+++ b/pyezvizapi/cloud_stream.py
@@ -302,7 +302,7 @@ def _auth_base_url(client: Any) -> str:
 
     auth_addr = str(service_urls.get("authAddr", "")).strip()
     if _missing_auth_addr(auth_addr):
-        raise PyEzvizError("Missing authAddr in service URLs")
+        auth_addr = _derive_auth_addr(token)
     if not auth_addr.startswith(("http://", "https://")):
         auth_addr = f"https://{auth_addr}"
     parsed = urlparse(auth_addr)
@@ -320,3 +320,18 @@ def _missing_auth_addr(value: Any) -> bool:
         candidate = f"https://{candidate}"
     parsed = urlparse(candidate)
     return (parsed.hostname or "").lower() in {"", "none", "null"}
+
+
+def _derive_auth_addr(token: Any) -> str:
+    """Derive the auth service host when system info returns a null authAddr."""
+
+    api_url = str(token.get("api_url", "") if isinstance(token, dict) else "").strip()
+    parsed = urlparse(api_url if "://" in api_url else f"https://{api_url}")
+    host = parsed.hostname or ""
+    prefix = "apii"
+    suffix = ".ezvizlife.com"
+    if host.startswith(prefix) and host.endswith(suffix):
+        region = host[len(prefix) : -len(suffix)]
+        if region:
+            return f"https://{region}auth.ezvizlife.com"
+    raise PyEzvizError("Missing authAddr in service URLs")

--- a/pyezvizapi/stream.py
+++ b/pyezvizapi/stream.py
@@ -240,24 +240,40 @@ class VtmStreamClient:
         *,
         vtm_stream_key: str | None = None,
         max_control_packets: int = 20,
+        max_redirects: int = 3,
     ) -> StreamInfoResponse:
         """Request stream info and return the decoded ``StreamInfoRsp``."""
 
-        self.connect()
-        request = build_stream_info_request(
-            self.stream_url,
-            vtm_stream_key=vtm_stream_key,
-            client_version=self.client_version,
-        )
-        self.send_packet(request)
+        redirect_count = 0
+        while True:
+            self.connect()
+            request = build_stream_info_request(
+                self.stream_url,
+                vtm_stream_key=vtm_stream_key,
+                client_version=self.client_version,
+            )
+            self.send_packet(request)
 
-        for _ in range(max_control_packets):
-            packet = self.read_packet()
-            if packet.message_code == VtmMessageCode.STREAMINFO_RSP:
-                self.stream_info = parse_stream_info_response(packet.body)
-                return self.stream_info
-
-        raise PyEzvizError("Timed out waiting for VTM stream info response")
+            for _ in range(max_control_packets):
+                packet = self.read_packet()
+                if packet.message_code == VtmMessageCode.STREAMINFO_RSP:
+                    self.stream_info = parse_stream_info_response(packet.body)
+                    redirect_url = self.stream_info.streamurl
+                    redirect_key = self.stream_info.vtmstreamkey
+                    if (
+                        self.stream_info.result
+                        and redirect_url
+                        and redirect_key
+                        and redirect_count < max_redirects
+                    ):
+                        self.close()
+                        self.stream_url = redirect_url
+                        vtm_stream_key = redirect_key
+                        redirect_count += 1
+                        break
+                    return self.stream_info
+            else:
+                raise PyEzvizError("Timed out waiting for VTM stream info response")
 
     def send_keepalive(
         self,
@@ -319,6 +335,7 @@ class VtmStreamClient:
         *,
         max_packets: int = 20,
         vtm_stream_key: str | None = None,
+        max_redirects: int = 3,
     ) -> list[VtmTraceEvent]:
         """Return sanitized packet summaries from the VTM connection.
 
@@ -332,21 +349,46 @@ class VtmStreamClient:
         if max_packets < 1:
             raise PyEzvizError("VTM trace must request at least one packet")
 
-        self.connect()
-        request = build_stream_info_request(
-            self.stream_url,
-            vtm_stream_key=vtm_stream_key,
-            client_version=self.client_version,
-        )
-        self.send_packet(request)
-
         events: list[VtmTraceEvent] = []
-        for index in range(max_packets):
+        redirect_count = 0
+        while len(events) < max_packets:
+            self.connect()
+            request = build_stream_info_request(
+                self.stream_url,
+                vtm_stream_key=vtm_stream_key,
+                client_version=self.client_version,
+            )
+            self.send_packet(request)
+
             packet = self.read_packet()
-            events.append(summarize_vtm_packet(packet, index=index))
+            events.append(summarize_vtm_packet(packet, index=len(events)))
             if packet.message_code == VtmMessageCode.STREAMINFO_RSP:
                 self.stream_info = parse_stream_info_response(packet.body)
+                redirect_url = self.stream_info.streamurl
+                redirect_key = self.stream_info.vtmstreamkey
+                if (
+                    self.stream_info.result
+                    and redirect_url
+                    and redirect_key
+                    and redirect_count < max_redirects
+                    and len(events) < max_packets
+                ):
+                    self.close()
+                    self.stream_url = redirect_url
+                    vtm_stream_key = redirect_key
+                    redirect_count += 1
+                    continue
             elif packet.message_code == VtmMessageCode.KEEPALIVE_REQ:
+                self.send_packet(
+                    packet.body,
+                    message_code=VtmMessageCode.KEEPALIVE_RSP,
+                )
+            break
+
+        while len(events) < max_packets:
+            packet = self.read_packet()
+            events.append(summarize_vtm_packet(packet, index=len(events)))
+            if packet.message_code == VtmMessageCode.KEEPALIVE_REQ:
                 self.send_packet(
                     packet.body,
                     message_code=VtmMessageCode.KEEPALIVE_RSP,

--- a/pyezvizapi/stream.py
+++ b/pyezvizapi/stream.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Iterator
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 from enum import IntEnum
 from ipaddress import IPv6Address, ip_address
 import socket
@@ -66,6 +66,26 @@ class VtmPacket:
             VtmChannel.ENCRYPTED_MESSAGE,
             VtmChannel.ENCRYPTED_STREAM,
         )
+
+
+@dataclass(frozen=True)
+class VtmTraceEvent:
+    """Sanitized VTM/VTDU packet summary for live stream tracing."""
+
+    index: int
+    channel: int
+    channel_name: str | None
+    length: int
+    sequence: int
+    message_code: int
+    message_name: str | None
+    encrypted: bool
+    transport: str
+
+    def as_dict(self) -> dict[str, int | str | bool | None]:
+        """Return a JSON-serializable trace event."""
+
+        return asdict(self)
 
 
 @dataclass(frozen=True)
@@ -294,6 +314,45 @@ class VtmStreamClient:
         for packet in self.iter_packets(max_packets=max_packets):
             yield packet.body
 
+    def trace_packets(
+        self,
+        *,
+        max_packets: int = 20,
+        vtm_stream_key: str | None = None,
+    ) -> list[VtmTraceEvent]:
+        """Return sanitized packet summaries from the VTM connection.
+
+        The trace opens the connection, sends ``StreamInfoReq``, records packet
+        metadata only, parses ``StreamInfoRsp`` when seen, and auto-responds to
+        keepalive requests so the server continues sending packets. Packet
+        bodies are intentionally not included because they may contain tokens,
+        keys, or encrypted media.
+        """
+
+        if max_packets < 1:
+            raise PyEzvizError("VTM trace must request at least one packet")
+
+        self.connect()
+        request = build_stream_info_request(
+            self.stream_url,
+            vtm_stream_key=vtm_stream_key,
+            client_version=self.client_version,
+        )
+        self.send_packet(request)
+
+        events: list[VtmTraceEvent] = []
+        for index in range(max_packets):
+            packet = self.read_packet()
+            events.append(summarize_vtm_packet(packet, index=index))
+            if packet.message_code == VtmMessageCode.STREAMINFO_RSP:
+                self.stream_info = parse_stream_info_response(packet.body)
+            elif packet.message_code == VtmMessageCode.KEEPALIVE_REQ:
+                self.send_packet(
+                    packet.body,
+                    message_code=VtmMessageCode.KEEPALIVE_RSP,
+                )
+        return events
+
     def _require_socket(self) -> Any:
         sock = self._socket
         if sock is None:
@@ -371,6 +430,26 @@ def decode_vtm_packet(packet: bytes) -> VtmPacket:
         sequence=header.sequence,
         message_code=header.message_code,
         body=body,
+    )
+
+
+def summarize_vtm_packet(packet: VtmPacket, *, index: int = 0) -> VtmTraceEvent:
+    """Build a body-free packet summary for debugging live VTM streams."""
+
+    transport = StreamTransport.UNKNOWN
+    if packet.channel == VtmChannel.STREAM:
+        transport = detect_transport(packet.body)
+
+    return VtmTraceEvent(
+        index=index,
+        channel=packet.channel,
+        channel_name=_enum_name(VtmChannel, packet.channel),
+        length=packet.length,
+        sequence=packet.sequence,
+        message_code=packet.message_code,
+        message_name=_enum_name(VtmMessageCode, packet.message_code),
+        encrypted=packet.encrypted,
+        transport=transport.name,
     )
 
 
@@ -645,6 +724,13 @@ def rtp_payload(data: bytes) -> bytes:
 
 def _proto_key(field: int, wire_type: int) -> bytes:
     return _encode_varint((field << 3) | wire_type)
+
+
+def _enum_name(enum_type: type[IntEnum], value: int) -> str | None:
+    try:
+        return enum_type(value).name
+    except ValueError:
+        return None
 
 
 def _format_url_host(host: str) -> str:

--- a/pyezvizapi/stream.py
+++ b/pyezvizapi/stream.py
@@ -360,39 +360,36 @@ class VtmStreamClient:
             )
             self.send_packet(request)
 
-            packet = self.read_packet()
-            events.append(summarize_vtm_packet(packet, index=len(events)))
-            if packet.message_code == VtmMessageCode.STREAMINFO_RSP:
-                self.stream_info = parse_stream_info_response(packet.body)
-                redirect_url = self.stream_info.streamurl
-                redirect_key = self.stream_info.vtmstreamkey
-                if (
-                    self.stream_info.result
-                    and redirect_url
-                    and redirect_key
-                    and redirect_count < max_redirects
-                    and len(events) < max_packets
-                ):
-                    self.close()
-                    self.stream_url = redirect_url
-                    vtm_stream_key = redirect_key
-                    redirect_count += 1
-                    continue
-            elif packet.message_code == VtmMessageCode.KEEPALIVE_REQ:
-                self.send_packet(
-                    packet.body,
-                    message_code=VtmMessageCode.KEEPALIVE_RSP,
-                )
-            break
+            redirected = False
+            while len(events) < max_packets:
+                packet = self.read_packet()
+                events.append(summarize_vtm_packet(packet, index=len(events)))
 
-        while len(events) < max_packets:
-            packet = self.read_packet()
-            events.append(summarize_vtm_packet(packet, index=len(events)))
-            if packet.message_code == VtmMessageCode.KEEPALIVE_REQ:
-                self.send_packet(
-                    packet.body,
-                    message_code=VtmMessageCode.KEEPALIVE_RSP,
-                )
+                if packet.message_code == VtmMessageCode.STREAMINFO_RSP:
+                    self.stream_info = parse_stream_info_response(packet.body)
+                    redirect_url = self.stream_info.streamurl
+                    redirect_key = self.stream_info.vtmstreamkey
+                    if (
+                        self.stream_info.result
+                        and redirect_url
+                        and redirect_key
+                        and redirect_count < max_redirects
+                        and len(events) < max_packets
+                    ):
+                        self.close()
+                        self.stream_url = redirect_url
+                        vtm_stream_key = redirect_key
+                        redirect_count += 1
+                        redirected = True
+                        break
+                elif packet.message_code == VtmMessageCode.KEEPALIVE_REQ:
+                    self.send_packet(
+                        packet.body,
+                        message_code=VtmMessageCode.KEEPALIVE_RSP,
+                    )
+
+            if not redirected:
+                break
         return events
 
     def _require_socket(self) -> Any:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -239,6 +239,94 @@ def test_unifiedmsg_urls_only_extracts_media_urls(monkeypatch, tmp_path, capsys)
     ]
 
 
+def test_stream_trace_outputs_sanitized_json_lines(monkeypatch, tmp_path, capsys) -> None:
+    fake_client = _install_fake_client(monkeypatch)
+
+    class FakeEvent:
+        def __init__(self, index: int, encrypted: bool) -> None:
+            self.index = index
+            self.encrypted = encrypted
+
+        def as_dict(self) -> dict[str, Any]:
+            return {
+                "index": self.index,
+                "channel": 11 if self.encrypted else 0,
+                "channel_name": "ENCRYPTED_STREAM" if self.encrypted else "MESSAGE",
+                "length": 12,
+                "sequence": self.index + 7,
+                "message_code": 330 if self.encrypted else 316,
+                "message_name": "STREAM_VTMSTREAM_ECDH_NOTIFY"
+                if self.encrypted
+                else "STREAMINFO_RSP",
+                "encrypted": self.encrypted,
+                "transport": "UNKNOWN",
+            }
+
+    class FakeStream:
+        def __init__(self) -> None:
+            self.closed = False
+
+        def __enter__(self) -> FakeStream:
+            return self
+
+        def __exit__(self, *_exc_info: object) -> None:
+            self.closed = True
+
+        def trace_packets(self, *, max_packets: int) -> list[FakeEvent]:
+            assert max_packets == 2
+            return [FakeEvent(0, False), FakeEvent(1, True)]
+
+    calls: list[dict[str, Any]] = []
+    fake_stream = FakeStream()
+
+    def fake_open_cloud_stream(client: Any, serial: str, **kwargs: Any) -> FakeStream:
+        calls.append({"client": client, "serial": serial, **kwargs})
+        return fake_stream
+
+    monkeypatch.setattr(cli_module, "open_cloud_stream", fake_open_cloud_stream)
+
+    assert (
+        cli_module.main(
+            [
+                "--token-file",
+                _token_file(tmp_path),
+                "stream",
+                "trace",
+                "--serial",
+                "CAM123",
+                "--channel",
+                "2",
+                "--max-packets",
+                "2",
+                "--timeout",
+                "3",
+                "--no-refresh-vtm",
+                "--json-lines",
+            ]
+        )
+        == 0
+    )
+
+    client = fake_client.instances[0]
+    assert calls == [
+        {
+            "client": client,
+            "serial": "CAM123",
+            "channel": 2,
+            "client_type": 9,
+            "token_index": 0,
+            "refresh_vtm": False,
+            "timeout": 3.0,
+        }
+    ]
+    assert client.closed is True
+    assert fake_stream.closed is True
+    output = [json.loads(line) for line in capsys.readouterr().out.splitlines()]
+    assert output[0]["message_name"] == "STREAMINFO_RSP"
+    assert output[1]["encrypted"] is True
+    assert "body" not in output[1]
+
+
 def test_unifiedmsg_table_output_handles_empty_response(monkeypatch, tmp_path, capsys) -> None:
     class UnifiedClient(_FakeClient):
         def get_device_messages_list(self, **_kwargs: Any) -> dict[str, Any]:

--- a/tests/test_http_helpers.py
+++ b/tests/test_http_helpers.py
@@ -2438,7 +2438,7 @@ def test_download_alarm_image_returns_plain_image_without_key_lookup(monkeypatch
 
 def test_download_alarm_image_fetches_key_and_decrypts_encrypted_payload(monkeypatch) -> None:
     client = _client()
-    encrypted_payload = HIK_ENCRYPTION_HEADER + b"x" * 64
+    encrypted_payload = b"x" * 300 + HIK_ENCRYPTION_HEADER + b"x" * 64
     decrypted_payload = b"decrypted-jpeg"
     calls: dict[str, Any] = {}
 

--- a/tests/test_http_helpers.py
+++ b/tests/test_http_helpers.py
@@ -11,6 +11,7 @@ import requests
 from pyezvizapi.client import EzvizClient
 from pyezvizapi.constants import (
     FEATURE_CODE,
+    HIK_ENCRYPTION_HEADER,
     DefenseModeType,
     DeviceSwitchType,
     UnifiedMessageSubtype,
@@ -40,6 +41,14 @@ def _response(*, status_code: int = 200, text: str = '{"meta": {"code": 200}}') 
     resp.status_code = status_code
     resp._content = text.encode()
     resp.url = "https://api.example.test/path"
+    return resp
+
+
+def _binary_response(content: bytes) -> requests.Response:
+    resp = requests.Response()
+    resp.status_code = 200
+    resp._content = content
+    resp.url = "https://image.example.test/alarm.jpg"
     return resp
 
 
@@ -2406,6 +2415,82 @@ def test_get_cam_key_retries_and_returns_encrypt_key(monkeypatch) -> None:
     }
     assert calls[0]["retry_401"] is True
     assert calls[0]["max_retries"] == 0
+
+
+def test_download_alarm_image_returns_plain_image_without_key_lookup(monkeypatch) -> None:
+    client = _client()
+    plain_payload = b"plain-jpeg-bytes"
+
+    def fake_http_request(method: str, url: str, **kwargs: Any) -> requests.Response:
+        assert method == "GET"
+        assert url == "https://image.example.test/plain.jpg"
+        assert kwargs["retry_401"] is False
+        return _binary_response(plain_payload)
+
+    def fail_get_cam_key(*args: Any, **kwargs: Any) -> str:
+        raise AssertionError("plain images should not fetch the camera key")
+
+    monkeypatch.setattr(client, "_http_request", fake_http_request)
+    monkeypatch.setattr(client, "get_cam_key", fail_get_cam_key)
+
+    assert client.download_alarm_image("https://image.example.test/plain.jpg") == plain_payload
+
+
+def test_download_alarm_image_fetches_key_and_decrypts_encrypted_payload(monkeypatch) -> None:
+    client = _client()
+    encrypted_payload = HIK_ENCRYPTION_HEADER + b"x" * 64
+    decrypted_payload = b"decrypted-jpeg"
+    calls: dict[str, Any] = {}
+
+    def fake_http_request(method: str, url: str, **kwargs: Any) -> requests.Response:
+        calls["http"] = {"method": method, "url": url, **kwargs}
+        return _binary_response(encrypted_payload)
+
+    def fake_get_cam_key(serial: str, **kwargs: Any) -> str:
+        calls["key"] = {"serial": serial, **kwargs}
+        return "ENC123"
+
+    def fake_decrypt_image(image_data: bytes, password: str) -> bytes:
+        calls["decrypt"] = {"image_data": image_data, "password": password}
+        return decrypted_payload
+
+    monkeypatch.setattr(client, "_http_request", fake_http_request)
+    monkeypatch.setattr(client, "get_cam_key", fake_get_cam_key)
+    monkeypatch.setattr("pyezvizapi.client.decrypt_image", fake_decrypt_image)
+
+    assert (
+        client.download_alarm_image(
+            "https://image.example.test/encrypted.jpg",
+            "CAM123",
+            smscode=123456,
+            max_retries=2,
+        )
+        == decrypted_payload
+    )
+    assert calls["http"]["retry_401"] is False
+    assert calls["key"] == {
+        "serial": "CAM123",
+        "smscode": 123456,
+        "max_retries": 2,
+    }
+    assert calls["decrypt"] == {
+        "image_data": encrypted_payload,
+        "password": "ENC123",
+    }
+
+
+def test_download_alarm_image_requires_serial_or_key_for_encrypted_payload(
+    monkeypatch,
+) -> None:
+    client = _client()
+
+    def fake_http_request(method: str, url: str, **kwargs: Any) -> requests.Response:
+        return _binary_response(HIK_ENCRYPTION_HEADER + b"x" * 64)
+
+    monkeypatch.setattr(client, "_http_request", fake_http_request)
+
+    with pytest.raises(PyEzvizError, match="Camera serial or encryption key"):
+        client.download_alarm_image("https://image.example.test/encrypted.jpg")
 
 
 def test_get_cam_key_maps_special_errors(monkeypatch) -> None:

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -765,6 +765,44 @@ def test_get_vtdu_token_v2_recomputes_auth_after_login(monkeypatch) -> None:
     assert calls[1]["retry_401"] is False
 
 
+def test_get_vtdu_token_v2_derives_auth_addr_when_service_returns_null(
+    monkeypatch,
+) -> None:
+    client = EzvizClient(
+        token={
+            "session_id": _jwt({"s": "sign-value"}),
+            "api_url": "apiieu.ezvizlife.com",
+            "service_urls": {"authAddr": "https://null"},
+        },
+        timeout=1,
+    )
+    calls: list[dict[str, Any]] = []
+
+    class FakeResponse:
+        def __init__(self) -> None:
+            self.status_code = 200
+            self.headers: dict[str, str] = {}
+            self.content = b"{}"
+            self.text = "{}"
+
+        def json(self) -> dict[str, Any]:
+            return {"retcode": 0, "tokens": ["token-1"], "msg": "ok"}
+
+    def fake_get_service_urls() -> dict[str, Any]:
+        return {"authAddr": "https://null"}
+
+    def fake_http_request(method: str, url: str, **kwargs: Any) -> FakeResponse:
+        calls.append({"method": method, "url": url, **kwargs})
+        return FakeResponse()
+
+    monkeypatch.setattr(client, "get_service_urls", fake_get_service_urls)
+    monkeypatch.setattr(client, "_http_request", fake_http_request)
+
+    assert get_vtdu_token_v2(client).get("tokens") == ["token-1"]
+    assert calls[0]["url"] == "https://euauth.ezvizlife.com/vtdutoken2"
+    assert client.export_token()["service_urls"]["authAddr"] == "https://null"
+
+
 def test_get_vtdu_token_v2_does_not_relogin_after_non_auth_error(monkeypatch) -> None:
     client = _client()
     login_calls = 0

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -102,6 +102,16 @@ def _http_error(status_code: int) -> HTTPError:
     return wrapped
 
 
+def _decode_sent_packets(data: bytes) -> list[Any]:
+    packets: list[Any] = []
+    offset = 0
+    while offset < len(data):
+        packet_length = int.from_bytes(data[offset + 2 : offset + 4], "big") + 8
+        packets.append(decode_vtm_packet(data[offset : offset + packet_length]))
+        offset += packet_length
+    return packets
+
+
 def test_package_exports_vtdu_stream_helpers() -> None:
     assert pyezvizapi.VtduInfoResponse is not None
     assert pyezvizapi.VtduStreamResponse is not None
@@ -419,6 +429,70 @@ def test_vtm_stream_client_starts_and_reads_payloads() -> None:
     assert payloads == [b"\x47abc"]
 
 
+def test_vtm_stream_client_start_follows_redirect_response() -> None:
+    redirect_url = "ysproto://redirect.example.test:6000/live?dev=CAM123"
+    redirect_key = "redirect-key"
+    redirect_body = (
+        b"\x08\xb6\x29"
+        + b"\x2a"
+        + bytes([len(redirect_key)])
+        + redirect_key.encode()
+        + b"\x3a"
+        + bytes([len(redirect_url)])
+        + redirect_url.encode()
+    )
+    success_body = b"\x08\x00\x22\x07ssn-123"
+    sockets = [
+        FakeVtmSocket(
+            [
+                encode_vtm_packet(
+                    redirect_body,
+                    message_code=VtmMessageCode.STREAMINFO_RSP,
+                    sequence=7,
+                )
+            ]
+        ),
+        FakeVtmSocket(
+            [
+                encode_vtm_packet(
+                    success_body,
+                    message_code=VtmMessageCode.STREAMINFO_RSP,
+                    sequence=8,
+                )
+            ]
+        ),
+    ]
+    calls: list[tuple[str, int]] = []
+
+    def socket_factory(
+        address: tuple[str, int],
+        _timeout: float | None,
+    ) -> FakeVtmSocket:
+        calls.append(address)
+        return sockets[len(calls) - 1]
+
+    with VtmStreamClient(
+        "ysproto://vtm.example.test:8554/live",
+        socket_factory=socket_factory,
+    ) as stream:
+        info = stream.start()
+
+    second_packets = _decode_sent_packets(sockets[1].sent)
+
+    assert calls == [
+        ("vtm.example.test", 8554),
+        ("redirect.example.test", 6000),
+    ]
+    assert sockets[0].closed
+    assert sockets[1].closed
+    assert stream.stream_url == redirect_url
+    assert info.result == 0
+    assert info.streamssn == "ssn-123"
+    assert second_packets[0].message_code == VtmMessageCode.STREAMINFO_REQ
+    assert redirect_url.encode() in second_packets[0].body
+    assert redirect_key.encode() in second_packets[0].body
+
+
 def test_vtm_stream_client_traces_sanitized_packet_metadata() -> None:
     stream_info_body = b"\x08\x00\x22\x07ssn-123\x2a\x05key-1"
     responses = [
@@ -506,6 +580,111 @@ def test_vtm_stream_client_traces_sanitized_packet_metadata() -> None:
     assert "body" not in events[0].as_dict()
     assert keepalive_sent.message_code == VtmMessageCode.KEEPALIVE_RSP
     assert keepalive_sent.body == KEEPALIVE_REQ
+
+
+def test_vtm_stream_client_trace_follows_redirect_response() -> None:
+    redirect_url = "ysproto://redirect.example.test:6000/live?dev=CAM123"
+    redirect_key = "redirect-key"
+    redirect_body = (
+        b"\x08\xb6\x29"
+        + b"\x2a"
+        + bytes([len(redirect_key)])
+        + redirect_key.encode()
+        + b"\x3a"
+        + bytes([len(redirect_url)])
+        + redirect_url.encode()
+    )
+    success_body = b"\x08\x00\x22\x07ssn-123"
+    stream_body = b"\x00\x00\x01\xbaabc"
+    sockets = [
+        FakeVtmSocket(
+            [
+                encode_vtm_packet(
+                    redirect_body,
+                    message_code=VtmMessageCode.STREAMINFO_RSP,
+                    sequence=7,
+                )
+            ]
+        ),
+        FakeVtmSocket(
+            [
+                encode_vtm_packet(
+                    success_body,
+                    message_code=VtmMessageCode.STREAMINFO_RSP,
+                    sequence=8,
+                ),
+                encode_vtm_packet(
+                    stream_body,
+                    channel=VtmChannel.STREAM,
+                    message_code=0,
+                    sequence=9,
+                ),
+            ]
+        ),
+    ]
+    calls: list[tuple[str, int]] = []
+
+    def socket_factory(
+        address: tuple[str, int],
+        _timeout: float | None,
+    ) -> FakeVtmSocket:
+        calls.append(address)
+        return sockets[len(calls) - 1]
+
+    with VtmStreamClient(
+        "ysproto://vtm.example.test:8554/live",
+        socket_factory=socket_factory,
+    ) as stream:
+        events = stream.trace_packets(max_packets=3)
+
+    second_packets = _decode_sent_packets(sockets[1].sent)
+
+    assert calls == [
+        ("vtm.example.test", 8554),
+        ("redirect.example.test", 6000),
+    ]
+    assert sockets[0].closed
+    assert stream.stream_url == redirect_url
+    assert stream.stream_info is not None
+    assert stream.stream_info.result == 0
+    assert second_packets[0].message_code == VtmMessageCode.STREAMINFO_REQ
+    assert redirect_url.encode() in second_packets[0].body
+    assert redirect_key.encode() in second_packets[0].body
+    assert events == [
+        VtmTraceEvent(
+            index=0,
+            channel=VtmChannel.MESSAGE,
+            channel_name="MESSAGE",
+            length=len(redirect_body),
+            sequence=7,
+            message_code=VtmMessageCode.STREAMINFO_RSP,
+            message_name="STREAMINFO_RSP",
+            encrypted=False,
+            transport="UNKNOWN",
+        ),
+        VtmTraceEvent(
+            index=1,
+            channel=VtmChannel.MESSAGE,
+            channel_name="MESSAGE",
+            length=len(success_body),
+            sequence=8,
+            message_code=VtmMessageCode.STREAMINFO_RSP,
+            message_name="STREAMINFO_RSP",
+            encrypted=False,
+            transport="UNKNOWN",
+        ),
+        VtmTraceEvent(
+            index=2,
+            channel=VtmChannel.STREAM,
+            channel_name="STREAM",
+            length=len(stream_body),
+            sequence=9,
+            message_code=0,
+            message_name=None,
+            encrypted=False,
+            transport="MPEG_PS",
+        ),
+    ]
 
 
 def test_vtm_trace_rejects_empty_packet_count() -> None:

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -21,6 +21,7 @@ from pyezvizapi.stream import (
     VtmChannel,
     VtmMessageCode,
     VtmStreamClient,
+    VtmTraceEvent,
     build_get_vtdu_info_request,
     build_peer_stream_request,
     build_start_stream_request,
@@ -38,6 +39,7 @@ from pyezvizapi.stream import (
     parse_stream_info_response,
     parse_vtm_url,
     rtp_payload,
+    summarize_vtm_packet,
 )
 
 BODY = b"abc"
@@ -104,6 +106,7 @@ def test_package_exports_vtdu_stream_helpers() -> None:
     assert pyezvizapi.VtduInfoResponse is not None
     assert pyezvizapi.VtduStreamResponse is not None
     assert pyezvizapi.StopStreamResponse is not None
+    assert pyezvizapi.VtmTraceEvent is VtmTraceEvent
     assert pyezvizapi.build_get_vtdu_info_request is build_get_vtdu_info_request
     assert pyezvizapi.build_start_stream_request is build_start_stream_request
     assert pyezvizapi.build_peer_stream_request is build_peer_stream_request
@@ -112,6 +115,7 @@ def test_package_exports_vtdu_stream_helpers() -> None:
     assert pyezvizapi.parse_start_stream_response is parse_start_stream_response
     assert pyezvizapi.parse_peer_stream_response is parse_peer_stream_response
     assert pyezvizapi.parse_stop_stream_response is parse_stop_stream_response
+    assert pyezvizapi.summarize_vtm_packet is summarize_vtm_packet
 
 
 def test_vtm_packet_roundtrip() -> None:
@@ -413,6 +417,102 @@ def test_vtm_stream_client_starts_and_reads_payloads() -> None:
     assert first_sent.message_code == VtmMessageCode.STREAMINFO_REQ
     assert second_sent.message_code == VtmMessageCode.KEEPALIVE_RSP
     assert payloads == [b"\x47abc"]
+
+
+def test_vtm_stream_client_traces_sanitized_packet_metadata() -> None:
+    stream_info_body = b"\x08\x00\x22\x07ssn-123\x2a\x05key-1"
+    responses = [
+        encode_vtm_packet(
+            stream_info_body,
+            message_code=VtmMessageCode.STREAMINFO_RSP,
+            sequence=7,
+        ),
+        encode_vtm_packet(
+            b"encrypted-control",
+            channel=VtmChannel.ENCRYPTED_MESSAGE,
+            message_code=VtmMessageCode.STREAM_VTMSTREAM_ECDH_NOTIFY,
+            sequence=8,
+        ),
+        encode_vtm_packet(
+            b"\x47abc",
+            channel=VtmChannel.STREAM,
+            message_code=0,
+            sequence=9,
+        ),
+        encode_vtm_packet(
+            build_stream_keepalive_request("ssn-123"),
+            message_code=VtmMessageCode.KEEPALIVE_REQ,
+            sequence=10,
+        ),
+    ]
+    fake_socket = FakeVtmSocket(responses)
+
+    with VtmStreamClient(
+        "ysproto://vtm.example.test:8554/live",
+        socket_factory=lambda _address, _timeout: fake_socket,
+    ) as stream:
+        events = stream.trace_packets(max_packets=4)
+
+    keepalive_sent = decode_vtm_packet(fake_socket.sent[-(len(KEEPALIVE_REQ) + 8) :])
+
+    assert stream.stream_info is not None
+    assert stream.stream_info.streamssn == "ssn-123"
+    assert events == [
+        VtmTraceEvent(
+            index=0,
+            channel=VtmChannel.MESSAGE,
+            channel_name="MESSAGE",
+            length=len(stream_info_body),
+            sequence=7,
+            message_code=VtmMessageCode.STREAMINFO_RSP,
+            message_name="STREAMINFO_RSP",
+            encrypted=False,
+            transport="UNKNOWN",
+        ),
+        VtmTraceEvent(
+            index=1,
+            channel=VtmChannel.ENCRYPTED_MESSAGE,
+            channel_name="ENCRYPTED_MESSAGE",
+            length=len(b"encrypted-control"),
+            sequence=8,
+            message_code=VtmMessageCode.STREAM_VTMSTREAM_ECDH_NOTIFY,
+            message_name="STREAM_VTMSTREAM_ECDH_NOTIFY",
+            encrypted=True,
+            transport="UNKNOWN",
+        ),
+        VtmTraceEvent(
+            index=2,
+            channel=VtmChannel.STREAM,
+            channel_name="STREAM",
+            length=4,
+            sequence=9,
+            message_code=0,
+            message_name=None,
+            encrypted=False,
+            transport="MPEG_TS",
+        ),
+        VtmTraceEvent(
+            index=3,
+            channel=VtmChannel.MESSAGE,
+            channel_name="MESSAGE",
+            length=len(KEEPALIVE_REQ),
+            sequence=10,
+            message_code=VtmMessageCode.KEEPALIVE_REQ,
+            message_name="KEEPALIVE_REQ",
+            encrypted=False,
+            transport="UNKNOWN",
+        ),
+    ]
+    assert "body" not in events[0].as_dict()
+    assert keepalive_sent.message_code == VtmMessageCode.KEEPALIVE_RSP
+    assert keepalive_sent.body == KEEPALIVE_REQ
+
+
+def test_vtm_trace_rejects_empty_packet_count() -> None:
+    stream = VtmStreamClient("ysproto://vtm.example.test:8554/live")
+
+    with pytest.raises(PyEzvizError, match="at least one packet"):
+        stream.trace_packets(max_packets=0)
 
 
 def test_vtm_stream_client_rejects_closed_socket() -> None:

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -687,6 +687,81 @@ def test_vtm_stream_client_trace_follows_redirect_response() -> None:
     ]
 
 
+def test_vtm_stream_client_trace_follows_redirect_after_keepalive() -> None:
+    redirect_url = "ysproto://redirect.example.test:6000/live?dev=CAM123"
+    redirect_key = "redirect-key"
+    redirect_body = (
+        b"\x08\xb6\x29"
+        + b"\x2a"
+        + bytes([len(redirect_key)])
+        + redirect_key.encode()
+        + b"\x3a"
+        + bytes([len(redirect_url)])
+        + redirect_url.encode()
+    )
+    success_body = b"\x08\x00\x22\x07ssn-123"
+    sockets = [
+        FakeVtmSocket(
+            [
+                encode_vtm_packet(
+                    build_stream_keepalive_request("ssn-123"),
+                    message_code=VtmMessageCode.KEEPALIVE_REQ,
+                    sequence=6,
+                ),
+                encode_vtm_packet(
+                    redirect_body,
+                    message_code=VtmMessageCode.STREAMINFO_RSP,
+                    sequence=7,
+                ),
+            ]
+        ),
+        FakeVtmSocket(
+            [
+                encode_vtm_packet(
+                    success_body,
+                    message_code=VtmMessageCode.STREAMINFO_RSP,
+                    sequence=8,
+                ),
+            ]
+        ),
+    ]
+    calls: list[tuple[str, int]] = []
+
+    def socket_factory(
+        address: tuple[str, int],
+        _timeout: float | None,
+    ) -> FakeVtmSocket:
+        calls.append(address)
+        return sockets[len(calls) - 1]
+
+    with VtmStreamClient(
+        "ysproto://vtm.example.test:8554/live",
+        socket_factory=socket_factory,
+    ) as stream:
+        events = stream.trace_packets(max_packets=3)
+
+    first_packets = _decode_sent_packets(sockets[0].sent)
+    second_packets = _decode_sent_packets(sockets[1].sent)
+
+    assert calls == [
+        ("vtm.example.test", 8554),
+        ("redirect.example.test", 6000),
+    ]
+    assert sockets[0].closed
+    assert stream.stream_url == redirect_url
+    assert stream.stream_info is not None
+    assert stream.stream_info.result == 0
+    assert first_packets[-1].message_code == VtmMessageCode.KEEPALIVE_RSP
+    assert second_packets[0].message_code == VtmMessageCode.STREAMINFO_REQ
+    assert redirect_url.encode() in second_packets[0].body
+    assert redirect_key.encode() in second_packets[0].body
+    assert [event.message_code for event in events] == [
+        VtmMessageCode.KEEPALIVE_REQ,
+        VtmMessageCode.STREAMINFO_RSP,
+        VtmMessageCode.STREAMINFO_RSP,
+    ]
+
+
 def test_vtm_trace_rejects_empty_packet_count() -> None:
     stream = VtmStreamClient("ysproto://vtm.example.test:8554/live")
 


### PR DESCRIPTION
## Summary
- add a sanitized VTM packet trace harness and CLI command for live stream diagnostics
- follow VTM redirect responses using returned stream URL/key before tracing or starting streams
- add alarm image download/decrypt helper for EZVIZ/Hik encrypted snapshot payloads
- derive the EZVIZ auth host from `api_url` when service URLs return a null `authAddr`

## Validation
- `.venv/bin/python -m pytest tests/test_stream.py tests/test_http_helpers.py -q`
- Prior local validation on this branch: full pytest, Ruff, mypy, and pyright
- Live VTM traces against tested cameras produced sanitized stream metadata without exposing packet bodies/tokens/keys

## Notes
- The trace output intentionally records only metadata: packet index, channel/name, length, sequence, message code/name, encryption flag, and best-effort transport detection.
- Encrypted alarm image handling is separate from the live VTM media path; tested live streams still produced normal `STREAM` packets rather than `ENCRYPTED_STREAM`.