### PR TITLE
Add experimental VTM stream dump and proxy commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project follows [Semantic Versioning](https://semver.org/) for published re
 - Added cloud stream bootstrap helpers for VTM pagelist metadata, VTDU token retrieval, VTM/VTDU packet framing, `ysproto` URL handling, limited stream protobuf parsing, RTP payload extraction, and transport detection.
 - Added VTM server public-key extraction plus native VTDU protobuf helpers for `GetVtduInfo`, `StartStream`, `PeerStream`, and `StopStream` stream-control messages.
 - Added a sanitized VTM trace harness and CLI command for live stream diagnostics without exposing packet bodies, tokens, or keys.
+- Added experimental VTM stream dump/proxy CLI commands and README usage for writing stream payload bytes to stdout/file or serving a local FFmpeg-remuxed MPEG-TS URL.
 - Added alarm image download/decrypt helper support for EZVIZ/Hik encrypted snapshot payloads.
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ This project follows [Semantic Versioning](https://semver.org/) for published re
 - Added cloud stream bootstrap helpers for VTM pagelist metadata, VTDU token retrieval, VTM/VTDU packet framing, `ysproto` URL handling, limited stream protobuf parsing, RTP payload extraction, and transport detection.
 - Added VTM server public-key extraction plus native VTDU protobuf helpers for `GetVtduInfo`, `StartStream`, `PeerStream`, and `StopStream` stream-control messages.
 - Added a sanitized VTM trace harness and CLI command for live stream diagnostics without exposing packet bodies, tokens, or keys.
-- Added experimental VTM stream dump/proxy CLI commands and README usage for writing stream payload bytes to stdout/file or serving a local FFmpeg-remuxed MPEG-TS URL.
+- Added experimental VTM stream dump/proxy CLI commands and README usage for writing VLC-friendly one-minute MPEG-TS captures by default, raw payload dumps on request, or serving a local FFmpeg-remuxed MPEG-TS URL.
 - Added alarm image download/decrypt helper support for EZVIZ/Hik encrypted snapshot payloads.
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ Run the same local validation used by CI:
 ruff check .
 codespell pyezvizapi tests README.md pyproject.toml .github
 pip-audit --progress-spinner off
-mypy --install-types --non-interinteractive .
+mypy --install-types --non-interactive .
 pyright pyezvizapi
 pytest --cov=pyezvizapi --cov-report=term-missing --cov-report=xml --cov-fail-under=85
 python -m build

--- a/README.md
+++ b/README.md
@@ -102,6 +102,27 @@ name | status | device_category | device_sub_category | sleep | privacy | audio 
 
 The CLI also computes a `switch_flags` map for each device (all switch states by name, e.g. `privacy`, `sleep`, `sound`, `infrared_light`, `light`, etc.).
 
+### stream
+
+Experimental VTM cloud stream helpers. Packet tracing prints sanitized metadata only. Dumping writes stream payload bytes for FFmpeg/proxy experiments and fails on encrypted packets unless `--allow-encrypted` is set.
+
+```bash
+# Inspect stream packet metadata without printing media bytes
+pyezvizapi stream trace --serial ABC123 --channel 1 --max-packets 20 --json-lines
+
+# Dump raw VTM stream payloads to a file
+pyezvizapi stream dump --serial ABC123 --channel 1 --max-packets 500 --output stream.ps
+
+# Pipe directly into FFmpeg and remux to MPEG-TS
+pyezvizapi stream dump --serial ABC123 --channel 1 | \
+  ffmpeg -f mpeg -i pipe:0 -c copy -f mpegts stream.ts
+
+# Serve a local MPEG-TS URL for Home Assistant/FFmpeg clients
+pyezvizapi stream proxy --serial ABC123 --channel 1 --listen-host 0.0.0.0 --listen-port 8558
+```
+
+The proxy serves `http://<host>:8558/<serial>.ts` by default. Each HTTP client opens a fresh VTM stream and remuxes it through FFmpeg.
+
 ### camera
 
 Requires `--serial`.

--- a/README.md
+++ b/README.md
@@ -119,10 +119,10 @@ pyezvizapi stream dump --serial ABC123 --channel 1 --format raw | \
   ffmpeg -f mpeg -i pipe:0 -c copy -f mpegts stream.ts
 
 # Serve a local MPEG-TS URL for Home Assistant/FFmpeg clients
-pyezvizapi stream proxy --serial ABC123 --channel 1 --listen-host 0.0.0.0 --listen-port 8558
+pyezvizapi stream proxy --serial ABC123 --channel 1 --listen-port 8558
 ```
 
-The dump command captures one minute by default. Use `--duration 30s`, `--duration 2min`, or `--duration 0` for unlimited capture; `--max-packets` can still be used as an additional stop limit. MPEG-TS output requires FFmpeg and remuxes the camera payload with codec copy only; it does not transcode video or audio. The proxy serves `http://<host>:8558/<serial>.ts` by default. Each HTTP client opens a fresh VTM stream and remuxes it through FFmpeg.
+The dump command captures one minute by default. Use `--duration 30s`, `--duration 2min`, or `--duration 0` for unlimited capture; `--max-packets` can still be used as an additional stop limit. MPEG-TS output requires FFmpeg and remuxes the camera payload with codec copy only; it does not transcode video or audio. The proxy serves `http://<host>:8558/<serial>.ts` by default. Each HTTP client opens a fresh VTM stream and remuxes it through FFmpeg. Keep the proxy bound to loopback unless you put it behind an authenticated reverse proxy or otherwise restrict access; the stream URL is not authenticated by `pyezvizapi`.
 
 ### camera
 
@@ -246,7 +246,7 @@ Run the same local validation used by CI:
 ruff check .
 codespell pyezvizapi tests README.md pyproject.toml .github
 pip-audit --progress-spinner off
-mypy --install-types --non-interactive .
+mypy --install-types --non-interinteractive .
 pyright pyezvizapi
 pytest --cov=pyezvizapi --cov-report=term-missing --cov-report=xml --cov-fail-under=85
 python -m build

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Ezviz PyPi
 
 ![Upload Python Package](https://github.com/RenierM26/pyEzvizApi/workflows/Upload%20Python%20Package/badge.svg)
+[![Buy Me A Coffee](https://img.shields.io/badge/Buy%20me%20a%20coffee-renierm-yellow?logo=buymeacoffee)](https://www.buymeacoffee.com/renierm)
 
 ## Overview
 

--- a/README.md
+++ b/README.md
@@ -104,24 +104,24 @@ The CLI also computes a `switch_flags` map for each device (all switch states by
 
 ### stream
 
-Experimental VTM cloud stream helpers. Packet tracing prints sanitized metadata only. Dumping writes stream payload bytes for FFmpeg/proxy experiments and fails on encrypted packets unless `--allow-encrypted` is set.
+Experimental VTM cloud stream helpers. Packet tracing prints sanitized metadata only. Dumping writes VLC-friendly MPEG-TS by default using FFmpeg `-c copy` remuxing only, with `--format raw` available for unchanged VTM payloads. Encrypted packets fail unless `--allow-encrypted` is set.
 
 ```bash
 # Inspect stream packet metadata without printing media bytes
 pyezvizapi stream trace --serial ABC123 --channel 1 --max-packets 20 --json-lines
 
-# Dump raw VTM stream payloads to a file
-pyezvizapi stream dump --serial ABC123 --channel 1 --max-packets 500 --output stream.ps
+# Dump a VLC-playable MPEG-TS capture to a file
+pyezvizapi stream dump --serial ABC123 --channel 1 --duration 1m --output stream.ts
 
-# Pipe directly into FFmpeg and remux to MPEG-TS
-pyezvizapi stream dump --serial ABC123 --channel 1 | \
+# Pipe raw MPEG-PS payloads directly into FFmpeg and remux to MPEG-TS
+pyezvizapi stream dump --serial ABC123 --channel 1 --format raw | \
   ffmpeg -f mpeg -i pipe:0 -c copy -f mpegts stream.ts
 
 # Serve a local MPEG-TS URL for Home Assistant/FFmpeg clients
 pyezvizapi stream proxy --serial ABC123 --channel 1 --listen-host 0.0.0.0 --listen-port 8558
 ```
 
-The proxy serves `http://<host>:8558/<serial>.ts` by default. Each HTTP client opens a fresh VTM stream and remuxes it through FFmpeg.
+The dump command captures one minute by default. Use `--duration 30s`, `--duration 2min`, or `--duration 0` for unlimited capture; `--max-packets` can still be used as an additional stop limit. MPEG-TS output requires FFmpeg and remuxes the camera payload with codec copy only; it does not transcode video or audio. The proxy serves `http://<host>:8558/<serial>.ts` by default. Each HTTP client opens a fresh VTM stream and remuxes it through FFmpeg.
 
 ### camera
 

--- a/pyezvizapi/__main__.py
+++ b/pyezvizapi/__main__.py
@@ -881,8 +881,22 @@ def _remux_stream_payloads_to_mpegts(
 ) -> None:
     """Remux VTM MPEG-PS payloads to MPEG-TS and write them to output."""
 
+    process = _open_mpegts_remux_process(ffmpeg_path)
+    _copy_stream_payloads_to_mpegts(
+        stream,
+        output,
+        process=process,
+        max_packets=max_packets,
+        duration_seconds=duration_seconds,
+        allow_encrypted=allow_encrypted,
+    )
+
+
+def _open_mpegts_remux_process(ffmpeg_path: str) -> subprocess.Popen[bytes]:
+    """Open an FFmpeg process ready to remux MPEG-PS stdin to MPEG-TS stdout."""
+
     try:
-        process = subprocess.Popen(
+        return subprocess.Popen(
             [
                 ffmpeg_path,
                 "-hide_banner",
@@ -904,6 +918,19 @@ def _remux_stream_payloads_to_mpegts(
         )
     except OSError as err:
         raise PyEzvizError(f"Could not launch FFmpeg at {ffmpeg_path!r}: {err}") from err
+
+
+def _copy_stream_payloads_to_mpegts(
+    stream: Any,
+    output: BinaryIO,
+    *,
+    process: subprocess.Popen[bytes],
+    max_packets: int | None,
+    duration_seconds: float | None = None,
+    allow_encrypted: bool,
+) -> None:
+    """Copy stream payloads through an already-started FFmpeg remuxer."""
+
     stdin = process.stdin
     stdout = process.stdout
     if stdin is None or stdout is None:
@@ -968,6 +995,54 @@ def _normalize_stream_proxy_path(path: str | None, serial: str) -> str:
     return path if path.startswith("/") else f"/{path}"
 
 
+def _handle_stream_proxy_get(
+    handler: BaseHTTPRequestHandler,
+    config: StreamProxyConfig,
+    client: EzvizClient,
+) -> None:
+    """Handle one experimental VTM-to-MPEG-TS HTTP proxy request."""
+
+    if urlparse(handler.path).path != config.path:
+        handler.send_error(404, "Stream not found")
+        return
+
+    response_started = False
+    try:
+        with open_cloud_stream(
+            client,
+            config.serial,
+            channel=config.channel,
+            client_type=config.client_type,
+            token_index=config.token_index,
+            refresh_vtm=config.refresh_vtm,
+            timeout=config.timeout,
+        ) as stream:
+            stream.start()
+            process = _open_mpegts_remux_process(config.ffmpeg_path)
+            handler.send_response(200)
+            response_started = True
+            handler.send_header("Content-Type", "video/MP2T")
+            handler.send_header("Cache-Control", "no-store")
+            handler.send_header("Connection", "close")
+            handler.end_headers()
+            _copy_stream_payloads_to_mpegts(
+                stream,
+                cast(BinaryIO, handler.wfile),
+                process=process,
+                max_packets=config.max_packets,
+                allow_encrypted=config.allow_encrypted,
+            )
+    except (BrokenPipeError, ConnectionResetError):
+        _LOGGER.debug("Stream proxy client disconnected")
+    except PyEzvizError as err:
+        _LOGGER.error("%s", err)
+        if response_started:
+            if not handler.wfile.closed:
+                handler.close_connection = True
+        else:
+            handler.send_error(502, str(err))
+
+
 def _serve_stream_proxy(args: argparse.Namespace, client: EzvizClient) -> None:
     """Serve the experimental VTM-to-MPEG-TS HTTP proxy until interrupted."""
 
@@ -988,39 +1063,7 @@ def _serve_stream_proxy(args: argparse.Namespace, client: EzvizClient) -> None:
         server_version = "pyezvizapi-stream-proxy/0"
 
         def do_GET(self) -> None:
-            if urlparse(self.path).path != config.path:
-                self.send_error(404, "Stream not found")
-                return
-
-            try:
-                with open_cloud_stream(
-                    client,
-                    config.serial,
-                    channel=config.channel,
-                    client_type=config.client_type,
-                    token_index=config.token_index,
-                    refresh_vtm=config.refresh_vtm,
-                    timeout=config.timeout,
-                ) as stream:
-                    stream.start()
-                    self.send_response(200)
-                    self.send_header("Content-Type", "video/MP2T")
-                    self.send_header("Cache-Control", "no-store")
-                    self.send_header("Connection", "close")
-                    self.end_headers()
-                    _remux_stream_payloads_to_mpegts(
-                        stream,
-                        cast(BinaryIO, self.wfile),
-                        ffmpeg_path=config.ffmpeg_path,
-                        max_packets=config.max_packets,
-                        allow_encrypted=config.allow_encrypted,
-                    )
-            except (BrokenPipeError, ConnectionResetError):
-                _LOGGER.debug("Stream proxy client disconnected")
-            except PyEzvizError as err:
-                _LOGGER.error("%s", err)
-                if not self.wfile.closed:
-                    self.close_connection = True
+            _handle_stream_proxy_get(self, config, client)
 
         def log_message(self, format: str, *args: Any) -> None:
             _LOGGER.info("stream proxy: " + format, *args)

--- a/pyezvizapi/__main__.py
+++ b/pyezvizapi/__main__.py
@@ -45,6 +45,13 @@ class StreamProxyConfig:
     max_packets: int | None
 
 
+class StreamProxyHTTPServer(ThreadingHTTPServer):
+    """Threaded HTTP server that does not block CLI shutdown on active streams."""
+
+    daemon_threads = True
+    block_on_close = False
+
+
 def _parse_duration_seconds(value: str) -> float | None:
     """Parse a CLI duration value into seconds."""
 
@@ -1069,7 +1076,7 @@ def _serve_stream_proxy(args: argparse.Namespace, client: EzvizClient) -> None:
             _LOGGER.info("stream proxy: " + format, *args)
 
     try:
-        server = ThreadingHTTPServer(
+        server = StreamProxyHTTPServer(
             (args.listen_host, args.listen_port),
             StreamProxyHandler,
         )

--- a/pyezvizapi/__main__.py
+++ b/pyezvizapi/__main__.py
@@ -6,11 +6,17 @@ Small utility CLI for testing and scripting Ezviz operations.
 from __future__ import annotations
 
 import argparse
+from contextlib import suppress
+from dataclasses import dataclass
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 import json
 import logging
 from pathlib import Path
+import subprocess
 import sys
-from typing import Any, cast
+from threading import Thread
+from typing import Any, BinaryIO, cast
+from urllib.parse import urlparse
 
 from .camera import EzvizCamera
 from .client import EzvizClient
@@ -20,6 +26,22 @@ from .exceptions import EzvizAuthVerificationCode, PyEzvizError
 from .light_bulb import EzvizLightBulb
 
 _LOGGER = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class StreamProxyConfig:
+    """Configuration for the experimental HTTP stream proxy."""
+
+    serial: str
+    channel: int | None
+    client_type: int
+    token_index: int
+    refresh_vtm: bool
+    timeout: float | None
+    path: str
+    ffmpeg_path: str
+    allow_encrypted: bool
+    max_packets: int | None
 
 
 def _setup_logging(debug: bool) -> None:
@@ -340,6 +362,122 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         action="store_true",
         help="Print one JSON object per trace event instead of a JSON array",
     )
+    parser_stream_dump = subparsers_stream.add_parser(
+        "dump",
+        help="Dump VTM stream payload bytes for FFmpeg/proxy experiments",
+    )
+    parser_stream_dump.add_argument("--serial", required=True, help="camera SERIAL")
+    parser_stream_dump.add_argument(
+        "--channel",
+        type=int,
+        default=None,
+        help="Camera channel/local index (default: first matching VTM resource)",
+    )
+    parser_stream_dump.add_argument(
+        "--max-packets",
+        type=int,
+        default=None,
+        help="Stop after this many stream packets (default: run until interrupted)",
+    )
+    parser_stream_dump.add_argument(
+        "--timeout",
+        type=float,
+        default=10.0,
+        help="Socket timeout in seconds (default: 10)",
+    )
+    parser_stream_dump.add_argument(
+        "--client-type",
+        type=int,
+        default=9,
+        help="VTM client type used in the ysproto URL (default: 9)",
+    )
+    parser_stream_dump.add_argument(
+        "--token-index",
+        type=int,
+        default=0,
+        help="VTDU token index to use from /vtdutoken2 (default: 0)",
+    )
+    parser_stream_dump.add_argument(
+        "--no-refresh-vtm",
+        action="store_true",
+        help="Use pagelist VTM metadata without refreshing via /v3/streaming/vtm",
+    )
+    parser_stream_dump.add_argument(
+        "--output",
+        default="-",
+        help="Output file for stream bytes, or '-' for stdout (default: -)",
+    )
+    parser_stream_dump.add_argument(
+        "--allow-encrypted",
+        action="store_true",
+        help="Write encrypted stream payloads instead of failing on first encrypted packet",
+    )
+    parser_stream_proxy = subparsers_stream.add_parser(
+        "proxy",
+        help="Serve a local HTTP MPEG-TS stream for FFmpeg/Home Assistant",
+    )
+    parser_stream_proxy.add_argument("--serial", required=True, help="camera SERIAL")
+    parser_stream_proxy.add_argument(
+        "--channel",
+        type=int,
+        default=None,
+        help="Camera channel/local index (default: first matching VTM resource)",
+    )
+    parser_stream_proxy.add_argument(
+        "--listen-host",
+        default="127.0.0.1",
+        help="Host/IP to bind the proxy to (default: 127.0.0.1)",
+    )
+    parser_stream_proxy.add_argument(
+        "--listen-port",
+        type=int,
+        default=8558,
+        help="TCP port to bind the proxy to (default: 8558)",
+    )
+    parser_stream_proxy.add_argument(
+        "--path",
+        default=None,
+        help="HTTP path to serve (default: /<serial>.ts)",
+    )
+    parser_stream_proxy.add_argument(
+        "--timeout",
+        type=float,
+        default=10.0,
+        help="Socket timeout in seconds (default: 10)",
+    )
+    parser_stream_proxy.add_argument(
+        "--client-type",
+        type=int,
+        default=9,
+        help="VTM client type used in the ysproto URL (default: 9)",
+    )
+    parser_stream_proxy.add_argument(
+        "--token-index",
+        type=int,
+        default=0,
+        help="VTDU token index to use from /vtdutoken2 (default: 0)",
+    )
+    parser_stream_proxy.add_argument(
+        "--no-refresh-vtm",
+        action="store_true",
+        help="Use pagelist VTM metadata without refreshing via /v3/streaming/vtm",
+    )
+    parser_stream_proxy.add_argument(
+        "--ffmpeg-path",
+        default="ffmpeg",
+        help="FFmpeg executable to use for MPEG-TS remuxing (default: ffmpeg)",
+    )
+    parser_stream_proxy.add_argument(
+        "--allow-encrypted",
+        action="store_true",
+        help="Forward encrypted stream payloads instead of failing on first encrypted packet",
+    )
+    parser_stream_proxy.add_argument(
+        "--max-packets",
+        type=int,
+        default=None,
+        help="Stop each HTTP stream after this many packets (default: unlimited)",
+    )
 
     return parser.parse_args(argv)
 
@@ -633,12 +771,197 @@ def _handle_mqtt(_: argparse.Namespace, client: EzvizClient) -> int:
     return 0
 
 
+def _write_stream_payloads(
+    stream: Any,
+    output: BinaryIO,
+    *,
+    max_packets: int | None,
+    allow_encrypted: bool,
+    flush_each: bool = False,
+) -> None:
+    """Write VTM stream packet bodies to a binary file-like object."""
+
+    for packet in stream.iter_packets(max_packets=max_packets):
+        if packet.encrypted and not allow_encrypted:
+            raise PyEzvizError(
+                "Received encrypted VTM stream packet; "
+                "media decryption is not implemented"
+            )
+        output.write(packet.body)
+        if flush_each:
+            output.flush()
+    output.flush()
+
+
+def _remux_stream_payloads_to_mpegts(
+    stream: Any,
+    output: BinaryIO,
+    *,
+    ffmpeg_path: str,
+    max_packets: int | None,
+    allow_encrypted: bool,
+) -> None:
+    """Remux VTM MPEG-PS payloads to MPEG-TS and write them to output."""
+
+    process = subprocess.Popen(
+        [
+            ffmpeg_path,
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-f",
+            "mpeg",
+            "-i",
+            "pipe:0",
+            "-c",
+            "copy",
+            "-f",
+            "mpegts",
+            "pipe:1",
+        ],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+    )
+    stdin = process.stdin
+    stdout = process.stdout
+    if stdin is None or stdout is None:
+        raise PyEzvizError("Could not open FFmpeg pipes")
+
+    writer_errors: list[BaseException] = []
+
+    def _write_input() -> None:
+        try:
+            _write_stream_payloads(
+                stream,
+                cast(BinaryIO, stdin),
+                max_packets=max_packets,
+                allow_encrypted=allow_encrypted,
+                flush_each=True,
+            )
+        except (BrokenPipeError, ConnectionResetError):
+            pass
+        except BaseException as err:  # pragma: no cover - defensive thread handoff
+            writer_errors.append(err)
+        finally:
+            with suppress(OSError):
+                stdin.close()
+
+    writer = Thread(target=_write_input, daemon=True)
+    writer.start()
+    try:
+        while True:
+            chunk = stdout.read(65536)
+            if not chunk:
+                break
+            output.write(chunk)
+            output.flush()
+    finally:
+        if process.poll() is None:
+            process.terminate()
+        writer.join(timeout=2)
+        try:
+            return_code = process.wait(timeout=2)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            return_code = process.wait()
+
+    if writer_errors:
+        raise writer_errors[0]
+    if return_code not in (0, -15):
+        raise PyEzvizError(f"FFmpeg exited with status {return_code}")
+
+
+def _default_stream_proxy_path(serial: str) -> str:
+    """Return the default HTTP path for a camera stream."""
+
+    return f"/{serial}.ts"
+
+
+def _normalize_stream_proxy_path(path: str | None, serial: str) -> str:
+    """Normalize a user-supplied proxy path."""
+
+    if not path:
+        return _default_stream_proxy_path(serial)
+    return path if path.startswith("/") else f"/{path}"
+
+
+def _serve_stream_proxy(args: argparse.Namespace, client: EzvizClient) -> None:
+    """Serve the experimental VTM-to-MPEG-TS HTTP proxy until interrupted."""
+
+    config = StreamProxyConfig(
+        serial=args.serial,
+        channel=args.channel,
+        client_type=args.client_type,
+        token_index=args.token_index,
+        refresh_vtm=not args.no_refresh_vtm,
+        timeout=args.timeout,
+        path=_normalize_stream_proxy_path(args.path, args.serial),
+        ffmpeg_path=args.ffmpeg_path,
+        allow_encrypted=args.allow_encrypted,
+        max_packets=args.max_packets,
+    )
+
+    class StreamProxyHandler(BaseHTTPRequestHandler):
+        server_version = "pyezvizapi-stream-proxy/0"
+
+        def do_GET(self) -> None:
+            if urlparse(self.path).path != config.path:
+                self.send_error(404, "Stream not found")
+                return
+
+            try:
+                with open_cloud_stream(
+                    client,
+                    config.serial,
+                    channel=config.channel,
+                    client_type=config.client_type,
+                    token_index=config.token_index,
+                    refresh_vtm=config.refresh_vtm,
+                    timeout=config.timeout,
+                ) as stream:
+                    stream.start()
+                    self.send_response(200)
+                    self.send_header("Content-Type", "video/MP2T")
+                    self.send_header("Cache-Control", "no-store")
+                    self.send_header("Connection", "close")
+                    self.end_headers()
+                    _remux_stream_payloads_to_mpegts(
+                        stream,
+                        cast(BinaryIO, self.wfile),
+                        ffmpeg_path=config.ffmpeg_path,
+                        max_packets=config.max_packets,
+                        allow_encrypted=config.allow_encrypted,
+                    )
+            except (BrokenPipeError, ConnectionResetError):
+                _LOGGER.debug("Stream proxy client disconnected")
+            except PyEzvizError as err:
+                _LOGGER.error("%s", err)
+                if not self.wfile.closed:
+                    self.close_connection = True
+
+        def log_message(self, format: str, *args: Any) -> None:
+            _LOGGER.info("stream proxy: " + format, *args)
+
+    server = ThreadingHTTPServer((args.listen_host, args.listen_port), StreamProxyHandler)
+    url = f"http://{args.listen_host}:{args.listen_port}{config.path}"
+    _LOGGER.info("Serving VTM stream proxy at %s", url)
+    try:
+        server.serve_forever()
+    finally:
+        server.server_close()
+
+
 def _handle_stream(args: argparse.Namespace, client: EzvizClient) -> int:
     """Handle experimental stream helpers."""
 
-    if args.stream_action != "trace":
+    if args.stream_action not in {"trace", "dump", "proxy"}:
         _LOGGER.error("Action not implemented, try running with -h switch for help")
         return 2
+
+    if args.stream_action == "proxy":
+        _serve_stream_proxy(args, client)
+        return 0
 
     with open_cloud_stream(
         client,
@@ -649,6 +972,25 @@ def _handle_stream(args: argparse.Namespace, client: EzvizClient) -> int:
         refresh_vtm=not args.no_refresh_vtm,
         timeout=args.timeout,
     ) as stream:
+        if args.stream_action == "dump":
+            stream.start()
+            if args.output == "-":
+                _write_stream_payloads(
+                    stream,
+                    sys.stdout.buffer,
+                    max_packets=args.max_packets,
+                    allow_encrypted=args.allow_encrypted,
+                )
+            else:
+                with Path(args.output).open("wb") as output:
+                    _write_stream_payloads(
+                        stream,
+                        output,
+                        max_packets=args.max_packets,
+                        allow_encrypted=args.allow_encrypted,
+                    )
+            return 0
+
         events = [
             event.as_dict()
             for event in stream.trace_packets(max_packets=args.max_packets)

--- a/pyezvizapi/__main__.py
+++ b/pyezvizapi/__main__.py
@@ -15,6 +15,7 @@ from pathlib import Path
 import subprocess
 import sys
 from threading import Thread
+import time
 from typing import Any, BinaryIO, cast
 from urllib.parse import urlparse
 
@@ -42,6 +43,54 @@ class StreamProxyConfig:
     ffmpeg_path: str
     allow_encrypted: bool
     max_packets: int | None
+
+
+def _parse_duration_seconds(value: str) -> float | None:
+    """Parse a CLI duration value into seconds."""
+
+    text = value.strip().lower()
+    if text in {"0", "none", "unlimited"}:
+        return None
+
+    multipliers = {
+        "s": 1.0,
+        "sec": 1.0,
+        "secs": 1.0,
+        "second": 1.0,
+        "seconds": 1.0,
+        "m": 60.0,
+        "min": 60.0,
+        "mins": 60.0,
+        "minute": 60.0,
+        "minutes": 60.0,
+        "h": 3600.0,
+        "hr": 3600.0,
+        "hrs": 3600.0,
+        "hour": 3600.0,
+        "hours": 3600.0,
+    }
+
+    multiplier = 1.0
+    for suffix, suffix_multiplier in sorted(
+        multipliers.items(),
+        key=lambda item: len(item[0]),
+        reverse=True,
+    ):
+        if text.endswith(suffix):
+            number = text[: -len(suffix)].strip()
+            multiplier = suffix_multiplier
+            break
+    else:
+        number = text
+
+    try:
+        duration = float(number) * multiplier
+    except ValueError as err:
+        raise argparse.ArgumentTypeError(f"invalid duration: {value}") from err
+
+    if duration <= 0:
+        raise argparse.ArgumentTypeError("duration must be positive, or 0 for unlimited")
+    return duration
 
 
 def _setup_logging(debug: bool) -> None:
@@ -380,6 +429,15 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help="Stop after this many stream packets (default: run until interrupted)",
     )
     parser_stream_dump.add_argument(
+        "--duration",
+        type=_parse_duration_seconds,
+        default=60.0,
+        help=(
+            "Stop after this capture duration; accepts seconds or units like "
+            "30s/1m/2min (default: 1m, use 0 for unlimited)"
+        ),
+    )
+    parser_stream_dump.add_argument(
         "--timeout",
         type=float,
         default=10.0,
@@ -406,6 +464,17 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "--output",
         default="-",
         help="Output file for stream bytes, or '-' for stdout (default: -)",
+    )
+    parser_stream_dump.add_argument(
+        "--format",
+        choices=("mpegts", "raw"),
+        default="mpegts",
+        help="Output container format: mpegts is VLC-friendly and remuxes with codec copy; raw writes VTM payloads unchanged (default: mpegts)",
+    )
+    parser_stream_dump.add_argument(
+        "--ffmpeg-path",
+        default="ffmpeg",
+        help="FFmpeg executable to use for MPEG-TS remuxing (default: ffmpeg)",
     )
     parser_stream_dump.add_argument(
         "--allow-encrypted",
@@ -776,12 +845,20 @@ def _write_stream_payloads(
     output: BinaryIO,
     *,
     max_packets: int | None,
+    duration_seconds: float | None = None,
     allow_encrypted: bool,
     flush_each: bool = False,
+    monotonic: Any = time.monotonic,
 ) -> None:
     """Write VTM stream packet bodies to a binary file-like object."""
 
+    deadline = None
+    if duration_seconds is not None:
+        deadline = monotonic() + duration_seconds
+
     for packet in stream.iter_packets(max_packets=max_packets):
+        if deadline is not None and monotonic() >= deadline:
+            break
         if packet.encrypted and not allow_encrypted:
             raise PyEzvizError(
                 "Received encrypted VTM stream packet; "
@@ -799,6 +876,7 @@ def _remux_stream_payloads_to_mpegts(
     *,
     ffmpeg_path: str,
     max_packets: int | None,
+    duration_seconds: float | None = None,
     allow_encrypted: bool,
 ) -> None:
     """Remux VTM MPEG-PS payloads to MPEG-TS and write them to output."""
@@ -836,6 +914,7 @@ def _remux_stream_payloads_to_mpegts(
                 stream,
                 cast(BinaryIO, stdin),
                 max_packets=max_packets,
+                duration_seconds=duration_seconds,
                 allow_encrypted=allow_encrypted,
                 flush_each=True,
             )
@@ -975,20 +1054,42 @@ def _handle_stream(args: argparse.Namespace, client: EzvizClient) -> int:
         if args.stream_action == "dump":
             stream.start()
             if args.output == "-":
-                _write_stream_payloads(
-                    stream,
-                    sys.stdout.buffer,
-                    max_packets=args.max_packets,
-                    allow_encrypted=args.allow_encrypted,
-                )
-            else:
-                with Path(args.output).open("wb") as output:
+                if args.format == "raw":
                     _write_stream_payloads(
                         stream,
-                        output,
+                        sys.stdout.buffer,
                         max_packets=args.max_packets,
+                        duration_seconds=args.duration,
                         allow_encrypted=args.allow_encrypted,
                     )
+                else:
+                    _remux_stream_payloads_to_mpegts(
+                        stream,
+                        sys.stdout.buffer,
+                        ffmpeg_path=args.ffmpeg_path,
+                        max_packets=args.max_packets,
+                        duration_seconds=args.duration,
+                        allow_encrypted=args.allow_encrypted,
+                    )
+            else:
+                with Path(args.output).open("wb") as output:
+                    if args.format == "raw":
+                        _write_stream_payloads(
+                            stream,
+                            output,
+                            max_packets=args.max_packets,
+                            duration_seconds=args.duration,
+                            allow_encrypted=args.allow_encrypted,
+                        )
+                    else:
+                        _remux_stream_payloads_to_mpegts(
+                            stream,
+                            output,
+                            ffmpeg_path=args.ffmpeg_path,
+                            max_packets=args.max_packets,
+                            duration_seconds=args.duration,
+                            allow_encrypted=args.allow_encrypted,
+                        )
             return 0
 
         events = [

--- a/pyezvizapi/__main__.py
+++ b/pyezvizapi/__main__.py
@@ -1068,7 +1068,15 @@ def _serve_stream_proxy(args: argparse.Namespace, client: EzvizClient) -> None:
         def log_message(self, format: str, *args: Any) -> None:
             _LOGGER.info("stream proxy: " + format, *args)
 
-    server = ThreadingHTTPServer((args.listen_host, args.listen_port), StreamProxyHandler)
+    try:
+        server = ThreadingHTTPServer(
+            (args.listen_host, args.listen_port),
+            StreamProxyHandler,
+        )
+    except OSError as err:
+        raise PyEzvizError(
+            f"Could not bind stream proxy to {args.listen_host}:{args.listen_port}: {err}"
+        ) from err
     url = f"http://{args.listen_host}:{args.listen_port}{config.path}"
     _LOGGER.info("Serving VTM stream proxy at %s", url)
     try:

--- a/pyezvizapi/__main__.py
+++ b/pyezvizapi/__main__.py
@@ -881,32 +881,35 @@ def _remux_stream_payloads_to_mpegts(
 ) -> None:
     """Remux VTM MPEG-PS payloads to MPEG-TS and write them to output."""
 
-    process = subprocess.Popen(
-        [
-            ffmpeg_path,
-            "-hide_banner",
-            "-loglevel",
-            "error",
-            "-f",
-            "mpeg",
-            "-i",
-            "pipe:0",
-            "-c",
-            "copy",
-            "-f",
-            "mpegts",
-            "pipe:1",
-        ],
-        stdin=subprocess.PIPE,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.DEVNULL,
-    )
+    try:
+        process = subprocess.Popen(
+            [
+                ffmpeg_path,
+                "-hide_banner",
+                "-loglevel",
+                "error",
+                "-f",
+                "mpeg",
+                "-i",
+                "pipe:0",
+                "-c",
+                "copy",
+                "-f",
+                "mpegts",
+                "pipe:1",
+            ],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+        )
+    except OSError as err:
+        raise PyEzvizError(f"Could not launch FFmpeg at {ffmpeg_path!r}: {err}") from err
     stdin = process.stdin
     stdout = process.stdout
     if stdin is None or stdout is None:
         raise PyEzvizError("Could not open FFmpeg pipes")
 
-    writer_errors: list[BaseException] = []
+    writer_errors: list[Exception] = []
 
     def _write_input() -> None:
         try:
@@ -919,8 +922,8 @@ def _remux_stream_payloads_to_mpegts(
                 flush_each=True,
             )
         except (BrokenPipeError, ConnectionResetError):
-            pass
-        except BaseException as err:  # pragma: no cover - defensive thread handoff
+            _LOGGER.debug("FFmpeg closed its input pipe")
+        except Exception as err:  # pragma: no cover - defensive thread handoff
             writer_errors.append(err)
         finally:
             with suppress(OSError):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -642,6 +642,29 @@ def test_remux_stream_payloads_to_mpegts_pipes_payloads(tmp_path) -> None:
     assert output.getvalue() == expected_payload
 
 
+def test_remux_stream_payloads_to_mpegts_wraps_ffmpeg_launch_failure() -> None:
+    output = io.BytesIO()
+
+    class FakeStream:
+        def iter_packets(self, *, max_packets: int | None = None) -> list[VtmPacket]:
+            return []
+
+    try:
+        cli_module._remux_stream_payloads_to_mpegts(  # noqa: SLF001
+            FakeStream(),
+            output,
+            ffmpeg_path="/does/not/exist/ffmpeg",
+            max_packets=2,
+            duration_seconds=None,
+            allow_encrypted=False,
+        )
+    except PyEzvizError as err:
+        assert "Could not launch FFmpeg" in str(err)
+        assert "/does/not/exist/ffmpeg" in str(err)
+    else:
+        raise AssertionError("Expected PyEzvizError")
+
+
 def test_stream_proxy_dispatches_blocking_proxy(monkeypatch, tmp_path) -> None:
     fake_client = _install_fake_client(monkeypatch)
     calls: list[dict[str, Any]] = []

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -735,6 +735,65 @@ def test_stream_proxy_path_defaults_to_serial() -> None:
     assert cli_module._normalize_stream_proxy_path("camera.ts", "CAM123") == "/camera.ts"  # noqa: SLF001
 
 
+def test_stream_proxy_sends_error_when_ffmpeg_fails_before_headers(monkeypatch) -> None:
+    class FakeStream:
+        def __enter__(self) -> FakeStream:
+            return self
+
+        def __exit__(self, *_args: object) -> None:
+            return None
+
+        def start(self) -> None:
+            return None
+
+    class FakeHandler:
+        path = "/CAM123.ts"
+        wfile = io.BytesIO()
+        close_connection = False
+
+        def __init__(self) -> None:
+            self.responses: list[int] = []
+            self.errors: list[tuple[int, str]] = []
+
+        def send_response(self, code: int) -> None:
+            self.responses.append(code)
+
+        def send_header(self, _key: str, _value: str) -> None:
+            return None
+
+        def end_headers(self) -> None:
+            return None
+
+        def send_error(self, code: int, message: str) -> None:
+            self.errors.append((code, message))
+
+    config = cli_module.StreamProxyConfig(
+        serial="CAM123",
+        channel=1,
+        client_type=1,
+        token_index=0,
+        refresh_vtm=True,
+        timeout=None,
+        path="/CAM123.ts",
+        ffmpeg_path="/does/not/exist/ffmpeg",
+        allow_encrypted=False,
+        max_packets=None,
+    )
+
+    monkeypatch.setattr(cli_module, "open_cloud_stream", lambda *_args, **_kwargs: FakeStream())
+    monkeypatch.setattr(
+        cli_module,
+        "_open_mpegts_remux_process",
+        lambda _path: (_ for _ in ()).throw(PyEzvizError("Could not launch FFmpeg")),
+    )
+
+    handler = FakeHandler()
+    cli_module._handle_stream_proxy_get(cast(Any, handler), config, cast(Any, object()))  # noqa: SLF001
+
+    assert handler.responses == []
+    assert handler.errors == [(502, "Could not launch FFmpeg")]
+
+
 def test_unifiedmsg_table_output_handles_empty_response(monkeypatch, tmp_path, capsys) -> None:
     class UnifiedClient(_FakeClient):
         def get_device_messages_list(self, **_kwargs: Any) -> dict[str, Any]:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import argparse
 import importlib.util
 import io
 import json
@@ -792,6 +793,37 @@ def test_stream_proxy_sends_error_when_ffmpeg_fails_before_headers(monkeypatch) 
 
     assert handler.responses == []
     assert handler.errors == [(502, "Could not launch FFmpeg")]
+
+
+def test_stream_proxy_wraps_bind_failure(monkeypatch) -> None:
+    def fake_server(*_args: object, **_kwargs: object) -> None:
+        raise OSError("Address already in use")
+
+    monkeypatch.setattr(cli_module, "ThreadingHTTPServer", fake_server)
+
+    args = argparse.Namespace(
+        serial="CAM123",
+        channel=1,
+        client_type=1,
+        token_index=0,
+        no_refresh_vtm=False,
+        timeout=None,
+        path=None,
+        ffmpeg_path="ffmpeg",
+        allow_encrypted=False,
+        max_packets=None,
+        listen_host="127.0.0.1",
+        listen_port=8558,
+    )
+
+    try:
+        cli_module._serve_stream_proxy(args, cast(Any, object()))  # noqa: SLF001
+    except PyEzvizError as err:
+        message = str(err)
+        assert "Could not bind stream proxy to 127.0.0.1:8558" in message
+        assert "Address already in use" in message
+    else:
+        raise AssertionError("Expected PyEzvizError")
 
 
 def test_unifiedmsg_table_output_handles_empty_response(monkeypatch, tmp_path, capsys) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,7 +4,7 @@ import importlib.util
 import io
 import json
 import sys
-from typing import Any, ClassVar, cast
+from typing import Any, BinaryIO, ClassVar, cast
 
 from cli_fakes import (
     FakeClient as _FakeClient,
@@ -396,6 +396,8 @@ def test_stream_dump_writes_payload_bytes_to_file(monkeypatch, tmp_path) -> None
                 "--no-refresh-vtm",
                 "--output",
                 str(output_file),
+                "--format",
+                "raw",
             ]
         )
         == 0
@@ -416,6 +418,128 @@ def test_stream_dump_writes_payload_bytes_to_file(monkeypatch, tmp_path) -> None
     assert client.closed is True
     assert fake_stream.closed is True
     assert output_file.read_bytes() == expected_payload
+
+
+def test_stream_dump_defaults_to_mpegts_remux(monkeypatch, tmp_path) -> None:
+    _install_fake_client(monkeypatch)
+    expected_payload = b"mpegts"
+
+    class FakeStream:
+        def __enter__(self) -> FakeStream:
+            return self
+
+        def __exit__(self, *_exc_info: object) -> None:
+            return None
+
+        def start(self) -> None:
+            return None
+
+    calls: list[dict[str, Any]] = []
+
+    def fake_remux(
+        stream: FakeStream,
+        output: BinaryIO,
+        *,
+        ffmpeg_path: str,
+        max_packets: int | None,
+        duration_seconds: float | None,
+        allow_encrypted: bool,
+    ) -> None:
+        calls.append(
+            {
+                "stream": stream,
+                "ffmpeg_path": ffmpeg_path,
+                "max_packets": max_packets,
+                "duration_seconds": duration_seconds,
+                "allow_encrypted": allow_encrypted,
+            }
+        )
+        output.write(expected_payload)
+
+    monkeypatch.setattr(
+        cli_module,
+        "open_cloud_stream",
+        lambda *_args, **_kwargs: FakeStream(),
+    )
+    monkeypatch.setattr(cli_module, "_remux_stream_payloads_to_mpegts", fake_remux)
+    output_file = tmp_path / "stream.ts"
+
+    assert (
+        cli_module.main(
+            [
+                "--token-file",
+                _token_file(tmp_path),
+                "stream",
+                "dump",
+                "--serial",
+                "CAM123",
+                "--duration",
+                "2min",
+                "--ffmpeg-path",
+                "ffmpeg-custom",
+                "--output",
+                str(output_file),
+            ]
+        )
+        == 0
+    )
+
+    assert len(calls) == 1
+    assert calls[0]["ffmpeg_path"] == "ffmpeg-custom"
+    assert calls[0]["max_packets"] is None
+    assert calls[0]["duration_seconds"] == cli_module._parse_duration_seconds("2min")  # noqa: SLF001
+    assert calls[0]["allow_encrypted"] is False
+    assert output_file.read_bytes() == expected_payload
+
+
+def test_parse_stream_dump_duration_units() -> None:
+    cases = {
+        "30": 30.0,
+        "30s": 30.0,
+        "1m": 60.0,
+        "2min": 120.0,
+    }
+    for value, expected in cases.items():
+        assert cli_module._parse_duration_seconds(value) == expected  # noqa: SLF001
+    assert cli_module._parse_duration_seconds("0") is None  # noqa: SLF001
+
+
+def test_write_stream_payloads_stops_after_duration() -> None:
+    expected_payload = b"abc"
+
+    class FakeStream:
+        def iter_packets(self, *, max_packets: int | None = None) -> list[VtmPacket]:
+            assert max_packets is None
+            return [
+                VtmPacket(
+                    channel=VtmChannel.STREAM,
+                    length=3,
+                    sequence=1,
+                    message_code=0,
+                    body=b"abc",
+                ),
+                VtmPacket(
+                    channel=VtmChannel.STREAM,
+                    length=3,
+                    sequence=2,
+                    message_code=0,
+                    body=b"def",
+                ),
+            ]
+
+    times = iter([100.0, 100.5, 101.5])
+    output = io.BytesIO()
+
+    cli_module._write_stream_payloads(  # noqa: SLF001
+        FakeStream(),
+        output,
+        max_packets=None,
+        duration_seconds=1.0,
+        allow_encrypted=False,
+        monotonic=lambda: next(times),
+    )
+
+    assert output.getvalue() == expected_payload
 
 
 def test_stream_dump_rejects_encrypted_packets_by_default(
@@ -463,6 +587,8 @@ def test_stream_dump_rejects_encrypted_packets_by_default(
                 "1",
                 "--output",
                 str(tmp_path / "stream.bin"),
+                "--format",
+                "raw",
             ]
         )
         == 1
@@ -509,6 +635,7 @@ def test_remux_stream_payloads_to_mpegts_pipes_payloads(tmp_path) -> None:
         output,
         ffmpeg_path=str(fake_ffmpeg),
         max_packets=2,
+        duration_seconds=None,
         allow_encrypted=False,
     )
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -799,7 +799,7 @@ def test_stream_proxy_wraps_bind_failure(monkeypatch) -> None:
     def fake_server(*_args: object, **_kwargs: object) -> None:
         raise OSError("Address already in use")
 
-    monkeypatch.setattr(cli_module, "ThreadingHTTPServer", fake_server)
+    monkeypatch.setattr(cli_module, "StreamProxyHTTPServer", fake_server)
 
     args = argparse.Namespace(
         serial="CAM123",
@@ -824,6 +824,11 @@ def test_stream_proxy_wraps_bind_failure(monkeypatch) -> None:
         assert "Address already in use" in message
     else:
         raise AssertionError("Expected PyEzvizError")
+
+
+def test_stream_proxy_server_does_not_block_on_active_stream_threads() -> None:
+    assert cli_module.StreamProxyHTTPServer.daemon_threads is True
+    assert cli_module.StreamProxyHTTPServer.block_on_close is False
 
 
 def test_unifiedmsg_table_output_handles_empty_response(monkeypatch, tmp_path, capsys) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import importlib.util
+import io
 import json
+import sys
 from typing import Any, ClassVar, cast
 
 from cli_fakes import (
@@ -13,6 +15,7 @@ from cli_fakes import (
 
 import pyezvizapi.__main__ as cli_module
 from pyezvizapi.exceptions import EzvizAuthVerificationCode, PyEzvizError
+from pyezvizapi.stream import VtmChannel, VtmPacket
 
 _format_cell = cli_module._format_cell  # noqa: SLF001
 _write_table = cli_module._write_table  # noqa: SLF001
@@ -325,6 +328,261 @@ def test_stream_trace_outputs_sanitized_json_lines(monkeypatch, tmp_path, capsys
     assert output[0]["message_name"] == "STREAMINFO_RSP"
     assert output[1]["encrypted"] is True
     assert "body" not in output[1]
+
+
+def test_stream_dump_writes_payload_bytes_to_file(monkeypatch, tmp_path) -> None:
+    fake_client = _install_fake_client(monkeypatch)
+    expected_payload = b"abcdef"
+
+    class FakeStream:
+        def __init__(self) -> None:
+            self.closed = False
+            self.started = False
+
+        def __enter__(self) -> FakeStream:
+            return self
+
+        def __exit__(self, *_exc_info: object) -> None:
+            self.closed = True
+
+        def start(self) -> None:
+            self.started = True
+
+        def iter_packets(self, *, max_packets: int | None = None) -> list[VtmPacket]:
+            assert self.started is True
+            assert max_packets == 2
+            return [
+                VtmPacket(
+                    channel=VtmChannel.STREAM,
+                    length=3,
+                    sequence=1,
+                    message_code=0,
+                    body=b"abc",
+                ),
+                VtmPacket(
+                    channel=VtmChannel.STREAM,
+                    length=3,
+                    sequence=2,
+                    message_code=0,
+                    body=b"def",
+                ),
+            ]
+
+    calls: list[dict[str, Any]] = []
+    fake_stream = FakeStream()
+
+    def fake_open_cloud_stream(client: Any, serial: str, **kwargs: Any) -> FakeStream:
+        calls.append({"client": client, "serial": serial, **kwargs})
+        return fake_stream
+
+    monkeypatch.setattr(cli_module, "open_cloud_stream", fake_open_cloud_stream)
+    output_file = tmp_path / "stream.bin"
+
+    assert (
+        cli_module.main(
+            [
+                "--token-file",
+                _token_file(tmp_path),
+                "stream",
+                "dump",
+                "--serial",
+                "CAM123",
+                "--channel",
+                "2",
+                "--max-packets",
+                "2",
+                "--timeout",
+                "3",
+                "--no-refresh-vtm",
+                "--output",
+                str(output_file),
+            ]
+        )
+        == 0
+    )
+
+    client = fake_client.instances[0]
+    assert calls == [
+        {
+            "client": client,
+            "serial": "CAM123",
+            "channel": 2,
+            "client_type": 9,
+            "token_index": 0,
+            "refresh_vtm": False,
+            "timeout": 3.0,
+        }
+    ]
+    assert client.closed is True
+    assert fake_stream.closed is True
+    assert output_file.read_bytes() == expected_payload
+
+
+def test_stream_dump_rejects_encrypted_packets_by_default(
+    monkeypatch, tmp_path, caplog
+) -> None:
+    _install_fake_client(monkeypatch)
+
+    class FakeStream:
+        def __enter__(self) -> FakeStream:
+            return self
+
+        def __exit__(self, *_exc_info: object) -> None:
+            return None
+
+        def start(self) -> None:
+            return None
+
+        def iter_packets(self, *, max_packets: int | None = None) -> list[VtmPacket]:
+            return [
+                VtmPacket(
+                    channel=VtmChannel.ENCRYPTED_STREAM,
+                    length=6,
+                    sequence=1,
+                    message_code=0,
+                    body=b"secret",
+                )
+            ]
+
+    monkeypatch.setattr(
+        cli_module,
+        "open_cloud_stream",
+        lambda *_args, **_kwargs: FakeStream(),
+    )
+
+    assert (
+        cli_module.main(
+            [
+                "--token-file",
+                _token_file(tmp_path),
+                "stream",
+                "dump",
+                "--serial",
+                "CAM123",
+                "--max-packets",
+                "1",
+                "--output",
+                str(tmp_path / "stream.bin"),
+            ]
+        )
+        == 1
+    )
+
+    assert "media decryption is not implemented" in caplog.text
+
+
+def test_remux_stream_payloads_to_mpegts_pipes_payloads(tmp_path) -> None:
+    expected_payload = b"abcdef"
+    fake_ffmpeg = tmp_path / "fake-ffmpeg"
+    fake_ffmpeg.write_text(
+        "#!/usr/bin/env python3\n"
+        "import sys\n"
+        "sys.stdout.buffer.write(sys.stdin.buffer.read())\n",
+        encoding="utf-8",
+    )
+    fake_ffmpeg.chmod(0o755)
+
+    class FakeStream:
+        def iter_packets(self, *, max_packets: int | None = None) -> list[VtmPacket]:
+            assert max_packets == 2
+            return [
+                VtmPacket(
+                    channel=VtmChannel.STREAM,
+                    length=3,
+                    sequence=1,
+                    message_code=0,
+                    body=b"abc",
+                ),
+                VtmPacket(
+                    channel=VtmChannel.STREAM,
+                    length=3,
+                    sequence=2,
+                    message_code=0,
+                    body=b"def",
+                ),
+            ]
+
+    output = io.BytesIO()
+
+    cli_module._remux_stream_payloads_to_mpegts(  # noqa: SLF001
+        FakeStream(),
+        output,
+        ffmpeg_path=str(fake_ffmpeg),
+        max_packets=2,
+        allow_encrypted=False,
+    )
+
+    assert output.getvalue() == expected_payload
+
+
+def test_stream_proxy_dispatches_blocking_proxy(monkeypatch, tmp_path) -> None:
+    fake_client = _install_fake_client(monkeypatch)
+    calls: list[dict[str, Any]] = []
+
+    def fake_serve_stream_proxy(args: Any, client: _FakeClient) -> None:
+        calls.append(
+            {
+                "client": client,
+                "serial": args.serial,
+                "channel": args.channel,
+                "listen_host": args.listen_host,
+                "listen_port": args.listen_port,
+                "path": args.path,
+                "ffmpeg_path": args.ffmpeg_path,
+                "refresh_vtm": not args.no_refresh_vtm,
+                "max_packets": args.max_packets,
+            }
+        )
+
+    monkeypatch.setattr(cli_module, "_serve_stream_proxy", fake_serve_stream_proxy)
+
+    assert (
+        cli_module.main(
+            [
+                "--token-file",
+                _token_file(tmp_path),
+                "stream",
+                "proxy",
+                "--serial",
+                "CAM123",
+                "--channel",
+                "2",
+                "--listen-host",
+                "0.0.0.0",
+                "--listen-port",
+                "8559",
+                "--path",
+                "/camera.ts",
+                "--ffmpeg-path",
+                sys.executable,
+                "--max-packets",
+                "4",
+                "--no-refresh-vtm",
+            ]
+        )
+        == 0
+    )
+
+    client = fake_client.instances[0]
+    assert calls == [
+        {
+            "client": client,
+            "serial": "CAM123",
+            "channel": 2,
+            "listen_host": "0.0.0.0",
+            "listen_port": 8559,
+            "path": "/camera.ts",
+            "ffmpeg_path": sys.executable,
+            "refresh_vtm": False,
+            "max_packets": 4,
+        }
+    ]
+    assert client.closed is True
+
+
+def test_stream_proxy_path_defaults_to_serial() -> None:
+    assert cli_module._normalize_stream_proxy_path(None, "CAM123") == "/CAM123.ts"  # noqa: SLF001
+    assert cli_module._normalize_stream_proxy_path("camera.ts", "CAM123") == "/camera.ts"  # noqa: SLF001
 
 
 def test_unifiedmsg_table_output_handles_empty_response(monkeypatch, tmp_path, capsys) -> None:


### PR DESCRIPTION
## Summary

- add experimental `pyezvizapi stream dump` support for VTM stream payload capture
- remux dumps to VLC-friendly MPEG-TS by default via FFmpeg, with `--format raw` available for unchanged payloads
- add experimental `pyezvizapi stream proxy` for a local MPEG-TS HTTP endpoint backed by a fresh VTM stream per client
- document stream trace/dump/proxy usage in the README and update the unreleased changelog

## Validation

- `.venv/bin/python -m pytest tests/test_cli.py`
- `.venv/bin/python -m pytest`
- `.venv/bin/python -m ruff check README.md CHANGELOG.md pyezvizapi/__main__.py tests/test_cli.py`
- `.venv/bin/python -m mypy pyezvizapi tests`