### PR TITLE
Fix HCNetSDK command-port media framing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ This project follows [Semantic Versioning](https://semver.org/) for published re
 
 - Fixed cloud and direct-local stream timeout handling so unreachable/offline cameras raise clear `DeviceException` errors instead of leaking raw timeouts.
 - Fixed direct-local encrypted-header decryption to preserve PES boundaries and avoid H.264/HEVC RTP payload overlap during stream remuxing.
+- Fixed HCNetSDK command-port media framing by parsing port-8000 `$` length words as little-endian total frame lengths, and added clear H.264 IDMX remuxing for those media packets.
 - Fixed partial CAS probe writes and base64 local-SDK CAS key handling.
 - Fixed `ptz_control_coordinates()` to use the app-matched `PTZManualCtrl/CtrlPTZ3DPosition` IoT action endpoint with `positionPoint.x/y`, restoring y-axis tilt coordinate moves.
 - Fixed PTZ coordinate validation to reject negative coordinate values and omitted zoom hints from point moves so focus/zoom metadata is left unchanged.
@@ -38,10 +39,9 @@ This project follows [Semantic Versioning](https://semver.org/) for published re
 - Added cloud video list/detail client helpers plus `cloud_videos` and `cloud_video_download` CLI commands for exploring and saving EZVIZ cloud clip media when the API returns a direct HTTP(S) URL.
 - Added `get_camera_ticket_info()` for the `/v3/cameras/ticketInfo` ticket used by the native cloud-storage download path.
 - Added pure-Python cloud `.tmp` PS/NAL decryption through `cloud_video_decrypt`.
-- Added pure-Python EZVIZ cloud replay download support for regular cloud-storage `streamUrl` clips, so `cloud_video_download` can fetch encrypted `.tmp` bytes without Android/Frida and decrypt them locally.
+- Added pure-Python EZVIZ cloud replay download support for regular cloud-storage `streamUrl` clips, so `cloud_video_download` can fetch encrypted `.tmp` bytes without Android tooling and decrypt them locally.
 - Added SD-card playback record helpers plus the `sdcard_videos` CLI for probing the EZVIZ app's v2/common/intelligent record-list endpoints.
 - Added alarm image download/decrypt helper support for EZVIZ/Hik encrypted snapshot payloads.
-- Added the Android/Frida native cloud-download bridge as a diagnostic-only helper under `tools/apk-re/bin`, outside the installed package CLI.
 
 ### Changed
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include LICENSE.md
 graft examples
-include tools/apk-re/bin/local-sdk-live-check
+global-exclude __pycache__/*
+global-exclude *.py[cod]

--- a/README.md
+++ b/README.md
@@ -85,6 +85,73 @@ All commands are subcommands of the module runner:
 pyezvizapi <command> [options]
 ```
 
+### save
+
+Person-friendly media save commands for scripts and Home Assistant
+`shell_command` usage. These write to local filesystem paths and print a small
+JSON result when `--json` is used.
+
+```bash
+# Save a short direct-local live clip. MPEG-TS uses FFmpeg remuxing with copy.
+pyezvizapi --token-file ezviz_token.json --json save clip \
+  --serial ABC123 --channel 1 --duration 10s \
+  --output /config/www/ezviz/front.ts
+
+# Save a direct-local encrypted battery-camera clip.
+pyezvizapi --token-file ezviz_token.json --json save clip \
+  --serial ABC123 --duration 10s --decrypt-video \
+  --output /config/www/ezviz/front.ts
+
+# Save from the full local HCNetSDK command-port media path on port 8000.
+pyezvizapi --token-file ezviz_token.json --json save clip \
+  --source hcnetsdk-command-port --serial ABC123 --host 192.0.2.10 \
+  --hcnetsdk-command-frames-file /config/ezviz/ABC123-port8000-frames.json \
+  --duration 10s --output /config/www/ezviz/front.ts
+
+# Trigger a snapshot and save the returned image locally.
+pyezvizapi --token-file ezviz_token.json --json save image \
+  --serial ABC123 --channel 1 \
+  --output /config/www/ezviz/front.jpg
+
+# Save a known alarm/snapshot image URL without triggering a new capture.
+pyezvizapi --token-file ezviz_token.json --json save image \
+  --serial ABC123 --image-url "https://..." \
+  --output /config/www/ezviz/alarm.jpg
+```
+
+`save clip` uses the direct-local `9010/9020` SDK path and fetches the LAN
+endpoint/CAS tuple from the authenticated client by default. Use
+`--source hcnetsdk-command-port` for the full local port-8000 media path when
+you have the complete HCNetSDK bootstrap command frames from a trusted local
+implementation; the release package consumes those frames and keeps APK/Frida
+tooling under `tools/apk-re`. `save image` triggers the camera capture endpoint
+unless `--image-url` is supplied, then downloads and decrypts EZVIZ encrypted
+image payloads when needed.
+
+Integrations can use the same behavior directly from `client.py` without
+shelling out:
+
+```python
+result = client.save_clip(
+    "ABC123",
+    "/config/www/ezviz/front.ts",
+    duration_seconds=10,
+    source="local-sdk",
+)
+
+image = client.save_image(
+    "ABC123",
+    "/config/www/ezviz/front.jpg",
+    channel=1,
+)
+```
+
+Use `source="hcnetsdk-command-port"`, `host="192.0.2.10"`, `command_port=8000`,
+and `hcnetsdk_command_frames=(...)` when an integration already has the complete
+full-local HCNetSDK port-8000 command bootstrap frames. Both helpers accept a
+local path or a binary file object and return a small result dict with the output
+name, byte count, content type, and source metadata.
+
 ### devices
 
 - Actions: `device`, `status`, `switch`, `connection`
@@ -226,8 +293,9 @@ packets.
 This is separate from the proprietary HCNetSDK command protocol on port `8000`.
 `pyezvizapi` includes native-Python framing/remux primitives for caller-supplied
 command-port frames, including the port-8000 `$` media length format and clear
-H.264 IDMX payloads. A standalone pure-Python `8000` login/player implementation
-is not shipped yet.
+H.264 IDMX payloads. The person-facing `save clip --source
+hcnetsdk-command-port` wrapper can consume those complete command frames and
+write a local MPEG-TS clip.
 
 ### cloud_videos
 

--- a/README.md
+++ b/README.md
@@ -223,26 +223,11 @@ captures must use a bounded `duration_seconds` or `max_packets` value; the decry
 transform buffers MPEG-PS data so it can handle NALs split across local RTP
 packets.
 
-For live regression checks from a source checkout while working on the
-direct-local path, use the operator harness under
-\`tools/apk-re/bin/local-sdk-live-check\`. It forwards your local-sdk-dump
-arguments, captures a short MPEG-TS sample, runs FFprobe, extracts one JPEG frame
-with FFmpeg, and prints sanitized JSON with the artifact paths and detected
-streams:
-
-    uv run tools/apk-re/bin/local-sdk-live-check --duration 5s --output-dir tmp/local-sdk-check -- \
-      --credentials-file local-sdk-credentials.json \
-      --decrypt-video --decrypt-codec encrypted-header
-
-The harness owns output, metadata, duration, format, and FFmpeg path arguments so
-it can keep the validation artifacts predictable. It does not print forwarded
-arguments, request bodies, keys, operation codes, UUIDs, timestamps, or payload
-bytes.
-
 This is separate from the proprietary HCNetSDK command protocol on port `8000`.
-That app path has been traced, but a standalone pure-Python `8000` login/player
-implementation still needs more packet-level reverse engineering or native SDK
-bindings.
+`pyezvizapi` includes native-Python framing/remux primitives for caller-supplied
+command-port frames, including the port-8000 `$` media length format and clear
+H.264 IDMX payloads. A standalone pure-Python `8000` login/player implementation
+is not shipped yet.
 
 ### cloud_videos
 
@@ -434,7 +419,7 @@ contracts.
 
 ## Side Notes
 
-There is no official API documentation. Much of this is based on reverse-engineering the Ezviz mobile app (Android/iOS). Some regions operate on separate endpoints; US example: `apiius.ezvizlife.com`.
+There is no official API documentation. Much of this is inferred from Ezviz mobile app behavior (Android/iOS). Some regions operate on separate endpoints; US example: `apiius.ezvizlife.com`.
 
 Example:
 

--- a/pyezvizapi/__init__.py
+++ b/pyezvizapi/__init__.py
@@ -140,6 +140,9 @@ if TYPE_CHECKING:
         EzvizLocalSdkStreamBootstrap,
         HcNetSdkAbility,
         HcNetSdkClientInfo,
+        HcNetSdkCommandPortClient,
+        HcNetSdkCommandPortExchange,
+        HcNetSdkCommandPortStreamBootstrap,
         HcNetSdkCommandTraceSummary,
         HcNetSdkDvrCommand,
         HcNetSdkLanEndpoint,
@@ -213,6 +216,8 @@ if TYPE_CHECKING:
         read_ezviz_interleaved_rtp_frame,
         read_ezviz_interleaved_rtp_frame_after_prefix,
         read_ezviz_local_sdk_frame,
+        read_hcnetsdk_command_port_interleaved_frame_after_prefix,
+        read_hcnetsdk_tcp_frame,
         summarize_hcnetsdk_command_trace,
     )
     from .light_bulb import EzvizLightBulb
@@ -220,6 +225,7 @@ if TYPE_CHECKING:
         EzvizLocalSdkCredentials,
         EzvizLocalSdkMediaStream,
         EzvizLocalStreamPacket,
+        HcNetSdkCommandPortMediaStream,
         LocalSdkOutputFormat,
         collect_local_stream_mpegps,
         copy_hcnetsdk_real_data_to_mpegts,
@@ -229,6 +235,7 @@ if TYPE_CHECKING:
         copy_local_stream_to_mpegps,
         copy_local_stream_to_mpegts,
         get_local_sdk_stream_credentials_from_client,
+        open_hcnetsdk_command_port_stream,
         open_local_sdk_stream,
         open_local_sdk_stream_from_client,
     )

--- a/pyezvizapi/__init__.py
+++ b/pyezvizapi/__init__.py
@@ -517,6 +517,8 @@ _EXPORTS = {
     "read_ezviz_interleaved_rtp_frame": "hcnetsdk",
     "read_ezviz_interleaved_rtp_frame_after_prefix": "hcnetsdk",
     "read_ezviz_local_sdk_frame": "hcnetsdk",
+    "read_hcnetsdk_command_port_interleaved_frame_after_prefix": "hcnetsdk",
+    "read_hcnetsdk_tcp_frame": "hcnetsdk",
     "SadpDeviceInfo": "hcnetsdk",
     "summarize_vtm_packet": "stream",
     "supplement_light_available": "feature",

--- a/pyezvizapi/__init__.py
+++ b/pyezvizapi/__init__.py
@@ -362,6 +362,10 @@ _EXPORTS = {
     "EzvizLocalStreamPacket": "local_stream",
     "LocalSdkOutputFormat": "local_stream",
     "HcNetSdkClientInfo": "hcnetsdk",
+    "HcNetSdkCommandPortClient": "hcnetsdk",
+    "HcNetSdkCommandPortExchange": "hcnetsdk",
+    "HcNetSdkCommandPortMediaStream": "local_stream",
+    "HcNetSdkCommandPortStreamBootstrap": "hcnetsdk",
     "HcNetSdkCommandTraceSummary": "hcnetsdk",
     "HcNetSdkRealDataPacket": "hcnetsdk",
     "HcNetSdkRealDataType": "hcnetsdk",
@@ -528,6 +532,7 @@ _EXPORTS = {
     "copy_local_stream_to_mpegps": "local_stream",
     "copy_local_stream_to_mpegts": "local_stream",
     "get_local_sdk_stream_credentials_from_client": "local_stream",
+    "open_hcnetsdk_command_port_stream": "local_stream",
     "open_local_sdk_stream": "local_stream",
     "open_local_sdk_stream_from_client": "local_stream",
 }

--- a/pyezvizapi/__init__.py
+++ b/pyezvizapi/__init__.py
@@ -18,6 +18,8 @@ if TYPE_CHECKING:
     from .client import EzvizClient
     from .cloud_stream import (
         VtduTokenResponse,
+        copy_cloud_stream_to_mpegps,
+        copy_cloud_stream_to_mpegts,
         get_cloud_stream_info,
         get_vtdu_token_v2,
         get_vtm_info,
@@ -528,6 +530,8 @@ _EXPORTS = {
     "classify_lan_ports": "hcnetsdk",
     "collect_local_stream_mpegps": "local_stream",
     "copy_hcnetsdk_real_data_to_mpegts": "local_stream",
+    "copy_cloud_stream_to_mpegps": "cloud_stream",
+    "copy_cloud_stream_to_mpegts": "cloud_stream",
     "copy_local_sdk_stream_from_client": "local_stream",
     "copy_local_stream_to_decrypted_mpegps": "local_stream",
     "copy_local_stream_to_decrypted_mpegts": "local_stream",

--- a/pyezvizapi/__main__.py
+++ b/pyezvizapi/__main__.py
@@ -617,11 +617,11 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser_save_clip.add_argument("--serial", required=True, help="camera SERIAL")
     parser_save_clip.add_argument(
         "--source",
-        choices=("local-sdk", "hcnetsdk-command-port"),
+        choices=("local-sdk", "cloud", "hcnetsdk-command-port"),
         default="local-sdk",
         help=(
-            "Local source to use: direct 9010/9020 SDK or full HCNetSDK "
-            "command-port media on port 8000 (default: local-sdk)"
+            "Source to use: direct 9010/9020 SDK, VTM cloud live stream, or "
+            "full HCNetSDK command-port media on port 8000 (default: local-sdk)"
         ),
     )
     parser_save_clip.add_argument(
@@ -722,6 +722,23 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
             "Comma-separated booleans controlling whether to read a response "
             "after each HCNetSDK command frame (default: read after every frame)."
         ),
+    )
+    parser_save_clip.add_argument(
+        "--client-type",
+        type=int,
+        default=9,
+        help="VTM client type for --source cloud (default: 9)",
+    )
+    parser_save_clip.add_argument(
+        "--token-index",
+        type=int,
+        default=0,
+        help="VTDU token index for --source cloud (default: 0)",
+    )
+    parser_save_clip.add_argument(
+        "--no-refresh-vtm",
+        action="store_true",
+        help="Use pagelist VTM metadata without refreshing it for --source cloud",
     )
 
     parser_save_image = subparsers_save.add_parser(
@@ -1914,25 +1931,32 @@ def _handle_save_clip(args: argparse.Namespace, client: EzvizClient) -> int:
         if command_frames is not None
         else True
     )
-    result = client.save_clip(
-        args.serial,
-        args.output,
-        source=args.source,
-        output_format=args.format,
-        duration_seconds=args.duration,
-        max_packets=args.max_packets,
-        channel=args.channel,
-        ffmpeg_path=args.ffmpeg_path,
-        decrypt_video=args.decrypt_video,
-        nalu_header_size=_codec_nalu_header_size(args.decrypt_codec),
-        cas_serial=args.cas_serial,
-        timeout=args.timeout,
-        smscode=args.sms_code,
-        host=args.host,
-        command_port=args.command_port,
-        hcnetsdk_command_frames=command_frames,
-        hcnetsdk_read_response_after_each=read_response_after_each,
-    )
+    save_kwargs: dict[str, Any] = {
+        "source": args.source,
+        "output_format": args.format,
+        "duration_seconds": args.duration,
+        "max_packets": args.max_packets,
+        "channel": args.channel,
+        "ffmpeg_path": args.ffmpeg_path,
+        "decrypt_video": args.decrypt_video,
+        "nalu_header_size": _codec_nalu_header_size(args.decrypt_codec),
+        "cas_serial": args.cas_serial,
+        "timeout": args.timeout,
+        "smscode": args.sms_code,
+        "host": args.host,
+        "command_port": args.command_port,
+        "hcnetsdk_command_frames": command_frames,
+        "hcnetsdk_read_response_after_each": read_response_after_each,
+    }
+    if args.source == "cloud":
+        save_kwargs.update(
+            {
+                "cloud_client_type": args.client_type,
+                "cloud_token_index": args.token_index,
+                "cloud_refresh_vtm": not args.no_refresh_vtm,
+            }
+        )
+    result = client.save_clip(args.serial, args.output, **save_kwargs)
     _write_save_result(args, result)
     return 0
 

--- a/pyezvizapi/__main__.py
+++ b/pyezvizapi/__main__.py
@@ -6,7 +6,7 @@ Small utility CLI for testing and scripting Ezviz operations.
 from __future__ import annotations
 
 import argparse
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
 from contextlib import suppress
 from dataclasses import dataclass
 import datetime as dt
@@ -605,6 +605,155 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         ),
     )
 
+    parser_save = subparsers.add_parser(
+        "save",
+        help="Save a local live clip or camera image to a file",
+    )
+    subparsers_save = parser_save.add_subparsers(dest="save_action")
+    parser_save_clip = subparsers_save.add_parser(
+        "clip",
+        help="Save a direct-local camera clip to a local file",
+    )
+    parser_save_clip.add_argument("--serial", required=True, help="camera SERIAL")
+    parser_save_clip.add_argument(
+        "--source",
+        choices=("local-sdk", "hcnetsdk-command-port"),
+        default="local-sdk",
+        help=(
+            "Local source to use: direct 9010/9020 SDK or full HCNetSDK "
+            "command-port media on port 8000 (default: local-sdk)"
+        ),
+    )
+    parser_save_clip.add_argument(
+        "--channel",
+        type=int,
+        default=1,
+        help="Camera channel number (default: 1)",
+    )
+    parser_save_clip.add_argument(
+        "--output",
+        required=True,
+        help="Local output path for the clip",
+    )
+    parser_save_clip.add_argument(
+        "--duration",
+        type=_parse_duration_seconds,
+        default=10.0,
+        help="Capture duration; accepts seconds or units like 10s/1m (default: 10s)",
+    )
+    parser_save_clip.add_argument(
+        "--max-packets",
+        type=int,
+        default=None,
+        help="Optional packet limit in addition to --duration",
+    )
+    parser_save_clip.add_argument(
+        "--format",
+        choices=("mpegts", "mpegps"),
+        default="mpegts",
+        help="Output container: MPEG-TS is easiest for FFmpeg/Home Assistant (default: mpegts)",
+    )
+    parser_save_clip.add_argument(
+        "--ffmpeg-path",
+        default="ffmpeg",
+        help="FFmpeg executable to use for MPEG-TS remuxing (default: ffmpeg)",
+    )
+    parser_save_clip.add_argument(
+        "--decrypt-video",
+        action="store_true",
+        help="Decrypt encrypted local video before writing/remuxing",
+    )
+    parser_save_clip.add_argument(
+        "--decrypt-codec",
+        choices=(
+            "auto",
+            "hevc",
+            "hevc-encrypted-header",
+            "h264",
+            "h264-clear-header",
+            "h264-encrypted-header",
+            "encrypted-header",
+        ),
+        default="encrypted-header",
+        help="Video codec transform for --decrypt-video (default: encrypted-header)",
+    )
+    parser_save_clip.add_argument(
+        "--cas-serial",
+        help="Device serial to send to cloud CAS when it differs from --serial",
+    )
+    parser_save_clip.add_argument(
+        "--timeout",
+        type=float,
+        default=10.0,
+        help="Local socket timeout in seconds (default: 10)",
+    )
+    parser_save_clip.add_argument(
+        "--sms-code",
+        help="Optional MFA/elevation code for media key retrieval",
+    )
+    parser_save_clip.add_argument(
+        "--host",
+        help="Camera LAN address for --source hcnetsdk-command-port",
+    )
+    parser_save_clip.add_argument(
+        "--command-port",
+        type=int,
+        help="Camera command port for --source hcnetsdk-command-port (default: 8000)",
+    )
+    parser_save_clip.add_argument(
+        "--hcnetsdk-command-frame-hex",
+        action="append",
+        default=[],
+        help=(
+            "One complete port-8000 HCNetSDK command frame as hex. May be "
+            "passed more than once."
+        ),
+    )
+    parser_save_clip.add_argument(
+        "--hcnetsdk-command-frames-file",
+        help=(
+            "JSON or text file containing complete port-8000 command frame hex "
+            "values. JSON may be a list or an object with command_frames/frames."
+        ),
+    )
+    parser_save_clip.add_argument(
+        "--hcnetsdk-read-responses",
+        help=(
+            "Comma-separated booleans controlling whether to read a response "
+            "after each HCNetSDK command frame (default: read after every frame)."
+        ),
+    )
+
+    parser_save_image = subparsers_save.add_parser(
+        "image",
+        help="Capture or download a camera image to a local file",
+    )
+    parser_save_image.add_argument("--serial", required=True, help="camera SERIAL")
+    parser_save_image.add_argument(
+        "--channel",
+        type=int,
+        default=1,
+        help="Camera channel number (default: 1)",
+    )
+    parser_save_image.add_argument(
+        "--output",
+        required=True,
+        help="Local output path for the image",
+    )
+    parser_save_image.add_argument(
+        "--image-url",
+        help="Download this existing EZVIZ image URL instead of triggering capture",
+    )
+    parser_save_image.add_argument(
+        "--no-decrypt",
+        action="store_true",
+        help="Write encrypted image bytes as-is instead of decrypting when needed",
+    )
+    parser_save_image.add_argument(
+        "--sms-code",
+        help="Optional MFA/elevation code for encrypted image key retrieval",
+    )
+
     parser_stream = subparsers.add_parser(
         "stream",
         help="Experimental VTM cloud stream helpers",
@@ -1077,10 +1226,17 @@ def _action_requires_service_urls(args: argparse.Namespace) -> bool:
     """Return True when the selected CLI path needs CAS service metadata."""
 
     return bool(
-        args.action == "stream"
-        and (
-            args.stream_action == "local-sdk-keys"
-            or (args.stream_action == "local-sdk-dump" and args.fetch_cas)
+        (
+            args.action == "stream"
+            and (
+                args.stream_action == "local-sdk-keys"
+                or (args.stream_action == "local-sdk-dump" and args.fetch_cas)
+            )
+        )
+        or (
+            args.action == "save"
+            and getattr(args, "save_action", None) == "clip"
+            and getattr(args, "source", None) == "local-sdk"
         )
     )
 
@@ -1734,6 +1890,169 @@ def _handle_cloud_video_decrypt(
     else:
         sys.stdout.write(f"Wrote decrypted cloud video to {output_path}\n")
     return 0
+
+
+def _write_save_result(args: argparse.Namespace, result: dict[str, Any]) -> None:
+    """Write a human or JSON result for save commands."""
+
+    if args.json:
+        _write_json(result)
+    else:
+        sys.stdout.write(f"Wrote {result['bytes']} bytes to {result['output']}\n")
+
+
+def _handle_save_clip(args: argparse.Namespace, client: EzvizClient) -> int:
+    """Save a short direct-local camera clip to disk."""
+
+    command_frames = (
+        _hcnetsdk_command_frames_from_args(args)
+        if args.source == "hcnetsdk-command-port"
+        else None
+    )
+    read_response_after_each = (
+        _hcnetsdk_read_response_policy(args, len(command_frames or ()))
+        if command_frames is not None
+        else True
+    )
+    result = client.save_clip(
+        args.serial,
+        args.output,
+        source=args.source,
+        output_format=args.format,
+        duration_seconds=args.duration,
+        max_packets=args.max_packets,
+        channel=args.channel,
+        ffmpeg_path=args.ffmpeg_path,
+        decrypt_video=args.decrypt_video,
+        nalu_header_size=_codec_nalu_header_size(args.decrypt_codec),
+        cas_serial=args.cas_serial,
+        timeout=args.timeout,
+        smscode=args.sms_code,
+        host=args.host,
+        command_port=args.command_port,
+        hcnetsdk_command_frames=command_frames,
+        hcnetsdk_read_response_after_each=read_response_after_each,
+    )
+    _write_save_result(args, result)
+    return 0
+
+
+def _hcnetsdk_command_frames_from_args(args: argparse.Namespace) -> tuple[bytes, ...]:
+    """Load complete command-port frames from CLI hex values or a file."""
+
+    frame_hex_values = list(getattr(args, "hcnetsdk_command_frame_hex", []) or [])
+    frames_file = getattr(args, "hcnetsdk_command_frames_file", None)
+    if frames_file:
+        frame_hex_values.extend(_hcnetsdk_command_frame_hex_values_from_file(frames_file))
+    frames = tuple(_bytes_from_hex_value(value) for value in frame_hex_values)
+    if not frames:
+        raise PyEzvizError(
+            "--source hcnetsdk-command-port requires --hcnetsdk-command-frame-hex "
+            "or --hcnetsdk-command-frames-file"
+        )
+    return frames
+
+
+def _hcnetsdk_command_frame_hex_values_from_file(path: str) -> list[str]:
+    """Read command-frame hex values from JSON or text."""
+
+    text = Path(path).read_text(encoding="utf-8")
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError:
+        return [
+            line.split("#", 1)[0].strip()
+            for line in text.splitlines()
+            if line.split("#", 1)[0].strip()
+        ]
+    return list(_iter_hcnetsdk_command_frame_hex_values(data))
+
+
+def _iter_hcnetsdk_command_frame_hex_values(value: Any) -> Iterator[str]:
+    """Yield command-frame hex strings from simple JSON shapes."""
+
+    if isinstance(value, str):
+        yield value
+        return
+    if isinstance(value, list):
+        for item in value:
+            yield from _iter_hcnetsdk_command_frame_hex_values(item)
+        return
+    if isinstance(value, dict):
+        for key in (
+            "hex",
+            "frame_hex",
+            "frameHex",
+            "command_frame_hex",
+            "commandFrameHex",
+        ):
+            item = value.get(key)
+            if isinstance(item, str):
+                yield item
+        for key in ("command_frames", "commandFrames", "frames"):
+            item = value.get(key)
+            if isinstance(item, list):
+                yield from _iter_hcnetsdk_command_frame_hex_values(item)
+
+
+def _bytes_from_hex_value(value: str) -> bytes:
+    """Decode a user-supplied hex byte string."""
+
+    normalized = value.strip().replace(" ", "").replace(":", "").replace("-", "")
+    if normalized.startswith(("0x", "0X")):
+        normalized = normalized[2:]
+    try:
+        return bytes.fromhex(normalized)
+    except ValueError as err:
+        raise PyEzvizError("Invalid HCNetSDK command frame hex") from err
+
+
+def _hcnetsdk_read_response_policy(
+    args: argparse.Namespace,
+    frame_count: int,
+) -> bool | tuple[bool, ...]:
+    """Return response-read policy for command-port bootstrapping."""
+
+    value = getattr(args, "hcnetsdk_read_responses", None)
+    if not value:
+        return True
+    parts = [part.strip().lower() for part in value.split(",") if part.strip()]
+    flags = tuple(part in {"1", "true", "yes", "y"} for part in parts)
+    if len(flags) != frame_count:
+        raise PyEzvizError(
+            "--hcnetsdk-read-responses must include one boolean per command frame"
+        )
+    valid_values = {"1", "0", "true", "false", "yes", "no", "y", "n"}
+    unknown = [part for part in parts if part not in valid_values]
+    if unknown:
+        raise PyEzvizError("Invalid --hcnetsdk-read-responses value")
+    return flags
+
+
+def _handle_save_image(args: argparse.Namespace, client: EzvizClient) -> int:
+    """Save a camera image to disk, triggering capture when no URL is supplied."""
+
+    result = client.save_image(
+        args.serial,
+        args.output,
+        channel=args.channel,
+        image_url=args.image_url,
+        decrypt=not args.no_decrypt,
+        smscode=args.sms_code,
+    )
+    _write_save_result(args, result)
+    return 0
+
+
+def _handle_save(args: argparse.Namespace, client: EzvizClient) -> int:
+    """Handle person-friendly local save commands."""
+
+    if args.save_action == "clip":
+        return _handle_save_clip(args, client)
+    if args.save_action == "image":
+        return _handle_save_image(args, client)
+    _LOGGER.error("Action not implemented, try running with -h switch for help")
+    return 2
 
 
 def _handle_light(args: argparse.Namespace, client: EzvizClient) -> int:
@@ -3206,6 +3525,8 @@ def main(argv: list[str] | None = None) -> int:
             return _handle_mqtt(args, client)
         if args.action == "stream":
             return _handle_stream(args, client)
+        if args.action == "save":
+            return _handle_save(args, client)
         if args.action == "camera":
             return _handle_camera(args, client)
         if args.action == "pagelist":

--- a/pyezvizapi/__main__.py
+++ b/pyezvizapi/__main__.py
@@ -3500,6 +3500,14 @@ def _save_token_file(path: str | None, token: dict[str, Any]) -> None:
         _LOGGER.warning("Failed to save token file: %s", p)
 
 
+def _save_clip_can_run_without_cloud_credentials(args: argparse.Namespace) -> bool:
+    return (
+        args.action == "save"
+        and getattr(args, "save_action", None) == "clip"
+        and getattr(args, "source", None) == "hcnetsdk-command-port"
+    )
+
+
 def main(argv: list[str] | None = None) -> int:
     """CLI entry point."""
     args = _parse_args(argv)
@@ -3524,6 +3532,16 @@ def main(argv: list[str] | None = None) -> int:
         except PyEzvizError as exp:
             _LOGGER.error("%s", exp)
             return 1
+
+    if _save_clip_can_run_without_cloud_credentials(args):
+        client = EzvizClient(args.username, args.password, args.region, token=token)
+        try:
+            return _handle_save(args, client)
+        except PyEzvizError as exp:
+            _LOGGER.error("%s", exp)
+            return 1
+        finally:
+            client.close_session()
 
     if not has_session_token and (not args.username or not args.password):
         _LOGGER.error("Provide --token-file (existing) or --username/--password")

--- a/pyezvizapi/__main__.py
+++ b/pyezvizapi/__main__.py
@@ -6,7 +6,7 @@ Small utility CLI for testing and scripting Ezviz operations.
 from __future__ import annotations
 
 import argparse
-from collections.abc import Callable, Iterator
+from collections.abc import Callable, Iterator, Mapping
 from contextlib import suppress
 from dataclasses import dataclass
 import datetime as dt
@@ -1892,7 +1892,7 @@ def _handle_cloud_video_decrypt(
     return 0
 
 
-def _write_save_result(args: argparse.Namespace, result: dict[str, Any]) -> None:
+def _write_save_result(args: argparse.Namespace, result: Mapping[str, Any]) -> None:
     """Write a human or JSON result for save commands."""
 
     if args.json:

--- a/pyezvizapi/client.py
+++ b/pyezvizapi/client.py
@@ -2911,6 +2911,7 @@ class EzvizClient:
                 client_type=cloud_client_type,
                 token_index=cloud_token_index,
                 refresh_vtm=cloud_refresh_vtm,
+                smscode=smscode,
             )
         raise PyEzvizError(f"Unsupported clip source: {source}")
 
@@ -3091,6 +3092,7 @@ class EzvizClient:
         client_type: int,
         token_index: int,
         refresh_vtm: bool,
+        smscode: str | int | None,
     ) -> SaveMediaResult:
         """Save a clip through the EZVIZ VTM cloud live stream path."""
 
@@ -3113,6 +3115,7 @@ class EzvizClient:
                     decrypt_video=decrypt_video,
                     media_key=media_key,
                     nalu_header_size=nalu_header_size,
+                    smscode=smscode,
                 )
                 return
             copy_cloud_stream_to_mpegps(
@@ -3129,6 +3132,7 @@ class EzvizClient:
                 decrypt_video=decrypt_video,
                 media_key=media_key,
                 nalu_header_size=nalu_header_size,
+                smscode=smscode,
             )
 
         if isinstance(output, str | Path):

--- a/pyezvizapi/client.py
+++ b/pyezvizapi/client.py
@@ -9,7 +9,7 @@ import hashlib
 import json
 import logging
 from pathlib import Path
-from typing import Any, BinaryIO, ClassVar, NotRequired, TypedDict, cast
+from typing import Any, BinaryIO, ClassVar, Literal, NotRequired, TypedDict, cast
 from urllib.parse import urlencode
 from uuid import uuid4
 import zlib
@@ -154,8 +154,8 @@ UNIFIEDMSG_LOOKBACK_DAYS = 7
 MAX_UNIFIEDMSG_PAGES = 6
 
 JsonDict = dict[str, Any]
-ClipSource = str
-ClipOutputFormat = str
+ClipSource = Literal["local-sdk", "hcnetsdk-command-port"]
+ClipOutputFormat = Literal["mpegps", "mpegts"]
 
 
 class SaveMediaResult(TypedDict, total=False):

--- a/pyezvizapi/client.py
+++ b/pyezvizapi/client.py
@@ -8,7 +8,8 @@ import datetime as dt
 import hashlib
 import json
 import logging
-from typing import Any, ClassVar, NotRequired, TypedDict, cast
+from pathlib import Path
+from typing import Any, BinaryIO, ClassVar, NotRequired, TypedDict, cast
 from urllib.parse import urlencode
 from uuid import uuid4
 import zlib
@@ -137,6 +138,12 @@ from .exceptions import (
     PyEzvizError,
 )
 from .feature import optionals_mapping
+from .hcnetsdk import HcNetSdkLanEndpoint
+from .local_stream import (
+    copy_local_sdk_stream_from_client,
+    copy_local_stream_to_mpegts,
+    open_hcnetsdk_command_port_stream,
+)
 from .models import EzvizDeviceRecord, build_device_records_map
 from .mqtt import MQTTClient
 from .utils import convert_to_dict, decrypt_image, deep_merge
@@ -147,6 +154,26 @@ UNIFIEDMSG_LOOKBACK_DAYS = 7
 MAX_UNIFIEDMSG_PAGES = 6
 
 JsonDict = dict[str, Any]
+ClipSource = str
+ClipOutputFormat = str
+
+
+class SaveMediaResult(TypedDict, total=False):
+    """Result returned by media save helpers."""
+
+    ok: bool
+    kind: str
+    serial: str
+    channel: int
+    output: str | None
+    bytes: int | None
+    source: str
+    format: str
+    duration_seconds: float | None
+    content_type: str
+    command_port: int
+    image_url: str
+    triggered_capture: bool
 
 
 class ClientToken(TypedDict):
@@ -224,6 +251,98 @@ def _ezviz_password_digest(password: str) -> str:
 
     md5_factory = getattr(hashlib, "m" + "d5")
     return md5_factory(password.encode("utf-8"), usedforsecurity=False).hexdigest()
+
+
+def _content_type_for_output(
+    output: str | Path | BinaryIO,
+    *,
+    default: str,
+) -> str:
+    """Return a conservative content type from a path-like output."""
+
+    suffix = Path(output).suffix.lower() if isinstance(output, str | Path) else ""
+    if suffix in {".jpg", ".jpeg"}:
+        return "image/jpeg"
+    if suffix == ".png":
+        return "image/png"
+    if suffix == ".ts":
+        return "video/mp2t"
+    if suffix in {".ps", ".mpeg", ".mpg"}:
+        return "video/mpeg"
+    return default
+
+
+def _output_name(output: str | Path | BinaryIO) -> str | None:
+    """Return a stable output name for result metadata."""
+
+    if isinstance(output, str | Path):
+        return str(output)
+    name = getattr(output, "name", None)
+    return str(name) if isinstance(name, str) else None
+
+
+def _binary_position(output: BinaryIO) -> int | None:
+    """Return current binary stream position when available."""
+
+    try:
+        return int(output.tell())
+    except (AttributeError, OSError, TypeError, ValueError):
+        return None
+
+
+def _bytes_written_to_output(
+    output: str | Path | BinaryIO,
+    *,
+    start_position: int | None = None,
+) -> int | None:
+    """Return byte count for path output, or written delta for seekable streams."""
+
+    if isinstance(output, str | Path):
+        return Path(output).stat().st_size
+    end_position = _binary_position(output)
+    if start_position is None or end_position is None:
+        return None
+    return max(0, end_position - start_position)
+
+
+def _first_image_url(value: Any) -> str | None:
+    """Return the first HTTP(S) image URL from a known EZVIZ response shape."""
+
+    def normalize(candidate: Any) -> str | None:
+        if not isinstance(candidate, str):
+            return None
+        for part in candidate.split(";"):
+            text = part.strip()
+            if text.startswith(("http://", "https://")):
+                return text
+        return None
+
+    if isinstance(value, dict):
+        for key in (
+            "picUrl",
+            "picURL",
+            "imageUrl",
+            "imageURL",
+            "captureUrl",
+            "captureURL",
+            "pic",
+            "pics",
+            "image",
+            "url",
+        ):
+            found = normalize(value.get(key))
+            if found:
+                return found
+        for item in value.values():
+            found = _first_image_url(item)
+            if found:
+                return found
+    elif isinstance(value, list):
+        for item in value:
+            found = _first_image_url(item)
+            if found:
+                return found
+    return None
 
 
 class EzvizClient:
@@ -2705,6 +2824,325 @@ class EzvizClient:
                 )
             key = self.get_cam_key(serial, smscode=smscode, max_retries=max_retries)
         return decrypt_image(image_data, key)
+
+    def save_clip(  # noqa: PLR0913
+        self,
+        serial: str,
+        output: str | Path | BinaryIO,
+        *,
+        source: ClipSource = "local-sdk",
+        output_format: ClipOutputFormat = "mpegts",
+        duration_seconds: float | None = 10.0,
+        max_packets: int | None = None,
+        channel: int = 1,
+        ffmpeg_path: str = "ffmpeg",
+        decrypt_video: bool = False,
+        media_key: str | bytes | None = None,
+        nalu_header_size: int | None = 0,
+        cas_serial: str | None = None,
+        timeout: float | None = 10.0,
+        smscode: str | int | None = None,
+        host: str | None = None,
+        command_port: int | None = None,
+        hcnetsdk_command_frames: Iterable[bytes] | None = None,
+        hcnetsdk_read_response_after_each: bool | Iterable[bool] = True,
+    ) -> SaveMediaResult:
+        """Save a local camera clip to a path or binary file object.
+
+        ``source="local-sdk"`` uses the direct-local 9010/9020 SDK path.
+        ``source="hcnetsdk-command-port"`` consumes complete caller-supplied
+        port-8000 HCNetSDK bootstrap command frames, then remuxes the command
+        port media stream to MPEG-TS.
+        """
+
+        if source == "local-sdk":
+            return self._save_local_sdk_clip(
+                serial,
+                output,
+                output_format=output_format,
+                duration_seconds=duration_seconds,
+                max_packets=max_packets,
+                channel=channel,
+                ffmpeg_path=ffmpeg_path,
+                decrypt_video=decrypt_video,
+                media_key=media_key,
+                nalu_header_size=nalu_header_size,
+                cas_serial=cas_serial,
+                timeout=timeout,
+                smscode=smscode,
+            )
+        if source == "hcnetsdk-command-port":
+            return self._save_hcnetsdk_command_port_clip(
+                serial,
+                output,
+                output_format=output_format,
+                duration_seconds=duration_seconds,
+                max_packets=max_packets,
+                channel=channel,
+                ffmpeg_path=ffmpeg_path,
+                decrypt_video=decrypt_video,
+                timeout=timeout,
+                host=host,
+                command_port=command_port,
+                command_frames=hcnetsdk_command_frames,
+                read_response_after_each=hcnetsdk_read_response_after_each,
+            )
+        raise PyEzvizError(f"Unsupported clip source: {source}")
+
+    def _save_local_sdk_clip(  # noqa: PLR0913
+        self,
+        serial: str,
+        output: str | Path | BinaryIO,
+        *,
+        output_format: ClipOutputFormat,
+        duration_seconds: float | None,
+        max_packets: int | None,
+        channel: int,
+        ffmpeg_path: str,
+        decrypt_video: bool,
+        media_key: str | bytes | None,
+        nalu_header_size: int | None,
+        cas_serial: str | None,
+        timeout: float | None,
+        smscode: str | int | None,
+    ) -> SaveMediaResult:
+        """Save a clip through the direct-local SDK path."""
+
+        start_position = None
+        if isinstance(output, str | Path):
+            output_path = Path(output)
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            with output_path.open("wb") as output_file:
+                copy_local_sdk_stream_from_client(
+                    self,
+                    serial,
+                    output_file,
+                    output_format=output_format,
+                    decrypt_video=decrypt_video,
+                    media_key=media_key,
+                    nalu_header_size=nalu_header_size,
+                    channel=channel,
+                    cas_serial=cas_serial,
+                    timeout=timeout,
+                    max_packets=max_packets,
+                    duration_seconds=duration_seconds,
+                    ffmpeg_path=ffmpeg_path,
+                    smscode=smscode,
+                )
+        else:
+            start_position = _binary_position(output)
+            copy_local_sdk_stream_from_client(
+                self,
+                serial,
+                output,
+                output_format=output_format,
+                decrypt_video=decrypt_video,
+                media_key=media_key,
+                nalu_header_size=nalu_header_size,
+                channel=channel,
+                cas_serial=cas_serial,
+                timeout=timeout,
+                max_packets=max_packets,
+                duration_seconds=duration_seconds,
+                ffmpeg_path=ffmpeg_path,
+                smscode=smscode,
+            )
+
+        return {
+            "ok": True,
+            "kind": "clip",
+            "serial": serial,
+            "channel": channel,
+            "output": _output_name(output),
+            "bytes": _bytes_written_to_output(output, start_position=start_position),
+            "source": "local-sdk",
+            "format": output_format,
+            "duration_seconds": duration_seconds,
+            "content_type": _content_type_for_output(
+                output,
+                default="video/mp2t" if output_format == "mpegts" else "video/mpeg",
+            ),
+        }
+
+    def _save_hcnetsdk_command_port_clip(  # noqa: PLR0913
+        self,
+        serial: str,
+        output: str | Path | BinaryIO,
+        *,
+        output_format: ClipOutputFormat,
+        duration_seconds: float | None,
+        max_packets: int | None,
+        channel: int,
+        ffmpeg_path: str,
+        decrypt_video: bool,
+        timeout: float | None,
+        host: str | None,
+        command_port: int | None,
+        command_frames: Iterable[bytes] | None,
+        read_response_after_each: bool | Iterable[bool],
+    ) -> SaveMediaResult:
+        """Save a clip through caller-supplied port-8000 HCNetSDK frames."""
+
+        if output_format != "mpegts":
+            raise PyEzvizError(
+                "source='hcnetsdk-command-port' currently writes MPEG-TS only"
+            )
+        if decrypt_video:
+            raise PyEzvizError(
+                "decrypt_video is not needed for the clear H.264 IDMX command-port path"
+            )
+
+        frames = tuple(command_frames or ())
+        if not frames:
+            raise PyEzvizError(
+                "source='hcnetsdk-command-port' requires hcnetsdk_command_frames"
+            )
+        endpoint = self._hcnetsdk_command_port_endpoint(
+            serial,
+            host=host,
+            command_port=command_port,
+        )
+        start_position = None
+        if isinstance(output, str | Path):
+            output_path = Path(output)
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            with open_hcnetsdk_command_port_stream(
+                endpoint,
+                frames,
+                timeout=timeout,
+                read_response_after_each=read_response_after_each,
+            ) as stream, output_path.open("wb") as output_file:
+                copy_local_stream_to_mpegts(
+                    stream,
+                    output_file,
+                    ffmpeg_path=ffmpeg_path,
+                    max_packets=max_packets,
+                    duration_seconds=duration_seconds,
+                )
+        else:
+            start_position = _binary_position(output)
+            with open_hcnetsdk_command_port_stream(
+                endpoint,
+                frames,
+                timeout=timeout,
+                read_response_after_each=read_response_after_each,
+            ) as stream:
+                copy_local_stream_to_mpegts(
+                    stream,
+                    output,
+                    ffmpeg_path=ffmpeg_path,
+                    max_packets=max_packets,
+                    duration_seconds=duration_seconds,
+                )
+
+        return {
+            "ok": True,
+            "kind": "clip",
+            "serial": serial,
+            "channel": channel,
+            "output": _output_name(output),
+            "bytes": _bytes_written_to_output(output, start_position=start_position),
+            "source": "hcnetsdk-command-port",
+            "format": output_format,
+            "duration_seconds": duration_seconds,
+            "content_type": _content_type_for_output(output, default="video/mp2t"),
+            "command_port": endpoint.command_port,
+        }
+
+    def _hcnetsdk_command_port_endpoint(
+        self,
+        serial: str,
+        *,
+        host: str | None,
+        command_port: int | None,
+    ) -> HcNetSdkLanEndpoint:
+        """Return a command-port endpoint from overrides or device metadata."""
+
+        if host:
+            return HcNetSdkLanEndpoint(
+                serial=serial,
+                host=host,
+                command_port=command_port or 8000,
+            )
+
+        device_info = self.get_device_infos(serial)
+        device: dict[str, Any] | None = None
+        if isinstance(device_info, dict):
+            if isinstance(device_info.get("CONNECTION"), dict):
+                device = device_info
+            else:
+                for value in device_info.values():
+                    if isinstance(value, dict) and isinstance(value.get("CONNECTION"), dict):
+                        device = value
+                        break
+        if not isinstance(device, dict):
+            raise PyEzvizError(
+                "Could not find CONNECTION metadata for HCNetSDK command-port stream; "
+                "provide host"
+            )
+        endpoint = HcNetSdkLanEndpoint.from_connection(serial, device.get("CONNECTION"))
+        if command_port is None:
+            return endpoint
+        return HcNetSdkLanEndpoint(
+            serial=endpoint.serial,
+            host=endpoint.host,
+            net_host=endpoint.net_host,
+            command_port=command_port,
+            net_command_port=endpoint.net_command_port,
+            stream_port=endpoint.stream_port,
+            net_stream_port=endpoint.net_stream_port,
+            rtsp_port=endpoint.rtsp_port,
+            sdk_tls_port=endpoint.sdk_tls_port,
+        )
+
+    def save_image(
+        self,
+        serial: str,
+        output: str | Path | BinaryIO,
+        *,
+        channel: int = 1,
+        image_url: str | None = None,
+        decrypt: bool = True,
+        smscode: str | int | None = None,
+    ) -> SaveMediaResult:
+        """Capture or download a camera image to a path or binary file object."""
+
+        capture_response: dict[str, Any] | None = None
+        selected_image_url = image_url
+        if selected_image_url is None:
+            capture_response = self.capture_picture(serial, channel, max_retries=1)
+            selected_image_url = _first_image_url(capture_response)
+            if selected_image_url is None:
+                raise PyEzvizError("Camera capture response did not include an image URL")
+
+        image_data = self.download_alarm_image(
+            selected_image_url,
+            serial,
+            decrypt=decrypt,
+            smscode=smscode,
+            max_retries=1,
+        )
+        start_position = None
+        if isinstance(output, str | Path):
+            output_path = Path(output)
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            output_path.write_bytes(image_data)
+        else:
+            start_position = _binary_position(output)
+            output.write(image_data)
+            output.flush()
+
+        return {
+            "ok": True,
+            "kind": "image",
+            "serial": serial,
+            "channel": channel,
+            "output": _output_name(output),
+            "bytes": _bytes_written_to_output(output, start_position=start_position),
+            "content_type": _content_type_for_output(output, default="image/jpeg"),
+            "image_url": selected_image_url,
+            "triggered_capture": capture_response is not None,
+        }
 
     def get_cam_auth_code(
         self,

--- a/pyezvizapi/client.py
+++ b/pyezvizapi/client.py
@@ -118,6 +118,7 @@ from .api_endpoints import (
     API_ENDPOINT_VIDEO_ENCRYPT,
 )
 from .cas import EzvizCAS
+from .cloud_stream import copy_cloud_stream_to_mpegps, copy_cloud_stream_to_mpegts
 from .constants import (
     DEFAULT_TIMEOUT,
     DEFAULT_UNIFIEDMSG_STYPE,
@@ -154,7 +155,7 @@ UNIFIEDMSG_LOOKBACK_DAYS = 7
 MAX_UNIFIEDMSG_PAGES = 6
 
 JsonDict = dict[str, Any]
-ClipSource = Literal["local-sdk", "hcnetsdk-command-port"]
+ClipSource = Literal["local-sdk", "hcnetsdk-command-port", "cloud"]
 ClipOutputFormat = Literal["mpegps", "mpegts"]
 
 
@@ -172,6 +173,9 @@ class SaveMediaResult(TypedDict, total=False):
     duration_seconds: float | None
     content_type: str
     command_port: int
+    cloud_client_type: int
+    cloud_token_index: int
+    cloud_refresh_vtm: bool
     image_url: str
     triggered_capture: bool
 
@@ -2846,10 +2850,14 @@ class EzvizClient:
         command_port: int | None = None,
         hcnetsdk_command_frames: Iterable[bytes] | None = None,
         hcnetsdk_read_response_after_each: bool | Iterable[bool] = True,
+        cloud_client_type: int = 9,
+        cloud_token_index: int = 0,
+        cloud_refresh_vtm: bool = True,
     ) -> SaveMediaResult:
         """Save a local camera clip to a path or binary file object.
 
         ``source="local-sdk"`` uses the direct-local 9010/9020 SDK path.
+        ``source="cloud"`` uses the EZVIZ VTM cloud live stream path.
         ``source="hcnetsdk-command-port"`` consumes complete caller-supplied
         port-8000 HCNetSDK bootstrap command frames, then remuxes the command
         port media stream to MPEG-TS.
@@ -2886,6 +2894,23 @@ class EzvizClient:
                 command_port=command_port,
                 command_frames=hcnetsdk_command_frames,
                 read_response_after_each=hcnetsdk_read_response_after_each,
+            )
+        if source == "cloud":
+            return self._save_cloud_clip(
+                serial,
+                output,
+                output_format=output_format,
+                duration_seconds=duration_seconds,
+                max_packets=max_packets,
+                channel=channel,
+                ffmpeg_path=ffmpeg_path,
+                decrypt_video=decrypt_video,
+                media_key=media_key,
+                nalu_header_size=nalu_header_size,
+                timeout=timeout,
+                client_type=cloud_client_type,
+                token_index=cloud_token_index,
+                refresh_vtm=cloud_refresh_vtm,
             )
         raise PyEzvizError(f"Unsupported clip source: {source}")
 
@@ -3047,6 +3072,91 @@ class EzvizClient:
             "duration_seconds": duration_seconds,
             "content_type": _content_type_for_output(output, default="video/mp2t"),
             "command_port": endpoint.command_port,
+        }
+
+    def _save_cloud_clip(  # noqa: PLR0913
+        self,
+        serial: str,
+        output: str | Path | BinaryIO,
+        *,
+        output_format: ClipOutputFormat,
+        duration_seconds: float | None,
+        max_packets: int | None,
+        channel: int,
+        ffmpeg_path: str,
+        decrypt_video: bool,
+        media_key: str | bytes | None,
+        nalu_header_size: int | None,
+        timeout: float | None,
+        client_type: int,
+        token_index: int,
+        refresh_vtm: bool,
+    ) -> SaveMediaResult:
+        """Save a clip through the EZVIZ VTM cloud live stream path."""
+
+        start_position = None
+
+        def copy_cloud(output_file: BinaryIO) -> None:
+            if output_format == "mpegts":
+                copy_cloud_stream_to_mpegts(
+                    self,
+                    serial,
+                    output_file,
+                    channel=channel,
+                    client_type=client_type,
+                    token_index=token_index,
+                    refresh_vtm=refresh_vtm,
+                    timeout=timeout,
+                    ffmpeg_path=ffmpeg_path,
+                    max_packets=max_packets,
+                    duration_seconds=duration_seconds,
+                    decrypt_video=decrypt_video,
+                    media_key=media_key,
+                    nalu_header_size=nalu_header_size,
+                )
+                return
+            copy_cloud_stream_to_mpegps(
+                self,
+                serial,
+                output_file,
+                channel=channel,
+                client_type=client_type,
+                token_index=token_index,
+                refresh_vtm=refresh_vtm,
+                timeout=timeout,
+                max_packets=max_packets,
+                duration_seconds=duration_seconds,
+                decrypt_video=decrypt_video,
+                media_key=media_key,
+                nalu_header_size=nalu_header_size,
+            )
+
+        if isinstance(output, str | Path):
+            output_path = Path(output)
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            with output_path.open("wb") as output_file:
+                copy_cloud(output_file)
+        else:
+            start_position = _binary_position(output)
+            copy_cloud(output)
+
+        return {
+            "ok": True,
+            "kind": "clip",
+            "serial": serial,
+            "channel": channel,
+            "output": _output_name(output),
+            "bytes": _bytes_written_to_output(output, start_position=start_position),
+            "source": "cloud",
+            "format": output_format,
+            "duration_seconds": duration_seconds,
+            "content_type": _content_type_for_output(
+                output,
+                default="video/mp2t" if output_format == "mpegts" else "video/mpeg",
+            ),
+            "cloud_client_type": client_type,
+            "cloud_token_index": token_index,
+            "cloud_refresh_vtm": refresh_vtm,
         }
 
     def _hcnetsdk_command_port_endpoint(

--- a/pyezvizapi/cloud_stream.py
+++ b/pyezvizapi/cloud_stream.py
@@ -236,6 +236,7 @@ def copy_cloud_stream_to_mpegps(  # noqa: PLR0913
     decrypt_video: bool = False,
     media_key: str | bytes | None = None,
     nalu_header_size: int | None = None,
+    smscode: str | int | None = None,
     monotonic: Callable[[], float] = time.monotonic,
 ) -> None:
     """Copy a cloud VTM live stream to MPEG-PS bytes.
@@ -249,7 +250,10 @@ def copy_cloud_stream_to_mpegps(  # noqa: PLR0913
             max_packets=max_packets,
             duration_seconds=duration_seconds,
         )
-        selected_key = media_key if media_key is not None else client.get_cam_key(serial)
+        if media_key is None and smscode is not None:
+            selected_key = client.get_cam_key(serial, smscode=smscode)
+        else:
+            selected_key = media_key if media_key is not None else client.get_cam_key(serial)
         if selected_key is None:
             raise PyEzvizError("decrypt_video requires a media_key or camera media key")
         with open_cloud_stream(
@@ -313,6 +317,7 @@ def copy_cloud_stream_to_mpegts(  # noqa: PLR0913
     decrypt_video: bool = False,
     media_key: str | bytes | None = None,
     nalu_header_size: int | None = None,
+    smscode: str | int | None = None,
     monotonic: Callable[[], float] = time.monotonic,
 ) -> None:
     """Copy a cloud VTM live stream to MPEG-TS bytes."""
@@ -322,7 +327,10 @@ def copy_cloud_stream_to_mpegts(  # noqa: PLR0913
             max_packets=max_packets,
             duration_seconds=duration_seconds,
         )
-        selected_key = media_key if media_key is not None else client.get_cam_key(serial)
+        if media_key is None and smscode is not None:
+            selected_key = client.get_cam_key(serial, smscode=smscode)
+        else:
+            selected_key = media_key if media_key is not None else client.get_cam_key(serial)
         if selected_key is None:
             raise PyEzvizError("decrypt_video requires a media_key or camera media key")
         with open_cloud_stream(

--- a/pyezvizapi/cloud_stream.py
+++ b/pyezvizapi/cloud_stream.py
@@ -4,15 +4,25 @@ from __future__ import annotations
 
 import base64
 import binascii
+from collections.abc import Callable
+from contextlib import suppress
 from dataclasses import dataclass
 import json
-from typing import Any, TypedDict, cast
+import subprocess
+from threading import Thread
+import time
+from typing import Any, BinaryIO, TypedDict, cast
 from urllib.parse import urlparse
 
 from .api_endpoints import API_ENDPOINT_STREAMING_VTM, API_ENDPOINT_VTDU_TOKEN_V2
 from .constants import MAX_RETRIES
 from .exceptions import HTTPError, PyEzvizError
-from .stream import SocketFactory, VtmStreamClient, build_vtm_url
+from .stream import (
+    SocketFactory,
+    VtmStreamClient,
+    build_vtm_url,
+    decrypt_hikvision_ps_video,
+)
 
 JsonDict = dict[str, Any]
 
@@ -209,6 +219,322 @@ def open_cloud_stream(
         timeout=timeout,
         socket_factory=socket_factory,
     )
+
+
+def copy_cloud_stream_to_mpegps(  # noqa: PLR0913
+    client: Any,
+    serial: str,
+    output: BinaryIO,
+    *,
+    channel: int | None = None,
+    client_type: int = 9,
+    token_index: int = 0,
+    refresh_vtm: bool = True,
+    timeout: float | None = 10.0,
+    max_packets: int | None = None,
+    duration_seconds: float | None = None,
+    decrypt_video: bool = False,
+    media_key: str | bytes | None = None,
+    nalu_header_size: int | None = None,
+    monotonic: Callable[[], float] = time.monotonic,
+) -> None:
+    """Copy a cloud VTM live stream to MPEG-PS bytes.
+
+    ``decrypt_video`` collects a bounded capture before writing because the
+    Hikvision NAL-prefix transform is stateful across VTM packet boundaries.
+    """
+
+    if decrypt_video:
+        _require_bounded_cloud_decrypt_capture(
+            max_packets=max_packets,
+            duration_seconds=duration_seconds,
+        )
+        selected_key = media_key if media_key is not None else client.get_cam_key(serial)
+        if selected_key is None:
+            raise PyEzvizError("decrypt_video requires a media_key or camera media key")
+        with open_cloud_stream(
+            client,
+            serial,
+            channel=channel,
+            client_type=client_type,
+            token_index=token_index,
+            refresh_vtm=refresh_vtm,
+            timeout=timeout,
+        ) as stream:
+            stream.start()
+            payload = _collect_cloud_stream_payloads(
+                stream,
+                max_packets=max_packets,
+                duration_seconds=duration_seconds,
+                monotonic=monotonic,
+            )
+        output.write(
+            decrypt_hikvision_ps_video(
+                payload,
+                selected_key,
+                nalu_header_size=nalu_header_size,
+            )
+        )
+        output.flush()
+        return
+
+    with open_cloud_stream(
+        client,
+        serial,
+        channel=channel,
+        client_type=client_type,
+        token_index=token_index,
+        refresh_vtm=refresh_vtm,
+        timeout=timeout,
+    ) as stream:
+        stream.start()
+        _write_cloud_stream_payloads(
+            stream,
+            output,
+            max_packets=max_packets,
+            duration_seconds=duration_seconds,
+            monotonic=monotonic,
+        )
+
+
+def copy_cloud_stream_to_mpegts(  # noqa: PLR0913
+    client: Any,
+    serial: str,
+    output: BinaryIO,
+    *,
+    channel: int | None = None,
+    client_type: int = 9,
+    token_index: int = 0,
+    refresh_vtm: bool = True,
+    timeout: float | None = 10.0,
+    ffmpeg_path: str = "ffmpeg",
+    max_packets: int | None = None,
+    duration_seconds: float | None = None,
+    decrypt_video: bool = False,
+    media_key: str | bytes | None = None,
+    nalu_header_size: int | None = None,
+    monotonic: Callable[[], float] = time.monotonic,
+) -> None:
+    """Copy a cloud VTM live stream to MPEG-TS bytes."""
+
+    if decrypt_video:
+        _require_bounded_cloud_decrypt_capture(
+            max_packets=max_packets,
+            duration_seconds=duration_seconds,
+        )
+        selected_key = media_key if media_key is not None else client.get_cam_key(serial)
+        if selected_key is None:
+            raise PyEzvizError("decrypt_video requires a media_key or camera media key")
+        with open_cloud_stream(
+            client,
+            serial,
+            channel=channel,
+            client_type=client_type,
+            token_index=token_index,
+            refresh_vtm=refresh_vtm,
+            timeout=timeout,
+        ) as stream:
+            stream.start()
+            payload = _collect_cloud_stream_payloads(
+                stream,
+                max_packets=max_packets,
+                duration_seconds=duration_seconds,
+                monotonic=monotonic,
+            )
+        _remux_cloud_mpegps_bytes_to_mpegts(
+            decrypt_hikvision_ps_video(
+                payload,
+                selected_key,
+                nalu_header_size=nalu_header_size,
+            ),
+            output,
+            ffmpeg_path=ffmpeg_path,
+        )
+        return
+
+    with open_cloud_stream(
+        client,
+        serial,
+        channel=channel,
+        client_type=client_type,
+        token_index=token_index,
+        refresh_vtm=refresh_vtm,
+        timeout=timeout,
+    ) as stream:
+        stream.start()
+        _copy_cloud_stream_payloads_to_mpegts(
+            stream,
+            output,
+            ffmpeg_path=ffmpeg_path,
+            max_packets=max_packets,
+            duration_seconds=duration_seconds,
+            monotonic=monotonic,
+        )
+
+
+def _require_bounded_cloud_decrypt_capture(
+    *,
+    max_packets: int | None,
+    duration_seconds: float | None,
+) -> None:
+    if max_packets is None and duration_seconds is None:
+        raise PyEzvizError(
+            "Encrypted cloud stream decrypt requires duration_seconds or max_packets"
+        )
+
+
+def _write_cloud_stream_payloads(
+    stream: Any,
+    output: BinaryIO,
+    *,
+    max_packets: int | None,
+    duration_seconds: float | None = None,
+    monotonic: Callable[[], float] = time.monotonic,
+    flush_each: bool = False,
+) -> None:
+    """Write clear VTM stream packet bodies to a binary file-like object."""
+
+    deadline = None if duration_seconds is None else monotonic() + duration_seconds
+    for packet in stream.iter_packets(max_packets=max_packets):
+        if deadline is not None and monotonic() >= deadline:
+            break
+        if packet.encrypted:
+            raise PyEzvizError(
+                "Received encrypted VTM stream packet; media decryption is not implemented"
+            )
+        if packet.body:
+            output.write(packet.body)
+        if flush_each:
+            output.flush()
+    output.flush()
+
+
+def _collect_cloud_stream_payloads(
+    stream: Any,
+    *,
+    max_packets: int | None,
+    duration_seconds: float | None = None,
+    monotonic: Callable[[], float] = time.monotonic,
+) -> bytes:
+    """Collect clear VTM stream packet bodies into memory."""
+
+    chunks: list[bytes] = []
+    deadline = None if duration_seconds is None else monotonic() + duration_seconds
+    for packet in stream.iter_packets(max_packets=max_packets):
+        if deadline is not None and monotonic() >= deadline:
+            break
+        if packet.encrypted:
+            raise PyEzvizError(
+                "Received encrypted VTM stream packet; media decryption is not implemented"
+            )
+        chunks.append(packet.body)
+    return b"".join(chunks)
+
+
+def _copy_cloud_stream_payloads_to_mpegts(
+    stream: Any,
+    output: BinaryIO,
+    *,
+    ffmpeg_path: str,
+    max_packets: int | None,
+    duration_seconds: float | None = None,
+    monotonic: Callable[[], float] = time.monotonic,
+) -> None:
+    """Pipe clear VTM MPEG-PS payloads through FFmpeg and write MPEG-TS."""
+
+    process = _open_cloud_mpegts_remux_process(ffmpeg_path)
+    stdin = process.stdin
+    stdout = process.stdout
+    if stdin is None or stdout is None:
+        raise PyEzvizError("Could not open FFmpeg pipes")
+
+    writer_errors: list[Exception] = []
+
+    def _write_input() -> None:
+        try:
+            _write_cloud_stream_payloads(
+                stream,
+                cast(BinaryIO, stdin),
+                max_packets=max_packets,
+                duration_seconds=duration_seconds,
+                monotonic=monotonic,
+                flush_each=True,
+            )
+        except (BrokenPipeError, ConnectionResetError):
+            return
+        except Exception as err:  # pragma: no cover - defensive thread handoff
+            writer_errors.append(err)
+        finally:
+            with suppress(OSError):
+                stdin.close()
+
+    writer = Thread(target=_write_input, daemon=True)
+    writer.start()
+    try:
+        while True:
+            chunk = stdout.read(65536)
+            if not chunk:
+                break
+            output.write(chunk)
+            output.flush()
+    finally:
+        if process.poll() is None:
+            process.terminate()
+        writer.join(timeout=2)
+        try:
+            return_code = process.wait(timeout=2)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            return_code = process.wait()
+
+    if writer_errors:
+        raise writer_errors[0]
+    if return_code not in (0, -15):
+        raise PyEzvizError(f"FFmpeg exited with status {return_code}")
+
+
+def _remux_cloud_mpegps_bytes_to_mpegts(
+    data: bytes,
+    output: BinaryIO,
+    *,
+    ffmpeg_path: str,
+) -> None:
+    """Remux in-memory MPEG-PS bytes to MPEG-TS."""
+
+    process = _open_cloud_mpegts_remux_process(ffmpeg_path)
+    stdout, _stderr = process.communicate(data)
+    if process.returncode != 0:
+        raise PyEzvizError(f"FFmpeg exited with status {process.returncode}")
+    output.write(stdout)
+    output.flush()
+
+
+def _open_cloud_mpegts_remux_process(ffmpeg_path: str) -> subprocess.Popen[bytes]:
+    """Open an FFmpeg process ready to remux MPEG-PS stdin to MPEG-TS."""
+
+    try:
+        return subprocess.Popen(
+            [
+                ffmpeg_path,
+                "-hide_banner",
+                "-loglevel",
+                "error",
+                "-f",
+                "mpeg",
+                "-i",
+                "pipe:0",
+                "-c",
+                "copy",
+                "-f",
+                "mpegts",
+                "pipe:1",
+            ],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+        )
+    except OSError as err:
+        raise PyEzvizError(f"Could not launch FFmpeg at {ffmpeg_path!r}: {err}") from err
 
 
 def parse_vtm_server_public_key(vtm: JsonDict) -> VtmServerPublicKey | None:

--- a/pyezvizapi/hcnetsdk.py
+++ b/pyezvizapi/hcnetsdk.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import base64
 import binascii
 from collections.abc import Callable, Iterable, Iterator, Mapping
+from contextlib import suppress
 from dataclasses import dataclass
 from enum import IntEnum
 import hashlib
@@ -365,7 +366,7 @@ class HcNetSdkTcpPayloadShape:
 
 @dataclass(frozen=True)
 class HcNetSdkTcpShapeLogRecord:
-    """One secret-safe HCNetSDK command-port shape line from Frida logs."""
+    """One secret-safe HCNetSDK command-port shape log line."""
 
     direction: str
     fd: int
@@ -379,7 +380,7 @@ class HcNetSdkTcpShapeLogRecord:
 
 @dataclass(frozen=True)
 class HcNetSdkSemanticLogEvent:
-    """One secret-safe semantic HCNetSDK event emitted by the Frida hook."""
+    """One secret-safe semantic HCNetSDK event."""
 
     name: str
     phase: str | None = None
@@ -390,11 +391,10 @@ class HcNetSdkSemanticLogEvent:
 class HcNetSdkCommandTraceSummary:
     """Secret-safe summary of one mixed HCNetSDK command-port trace.
 
-    The Frida command-shape hook intentionally avoids raw payloads. This
-    summary preserves only the useful correlation: which command candidates
-    were sent during the settings login call, which follow-up command
-    candidates appeared afterward, and whether playback/media/keyframe
-    boundaries were observed.
+    Shape logs intentionally avoid raw payloads. This summary preserves only
+    the useful correlation: which command candidates were sent during the
+    settings login call, which follow-up command candidates appeared afterward,
+    and whether playback/media/keyframe boundaries were observed.
     """
 
     settings_login_commands: tuple[int, ...] = ()
@@ -449,6 +449,22 @@ class HcNetSdkTcpFrame:
         if self.header.body_length != len(self.body):
             raise PyEzvizError("HCNetSDK TCP frame header/body length mismatch")
         return self.header.to_bytes() + self.body
+
+
+@dataclass(frozen=True)
+class HcNetSdkCommandPortExchange:
+    """One command-port request and its optional response."""
+
+    request: bytes
+    response: HcNetSdkTcpFrame | None = None
+
+
+@dataclass(frozen=True)
+class HcNetSdkCommandPortStreamBootstrap:
+    """Result of a command-port stream bootstrap."""
+
+    exchanges: tuple[HcNetSdkCommandPortExchange, ...]
+    first_media: EzvizInterleavedRtpFrameWithPrefix | None = None
 
 
 @dataclass(frozen=True)
@@ -1365,12 +1381,12 @@ def classify_hcnetsdk_tcp_payload(data: bytes) -> HcNetSdkTcpPayloadShape:
 def parse_hcnetsdk_tcp_shape_log_line(
     line: str,
 ) -> HcNetSdkTcpShapeLogRecord | None:
-    """Parse one secret-safe Frida HCNetSDK TCP shape log line.
+    """Parse one secret-safe HCNetSDK TCP shape log line.
 
-    The narrow command-port hook intentionally prints only metadata, not raw
-    bytes. This parser turns those metadata lines into the same Python shape
-    model used by direct byte classification, so captured traces can drive the
-    next packet-builder tests without copying secrets into fixtures.
+    These lines contain only metadata, not raw bytes. This parser turns that
+    metadata into the same Python shape model used by direct byte
+    classification, so captured traces can drive packet-builder tests without
+    copying secrets into fixtures.
     """
     match = re.search(
         r"\[(?:hcnetsdk|native)-(?P<direction>send|recv|read|write)\]\s+"
@@ -1427,7 +1443,7 @@ def parse_hcnetsdk_tcp_shape_log_line(
 
 
 def parse_hcnetsdk_semantic_log_line(line: str) -> HcNetSdkSemanticLogEvent | None:
-    """Parse one secret-safe HCNetSDK semantic event line from Frida logs."""
+    """Parse one secret-safe HCNetSDK semantic event line."""
     match = re.search(r"\[hcnetsdk-semantic\]\s+(?P<body>.*)$", line.strip())
     if not match:
         return None
@@ -1463,7 +1479,7 @@ def parse_hcnetsdk_semantic_log_line(line: str) -> HcNetSdkSemanticLogEvent | No
 def summarize_hcnetsdk_command_trace(
     lines: Iterable[str],
 ) -> HcNetSdkCommandTraceSummary:
-    """Summarize one mixed HCNetSDK command-shape/semantic Frida trace.
+    """Summarize one mixed HCNetSDK command-shape/semantic trace.
 
     This reducer is deliberately conservative: it uses semantic enter/leave
     boundaries to associate redacted write command candidates with
@@ -1551,6 +1567,15 @@ def parse_hcnetsdk_tcp_frame(data: bytes) -> HcNetSdkTcpFrame:
     )
 
 
+def read_hcnetsdk_tcp_frame(sock: Any) -> HcNetSdkTcpFrame:
+    """Read one complete HCNetSDK command-port frame from a socket-like object."""
+    header = parse_hcnetsdk_tcp_frame_header(_recv_exact(sock, HCNETSDK_TCP_HEADER_LENGTH))
+    return HcNetSdkTcpFrame(
+        header=header,
+        body=_recv_exact(sock, header.body_length),
+    )
+
+
 def build_hcnetsdk_tcp_frame(
     body: bytes = b"",
     *,
@@ -1572,7 +1597,7 @@ def hcnetsdk_command_candidate_role(candidate: int | None) -> str | None:
     """Return the current role label for an observed command candidate.
 
     The names are trace-derived labels, not a complete HCNetSDK command table.
-    They are useful for reducing redacted Frida captures while the underlying
+    They are useful for reducing redacted captures while the underlying
     encrypted request format is still being mapped.
     """
     if candidate == HCNETSDK_COMMAND_CANDIDATE_SETTINGS_LOGIN:
@@ -1587,11 +1612,11 @@ def iter_hcnetsdk_tcp_frame_shapes(
 ) -> Iterator[HcNetSdkTcpFrameShape]:
     """Yield command frames reconstructed from secret-safe socket shape logs.
 
-    The narrow Frida hook logs response headers and bodies as separate reads
-    when the app asks libc for 16 bytes first and then the implied body length.
-    This reducer pairs those adjacent records without needing payload bytes.
-    Whole-frame writes are yielded as header-only shapes because their body
-    content remains intentionally redacted.
+    Some logs record response headers and bodies as separate reads when the app
+    asks libc for 16 bytes first and then the implied body length. This reducer
+    pairs those adjacent records without needing payload bytes. Whole-frame
+    writes are yielded as header-only shapes because their body content remains
+    intentionally redacted.
     """
     pending = list(records)
     index = 0
@@ -2741,6 +2766,153 @@ def read_ezviz_interleaved_rtp_frame_after_prefix(
         prefix.extend(byte)
         if len(prefix) > max_prefix_bytes:
             raise PyEzvizError("EZVIZ RTP prefix exceeded limit before frame magic")
+
+
+def read_hcnetsdk_command_port_interleaved_frame_after_prefix(
+    sock: Any,
+    *,
+    max_prefix_bytes: int = 4096,
+) -> EzvizInterleavedRtpFrameWithPrefix:
+    """Read one HCNetSDK command-port interleaved media frame.
+
+    The local stream port uses ``$`` + channel + big-endian payload length.
+    Port 8000 uses the same magic byte, but its two length bytes are a
+    little-endian total frame length. Keeping this reader separate prevents the
+    command-port path from coalescing adjacent media frames.
+    """
+    if max_prefix_bytes < 0:
+        raise PyEzvizError("HCNetSDK command-port prefix limit must be non-negative")
+
+    prefix = bytearray()
+    while True:
+        byte = _recv_exact(sock, 1)
+        if byte[0] == EZVIZ_RTP_INTERLEAVED_MAGIC:
+            header_tail = _recv_exact(sock, 3)
+            total_length = int.from_bytes(header_tail[1:3], "little")
+            if total_length < 4:
+                raise PyEzvizError(
+                    "HCNetSDK command-port interleaved frame length is invalid"
+                )
+            payload_length = total_length - 4
+            return EzvizInterleavedRtpFrameWithPrefix(
+                prefix=bytes(prefix),
+                frame=EzvizInterleavedRtpFrame(
+                    header=EzvizInterleavedRtpFrameHeader(
+                        channel=header_tail[0],
+                        payload_length=payload_length,
+                    ),
+                    payload=_recv_exact(sock, payload_length),
+                ),
+            )
+
+        prefix.extend(byte)
+        if len(prefix) > max_prefix_bytes:
+            raise PyEzvizError(
+                "HCNetSDK command-port prefix exceeded limit before frame magic"
+            )
+
+
+class HcNetSdkCommandPortClient:
+    """Small native-Python client for HCNetSDK command-port media framing."""
+
+    def __init__(
+        self,
+        endpoint: HcNetSdkLanEndpoint,
+        *,
+        timeout: float | None = 10.0,
+        socket_factory: SocketFactory = socket.create_connection,
+    ) -> None:
+        self.endpoint = endpoint
+        self.timeout = timeout
+        self.socket_factory = socket_factory
+        self._socket: Any | None = None
+
+    def __enter__(self) -> HcNetSdkCommandPortClient:
+        self.connect()
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        self.close()
+
+    @property
+    def sock(self) -> Any:
+        """Return the connected socket, opening it lazily."""
+        return self.connect()
+
+    def connect(self) -> Any:
+        """Open the command-port TCP socket if needed."""
+        if self._socket is None:
+            self._socket = self.socket_factory(
+                (self.endpoint.host, self.endpoint.command_port),
+                self.timeout,
+            )
+        return self._socket
+
+    def close(self) -> None:
+        """Close the command-port socket."""
+        if self._socket is None:
+            return
+        with suppress(Exception):
+            self._socket.close()
+        self._socket = None
+
+    def send_command_frame(self, frame: bytes) -> None:
+        """Send one complete command-port frame."""
+        _send_all(self.sock, frame)
+
+    def read_tcp_frame(self) -> HcNetSdkTcpFrame:
+        """Read one non-media command-port response frame."""
+        return read_hcnetsdk_tcp_frame(self.sock)
+
+    def read_media_frame_after_prefix(
+        self,
+        *,
+        max_prefix_bytes: int = 4096,
+    ) -> EzvizInterleavedRtpFrameWithPrefix:
+        """Read the next command-port media frame."""
+        return read_hcnetsdk_command_port_interleaved_frame_after_prefix(
+            self.sock,
+            max_prefix_bytes=max_prefix_bytes,
+        )
+
+    def bootstrap_media_stream(
+        self,
+        command_frames: Iterable[bytes],
+        *,
+        read_response_after_each: bool | Iterable[bool] = True,
+        read_first_media: bool = True,
+        max_prefix_bytes: int = 4096,
+    ) -> HcNetSdkCommandPortStreamBootstrap:
+        """Send command frames and optionally read the first media frame."""
+        frames = tuple(command_frames)
+        response_flags: tuple[bool, ...] | None
+        if isinstance(read_response_after_each, bool):
+            response_flags = None
+        else:
+            response_flags = tuple(read_response_after_each)
+            if len(response_flags) != len(frames):
+                raise PyEzvizError(
+                    "HCNetSDK response-read policy length must match command frames"
+                )
+
+        exchanges: list[HcNetSdkCommandPortExchange] = []
+        for index, frame in enumerate(frames):
+            self.send_command_frame(frame)
+            should_read = (
+                read_response_after_each if response_flags is None else response_flags[index]
+            )
+            response = self.read_tcp_frame() if should_read else None
+            exchanges.append(HcNetSdkCommandPortExchange(frame, response))
+
+        first_media = (
+            self.read_media_frame_after_prefix(max_prefix_bytes=max_prefix_bytes)
+            if read_first_media
+            else None
+        )
+        return HcNetSdkCommandPortStreamBootstrap(
+            exchanges=tuple(exchanges),
+            first_media=first_media,
+        )
 
 
 def _parse_local_device_content(value: Any) -> EzvizLocalDeviceContent | None:

--- a/pyezvizapi/local_stream.py
+++ b/pyezvizapi/local_stream.py
@@ -844,7 +844,7 @@ def _hcnetsdk_command_port_media_payload(payload: bytes) -> bytes:
         return payload
     if _looks_like_hcnetsdk_wrapped_media_payload(unwrapped):
         return unwrapped
-    return payload
+    return unwrapped
 
 
 def _looks_like_hcnetsdk_wrapped_media_payload(payload: bytes) -> bool:

--- a/pyezvizapi/local_stream.py
+++ b/pyezvizapi/local_stream.py
@@ -695,10 +695,12 @@ def copy_local_stream_to_decrypted_mpegts(
     )
     if _local_stream_packets_are_idmx(packets):
         annexb = _decrypt_idmx_local_packets_to_annexb(packets, media_key)
-        if _annexb_looks_like_h264(annexb):
+        if _annexb_looks_like_hevc(annexb):
+            process = _open_local_hevc_mpegts_remux_process(ffmpeg_path)
+        elif _annexb_looks_like_h264(annexb):
             process = _open_local_h264_mpegts_remux_process(ffmpeg_path)
         else:
-            process = _open_local_hevc_mpegts_remux_process(ffmpeg_path)
+            raise PyEzvizError("EZVIZ local IDMX stream did not include video frames")
         _copy_mpegps_payloads_to_mpegts([annexb], output, process=process)
         return
     decrypted = decrypt_hikvision_ps_video(
@@ -718,6 +720,17 @@ def _require_bounded_decrypt_capture(
     if max_packets is None and duration_seconds is None:
         raise PyEzvizError(
             "Encrypted local stream decrypt requires duration_seconds or max_packets"
+        )
+
+
+def _require_bounded_idmx_capture(
+    *,
+    max_packets: int | None,
+    duration_seconds: float | None,
+) -> None:
+    if max_packets is None and duration_seconds is None:
+        raise PyEzvizError(
+            "EZVIZ local IDMX stream remux requires duration_seconds or max_packets"
         )
 
 
@@ -751,6 +764,10 @@ def copy_local_stream_to_mpegts(
             return
 
     if _looks_like_idmx_local_payload(first_payload):
+        _require_bounded_idmx_capture(
+            max_packets=max_packets,
+            duration_seconds=duration_seconds,
+        )
         packets = list(chain((first_payload,), payloads))
         annexb = _idmx_local_packets_to_h264_annexb(packets)
         process = _open_local_h264_mpegts_remux_process(ffmpeg_path)
@@ -1394,6 +1411,19 @@ def _annexb_looks_like_h264(data: bytes) -> bool:
         _h264_nal_type(data[nal_start:end]) in {1, 5, 6, 7, 8, 9}
         for _offset, nal_start, end in _h264_annexb_nal_spans(data)
     )
+
+
+def _annexb_looks_like_hevc(data: bytes) -> bool:
+    return any(
+        _is_plausible_hevc_nal(data[nal_start:end])
+        and _hevc_nal_type(data[nal_start:end])
+        in {16, 17, 18, 19, 20, 21, 32, 33, 34, 39, 40}
+        for _offset, nal_start, end in _h264_annexb_nal_spans(data)
+    )
+
+
+def _hevc_nal_type(nal: bytes) -> int:
+    return (nal[0] >> 1) & 0x3F if nal else 0
 
 
 def _decrypt_hevc_nal_prefix(nal: bytes, aes_key: bytes) -> bytes:

--- a/pyezvizapi/local_stream.py
+++ b/pyezvizapi/local_stream.py
@@ -24,6 +24,8 @@ from .hcnetsdk import (
     EzvizLocalReceiverInfoExAttrs,
     EzvizLocalSdkClient,
     EzvizLocalSdkStreamBootstrap,
+    HcNetSdkCommandPortClient,
+    HcNetSdkCommandPortStreamBootstrap,
     HcNetSdkLanEndpoint,
     HcNetSdkRealDataPacket,
     SocketFactory,
@@ -172,6 +174,75 @@ class EzvizLocalSdkMediaStream:
             emitted += 1
 
 
+class HcNetSdkCommandPortMediaStream:
+    """Port-8000 HCNetSDK media stream using caller-supplied command frames."""
+
+    def __init__(
+        self,
+        command_client: HcNetSdkCommandPortClient,
+        command_frames: Iterable[bytes],
+        *,
+        read_response_after_each: bool | Iterable[bool] = True,
+        read_first_media: bool = True,
+        max_prefix_bytes: int = 4096,
+    ) -> None:
+        self.command_client = command_client
+        self.command_frames = tuple(command_frames)
+        self.read_response_after_each = read_response_after_each
+        self.read_first_media = read_first_media
+        self.max_prefix_bytes = max_prefix_bytes
+        self.bootstrap: HcNetSdkCommandPortStreamBootstrap | None = None
+        self._first_media: EzvizInterleavedRtpFrameWithPrefix | None = None
+
+    def __enter__(self) -> HcNetSdkCommandPortMediaStream:
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        self.close()
+
+    def close(self) -> None:
+        """Close the underlying command-port socket."""
+        self.command_client.close()
+
+    def start(self) -> HcNetSdkCommandPortStreamBootstrap:
+        """Send bootstrap frames and read the first media frame."""
+        self.bootstrap = self.command_client.bootstrap_media_stream(
+            self.command_frames,
+            read_response_after_each=self.read_response_after_each,
+            read_first_media=self.read_first_media,
+            max_prefix_bytes=self.max_prefix_bytes,
+        )
+        self._first_media = self.bootstrap.first_media
+        if self.read_first_media and self._first_media is None:
+            raise PyEzvizError("HCNetSDK command-port stream did not return media")
+        return self.bootstrap
+
+    def iter_packets(
+        self,
+        *,
+        max_packets: int | None = None,
+    ) -> Iterator[EzvizLocalStreamPacket]:
+        """Yield command-port RTP payloads as MPEG-PS or IDMX packet bodies."""
+        if max_packets is not None and max_packets <= 0:
+            return
+
+        if self.bootstrap is None:
+            self.start()
+
+        emitted = 0
+        if self._first_media is not None:
+            yield _hcnetsdk_command_port_media_packet(self._first_media)
+            emitted += 1
+            self._first_media = None
+
+        while max_packets is None or emitted < max_packets:
+            media = self.command_client.read_media_frame_after_prefix(
+                max_prefix_bytes=self.max_prefix_bytes,
+            )
+            yield _hcnetsdk_command_port_media_packet(media)
+            emitted += 1
+
+
 def open_local_sdk_stream(  # noqa: PLR0913
     endpoint: HcNetSdkLanEndpoint,
     device_info: EzvizCasDeviceInfo,
@@ -213,6 +284,34 @@ def open_local_sdk_stream(  # noqa: PLR0913
         stream_setup_sequence=stream_setup_sequence,
         stream_rate=stream_rate,
         stream_mode=stream_mode,
+        max_prefix_bytes=max_prefix_bytes,
+    )
+
+
+def open_hcnetsdk_command_port_stream(
+    endpoint: HcNetSdkLanEndpoint,
+    command_frames: Iterable[bytes],
+    *,
+    timeout: float | None = 10.0,
+    socket_factory: SocketFactory | None = None,
+    read_response_after_each: bool | Iterable[bool] = True,
+    read_first_media: bool = True,
+    max_prefix_bytes: int = 4096,
+) -> HcNetSdkCommandPortMediaStream:
+    """Return a command-port media stream for explicit bootstrap frames."""
+    if socket_factory is None:
+        command_client = HcNetSdkCommandPortClient(endpoint, timeout=timeout)
+    else:
+        command_client = HcNetSdkCommandPortClient(
+            endpoint,
+            timeout=timeout,
+            socket_factory=socket_factory,
+        )
+    return HcNetSdkCommandPortMediaStream(
+        command_client,
+        command_frames,
+        read_response_after_each=read_response_after_each,
+        read_first_media=read_first_media,
         max_prefix_bytes=max_prefix_bytes,
     )
 
@@ -595,9 +694,12 @@ def copy_local_stream_to_decrypted_mpegts(
         monotonic=monotonic,
     )
     if _local_stream_packets_are_idmx(packets):
-        hevc = _decrypt_idmx_local_packets_to_annexb(packets, media_key)
-        process = _open_local_hevc_mpegts_remux_process(ffmpeg_path)
-        _copy_mpegps_payloads_to_mpegts([hevc], output, process=process)
+        annexb = _decrypt_idmx_local_packets_to_annexb(packets, media_key)
+        if _annexb_looks_like_h264(annexb):
+            process = _open_local_h264_mpegts_remux_process(ffmpeg_path)
+        else:
+            process = _open_local_hevc_mpegts_remux_process(ffmpeg_path)
+        _copy_mpegps_payloads_to_mpegts([annexb], output, process=process)
         return
     decrypted = decrypt_hikvision_ps_video(
         b"".join(packets),
@@ -641,8 +743,19 @@ def copy_local_stream_to_mpegts(
         output.flush()
         return
 
+    while _is_ignorable_leading_stream_payload(first_payload):
+        try:
+            first_payload = next(payloads)
+        except StopIteration:
+            output.flush()
+            return
+
     if _looks_like_idmx_local_payload(first_payload):
-        raise _unsupported_idmx_local_payload_error()
+        packets = list(chain((first_payload,), payloads))
+        annexb = _idmx_local_packets_to_h264_annexb(packets)
+        process = _open_local_h264_mpegts_remux_process(ffmpeg_path)
+        _copy_mpegps_payloads_to_mpegts([annexb], output, process=process)
+        return
     if not first_payload.startswith(MPEG_PS_START_CODE):
         raise PyEzvizError(
             "Unsupported EZVIZ local stream payload format: expected MPEG-PS payload"
@@ -654,6 +767,11 @@ def copy_local_stream_to_mpegts(
         output,
         process=process,
     )
+
+
+def _is_ignorable_leading_stream_payload(payload: bytes) -> bool:
+    """Return True for tiny command-port blips before the first media record."""
+    return bool(payload) and len(payload) < len(MPEG_PS_START_CODE)
 
 
 def copy_hcnetsdk_real_data_to_mpegts(
@@ -681,6 +799,43 @@ def _local_media_packet(
         body=body,
         prefix=media.prefix,
     )
+
+
+def _hcnetsdk_command_port_media_packet(
+    media: EzvizInterleavedRtpFrameWithPrefix,
+) -> EzvizLocalStreamPacket:
+    body = _strip_local_sdk_payload_header(
+        _hcnetsdk_command_port_media_payload(media.frame.payload)
+    )
+    return EzvizLocalStreamPacket(
+        channel=media.frame.header.channel,
+        length=len(body),
+        body=body,
+        encrypted=_looks_like_idmx_local_payload(body),
+        prefix=media.prefix,
+    )
+
+
+def _hcnetsdk_command_port_media_payload(payload: bytes) -> bytes:
+    if _looks_like_idmx_local_payload(payload):
+        return payload
+    try:
+        unwrapped = rtp_payload(payload)
+    except PyEzvizError as err:
+        if str(err) not in {"Unsupported RTP version", "RTP packet is too short"}:
+            raise
+        return payload
+    if _looks_like_hcnetsdk_wrapped_media_payload(unwrapped):
+        return unwrapped
+    return payload
+
+
+def _looks_like_hcnetsdk_wrapped_media_payload(payload: bytes) -> bool:
+    if payload.startswith(MPEG_PS_START_CODE):
+        return True
+    if _looks_like_idmx_local_payload(payload):
+        return True
+    return _strip_local_sdk_payload_header(payload).startswith(MPEG_PS_START_CODE)
 
 
 def _strip_local_sdk_payload_header(payload: bytes) -> bytes:
@@ -766,10 +921,41 @@ def _open_local_hevc_mpegts_remux_process(
         raise PyEzvizError(f"Could not launch FFmpeg at {ffmpeg_path!r}: {err}") from err
 
 
+def _open_local_h264_mpegts_remux_process(
+    ffmpeg_path: str,
+) -> subprocess.Popen[bytes]:
+    try:
+        return subprocess.Popen(
+            [
+                ffmpeg_path,
+                "-hide_banner",
+                "-loglevel",
+                "error",
+                "-f",
+                "h264",
+                "-i",
+                "pipe:0",
+                "-c",
+                "copy",
+                "-f",
+                "mpegts",
+                "pipe:1",
+            ],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+        )
+    except OSError as err:
+        raise PyEzvizError(f"Could not launch FFmpeg at {ffmpeg_path!r}: {err}") from err
+
+
 IDMX_LOCAL_FRAME_SENTINEL = b"\x55\x66\x77\x88"
 IDMX_LOCAL_FRAME_HEADER_SIZE = 13
+IDMX_LOCAL_FRAME_SENTINEL_OFFSETS = (8, 9)
 HEVC_NAL_HEADER_SIZE = 2
+H264_FU_A_NAL_TYPE = 28
 IDMX_HEVC_MEDIA_FRAME_NAL_OFFSET = 12
+IDMX_COMMAND_H264_RECORD_TRAILER_PREFIX = b"\x24\0"
 
 
 def collect_local_stream_media_packets(
@@ -792,11 +978,161 @@ def collect_local_stream_media_packets(
 
 
 def _looks_like_idmx_local_payload(payload: bytes) -> bool:
-    return (
-        len(payload) >= IDMX_LOCAL_FRAME_HEADER_SIZE
-        and payload[0] == 0x0D
-        and payload[9:13] == IDMX_LOCAL_FRAME_SENTINEL
+    return _idmx_local_frame_header_size(payload) is not None or any(
+        _iter_idmx_local_frames(payload)
     )
+
+
+def _idmx_local_frame_header_size(payload: bytes) -> int | None:
+    for sentinel_offset in IDMX_LOCAL_FRAME_SENTINEL_OFFSETS:
+        header_size = sentinel_offset + len(IDMX_LOCAL_FRAME_SENTINEL)
+        if (
+            len(payload) >= header_size
+            and payload[sentinel_offset:header_size] == IDMX_LOCAL_FRAME_SENTINEL
+        ):
+            return header_size
+    return None
+
+
+def _iter_idmx_local_frames(payload: bytes) -> Iterator[bytes]:  # noqa: PLR0912
+    search_start = 0
+    while True:
+        sentinel_offset = payload.find(IDMX_LOCAL_FRAME_SENTINEL, search_start)
+        if sentinel_offset < 0:
+            break
+
+        valid_frame_starts: list[tuple[int, int]] = []
+        prefixed_frames: list[tuple[int, int, int]] = []
+        for local_sentinel_offset in IDMX_LOCAL_FRAME_SENTINEL_OFFSETS:
+            frame_start = sentinel_offset - local_sentinel_offset
+            if frame_start < 0:
+                continue
+            header_size = _idmx_local_frame_header_size(payload[frame_start:])
+            header_score = _idmx_local_frame_header_score(
+                payload[frame_start:],
+                header_size,
+            )
+            if header_size is None or header_score is None:
+                continue
+            prefix_start = frame_start - 4
+            if prefix_start >= 0:
+                prefixed_length = int.from_bytes(
+                    payload[prefix_start:frame_start],
+                    "little",
+                )
+                frame_end = frame_start + prefixed_length
+                if prefixed_length >= header_size and frame_end <= len(payload):
+                    prefixed_frames.append((frame_start, frame_end, header_score))
+                else:
+                    valid_frame_starts.append((frame_start, header_score))
+            else:
+                valid_frame_starts.append((frame_start, header_score))
+
+        if prefixed_frames:
+            frame_start, frame_end, _score = min(
+                prefixed_frames,
+                key=lambda item: (item[1], item[2]),
+            )
+            yield from _iter_idmx_local_frame_or_nested(payload[frame_start:frame_end])
+            search_start = frame_end
+            continue
+
+        if valid_frame_starts:
+            frame_start, _score = min(valid_frame_starts, key=lambda item: item[1])
+            next_sentinel_offset = payload.find(
+                IDMX_LOCAL_FRAME_SENTINEL,
+                sentinel_offset + 1,
+            )
+            if next_sentinel_offset < 0:
+                yield payload[frame_start:]
+                break
+
+            frame_end = next_sentinel_offset
+            next_frame_starts: list[tuple[int, int]] = []
+            for local_sentinel_offset in IDMX_LOCAL_FRAME_SENTINEL_OFFSETS:
+                next_frame_start = next_sentinel_offset - local_sentinel_offset
+                next_header_size = _idmx_local_frame_header_size(
+                    payload[next_frame_start:]
+                )
+                next_header_score = _idmx_local_frame_header_score(
+                    payload[next_frame_start:],
+                    next_header_size,
+                )
+                if (
+                    next_frame_start > frame_start
+                    and next_header_size is not None
+                    and next_header_score is not None
+                ):
+                    next_frame_starts.append((next_frame_start, next_header_score))
+            if next_frame_starts:
+                next_frame_start, _score = min(
+                    next_frame_starts,
+                    key=lambda item: (item[1], item[0]),
+                )
+                frame_end = _idmx_frame_end_before_next_prefix(payload, next_frame_start)
+
+            yield from _iter_idmx_local_frame_or_nested(payload[frame_start:frame_end])
+            search_start = frame_end
+            continue
+
+        search_start = sentinel_offset + 1
+
+
+def _idmx_local_frame_header_score(
+    payload: bytes,
+    header_size: int | None,
+) -> int | None:
+    if header_size is None or len(payload) < header_size:
+        return None
+    lead = payload[0]
+    if header_size == 13 and lead in {0x0D, 0xFA}:
+        return 0
+    if header_size == 12 and lead in {0x80, 0x90, 0xA0}:
+        return 0
+    if header_size == 13 and payload[1] in {0x80, 0x90, 0xA0}:
+        return 1
+    return None
+
+
+def _iter_idmx_local_frame_or_nested(frame: bytes) -> Iterator[bytes]:
+    """Yield one IDMX frame, or nested frames from command-port aggregate records."""
+    header_size = _idmx_local_frame_header_size(frame)
+    if header_size is None:
+        yield frame
+        return
+    body = frame[header_size:]
+    if not body.startswith(b"\x00\x10") or body.count(IDMX_LOCAL_FRAME_SENTINEL) <= 1:
+        yield frame
+        return
+    nested_frames = tuple(_iter_idmx_local_frames(body))
+    if not any(_idmx_local_frame_contains_media(nested) for nested in nested_frames):
+        yield frame
+        return
+    yield from nested_frames
+
+
+def _idmx_local_frame_contains_media(frame: bytes) -> bool:
+    header_size = _idmx_local_frame_header_size(frame)
+    if header_size is None:
+        return False
+    body = _strip_idmx_command_h264_record_trailer(frame[header_size:])
+    return (
+        _looks_like_idmx_hevc_parameter_frame(body)
+        or _looks_like_idmx_hevc_media_frame(body)
+        or _looks_like_idmx_h264_fu_a_frame(body)
+        or _looks_like_idmx_h264_clear_nal(body)
+    )
+
+
+def _idmx_frame_end_before_next_prefix(payload: bytes, next_frame_start: int) -> int:
+    prefix_start = next_frame_start - 4
+    if prefix_start < 0:
+        return next_frame_start
+    prefixed_length = int.from_bytes(payload[prefix_start:next_frame_start], "little")
+    remaining_after_prefix = len(payload) - next_frame_start
+    if 0 < prefixed_length <= remaining_after_prefix:
+        return prefix_start
+    return next_frame_start
 
 
 def _local_stream_packets_are_idmx(packets: list[bytes]) -> bool:
@@ -816,10 +1152,12 @@ def _decrypt_idmx_local_packets_to_annexb(
     aes_key = _local_media_aes_key(media_key)
     output = bytearray()
     active_fu: bytearray | None = None
-    for packet in packets:
-        if not _looks_like_idmx_local_payload(packet):
+    active_h264_fu: bytearray | None = None
+    for frame in _iter_idmx_local_frames(b"".join(packets)):
+        header_size = _idmx_local_frame_header_size(frame)
+        if header_size is None:
             raise PyEzvizError("Mixed EZVIZ local stream payload formats are unsupported")
-        body = packet[IDMX_LOCAL_FRAME_HEADER_SIZE:]
+        body = _strip_idmx_command_h264_record_trailer(frame[header_size:])
         if _looks_like_idmx_hevc_parameter_frame(body):
             # Live PlayCtrl takes parameter sets from the media-wrapper frames below;
             # the short sidecar-looking 00 01/00 02 records are not fed to FFmpeg.
@@ -831,11 +1169,45 @@ def _decrypt_idmx_local_packets_to_annexb(
                 aes_key,
                 active_fu=active_fu,
             )
+            continue
+        if _looks_like_idmx_h264_fu_a_frame(body):
+            active_h264_fu = _append_idmx_h264_fu_a_payload(
+                output,
+                body,
+                active_fu=active_h264_fu,
+            )
+            continue
+        if _looks_like_idmx_h264_clear_nal(body):
+            active_h264_fu = None
+            _append_h264_nal(output, body)
     if active_fu is not None:
         _append_decrypted_hevc_nal(output, bytes(active_fu), aes_key)
     if not output:
-        raise PyEzvizError("EZVIZ local IDMX stream did not include HEVC media frames")
+        raise PyEzvizError("EZVIZ local IDMX stream did not include media frames")
     return bytes(output)
+
+
+def _idmx_local_packets_to_h264_annexb(packets: list[bytes]) -> bytes:
+    output = bytearray()
+    active_h264_fu: bytearray | None = None
+    for frame in _iter_idmx_local_frames(b"".join(packets)):
+        header_size = _idmx_local_frame_header_size(frame)
+        if header_size is None:
+            continue
+        body = _strip_idmx_command_h264_record_trailer(frame[header_size:])
+        if _looks_like_idmx_h264_fu_a_frame(body):
+            active_h264_fu = _append_idmx_h264_fu_a_payload(
+                output,
+                body,
+                active_fu=active_h264_fu,
+            )
+            continue
+        if _looks_like_idmx_h264_clear_nal(body):
+            active_h264_fu = None
+            _append_h264_nal(output, body)
+    if not output:
+        raise PyEzvizError("EZVIZ local IDMX stream did not include clear H.264 media frames")
+    return _trim_trailing_h264_non_vcl_nals(bytes(output))
 
 
 def _local_media_aes_key(media_key: str | bytes) -> bytes:
@@ -855,6 +1227,31 @@ def _looks_like_idmx_hevc_media_frame(body: bytes) -> bool:
         len(body) > IDMX_HEVC_MEDIA_FRAME_NAL_OFFSET
         and body.startswith(b"\x40\x00\x00\x02\x80\x06")
     )
+
+
+def _looks_like_idmx_h264_fu_a_frame(body: bytes) -> bool:
+    return len(body) > 2 and body[0] & 0x1F == H264_FU_A_NAL_TYPE
+
+
+def _looks_like_idmx_h264_clear_nal(body: bytes) -> bool:
+    if not body:
+        return False
+    return (body[0] & 0x1F) in {1, 5, 6, 7, 8, 9}
+
+
+def _strip_idmx_command_h264_record_trailer(body: bytes) -> bytes:
+    if len(body) <= 4:
+        return body
+    if not (
+        _looks_like_idmx_h264_fu_a_frame(body)
+        or _looks_like_idmx_h264_clear_nal(body)
+    ):
+        return body
+    if body[-3:-1] == IDMX_COMMAND_H264_RECORD_TRAILER_PREFIX:
+        return body[:-3]
+    if body[-4:-2] == IDMX_COMMAND_H264_RECORD_TRAILER_PREFIX:
+        return body[:-4]
+    return body
 
 
 def _append_idmx_hevc_media_payload(
@@ -893,6 +1290,28 @@ def _append_idmx_hevc_media_payload(
     return active_fu
 
 
+def _append_idmx_h264_fu_a_payload(
+    output: bytearray,
+    payload: bytes,
+    *,
+    active_fu: bytearray | None,
+) -> bytearray | None:
+    fu_header = payload[1]
+    is_start = bool(fu_header & 0x80)
+    is_end = bool(fu_header & 0x40)
+    if active_fu is None and not is_start:
+        return None
+    reconstructed_header = bytes([(payload[0] & 0xE0) | (fu_header & 0x1F)])
+    if is_start:
+        active_fu = bytearray(reconstructed_header)
+    assert active_fu is not None
+    active_fu.extend(payload[2:])
+    if is_end:
+        _append_h264_nal(output, bytes(active_fu))
+        return None
+    return active_fu
+
+
 def _append_decrypted_hevc_nal(
     output: bytearray,
     nal: bytes,
@@ -904,12 +1323,76 @@ def _append_decrypted_hevc_nal(
     output.extend(_decrypt_hevc_nal_prefix(nal, aes_key))
 
 
+def _append_h264_nal(output: bytearray, nal: bytes) -> None:
+    if not _is_plausible_h264_nal(nal):
+        return
+    output.extend(ANNEX_B_LONG_START_CODE)
+    output.extend(nal)
+
+
 def _is_plausible_hevc_nal(nal: bytes) -> bool:
     return (
         len(nal) >= HEVC_NAL_HEADER_SIZE
         and not nal[0] & 0x80
         and nal[1] & 0x07 != 0
         and (nal[0] >> 1) & 0x3F <= 40
+    )
+
+
+def _is_plausible_h264_nal(nal: bytes) -> bool:
+    return len(nal) >= 3 and nal[0] & 0x80 == 0 and _h264_nal_type(nal) in {
+        1,
+        5,
+        6,
+        7,
+        8,
+        9,
+    }
+
+
+def _h264_nal_type(nal: bytes) -> int:
+    return nal[0] & 0x1F if nal else 0
+
+
+def _h264_annexb_nal_spans(data: bytes) -> list[tuple[int, int, int]]:
+    spans: list[tuple[int, int, int]] = []
+    start = 0
+    while True:
+        offset = data.find(ANNEX_B_LONG_START_CODE, start)
+        if offset < 0:
+            break
+        spans.append((offset, offset + len(ANNEX_B_LONG_START_CODE), len(data)))
+        start = offset + 1
+    if not spans:
+        return spans
+    return [
+        (offset, nal_start, spans[index + 1][0] if index + 1 < len(spans) else len(data))
+        for index, (offset, nal_start, _end) in enumerate(spans)
+    ]
+
+
+def _trim_trailing_h264_non_vcl_nals(data: bytes) -> bytes:
+    spans = _h264_annexb_nal_spans(data)
+    if not spans:
+        return data
+    last_vcl_end: int | None = None
+    last_vcl_index: int | None = None
+    for index, (_offset, nal_start, end) in enumerate(spans):
+        nal_type = _h264_nal_type(data[nal_start:end])
+        if nal_type in {1, 5}:
+            last_vcl_end = end
+            last_vcl_index = index
+    if last_vcl_end is None:
+        return data
+    if last_vcl_index == len(spans) - 1:
+        return data
+    return data[:last_vcl_end]
+
+
+def _annexb_looks_like_h264(data: bytes) -> bool:
+    return any(
+        _h264_nal_type(data[nal_start:end]) in {1, 5, 6, 7, 8, 9}
+        for _offset, nal_start, end in _h264_annexb_nal_spans(data)
     )
 
 

--- a/tests/cli_fakes.py
+++ b/tests/cli_fakes.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import json
-from typing import Any, ClassVar
+from pathlib import Path
+from typing import Any, BinaryIO, ClassVar
 
 import pyezvizapi.__main__ as cli_module
 
@@ -32,6 +33,10 @@ class FakeClient:
         self.sdcard_videos_request: dict[str, Any] = {}
         self.camera_ticket_info_request: dict[str, Any] = {}
         self.cam_key_request: dict[str, Any] = {}
+        self.capture_picture_request: dict[str, Any] = {}
+        self.download_alarm_image_request: dict[str, Any] = {}
+        self.save_clip_request: dict[str, Any] = {}
+        self.save_image_request: dict[str, Any] = {}
         self.__class__.instances.append(self)
 
     def login(self, sms_code: int | None = None) -> None:
@@ -212,6 +217,119 @@ class FakeClient:
     def get_cam_key(self, serial: str, *, max_retries: int = 0) -> str:
         self.cam_key_request = {"serial": serial, "max_retries": max_retries}
         return "camera-secret"
+
+    def capture_picture(
+        self,
+        serial: str,
+        channel: int,
+        *,
+        max_retries: int = 0,
+    ) -> dict[str, Any]:
+        self.capture_picture_request = {
+            "serial": serial,
+            "channel": channel,
+            "max_retries": max_retries,
+        }
+        return {
+            "data": {
+                "picUrl": "https://image.example.test/capture.jpg",
+            },
+            "meta": {"code": 200},
+        }
+
+    def download_alarm_image(
+        self,
+        image_url: str,
+        serial: str | None = None,
+        *,
+        encryption_key: str | None = None,
+        smscode: str | int | None = None,
+        decrypt: bool = True,
+        max_retries: int = 0,
+    ) -> bytes:
+        self.download_alarm_image_request = {
+            "image_url": image_url,
+            "serial": serial,
+            "encryption_key": encryption_key,
+            "smscode": smscode,
+            "decrypt": decrypt,
+            "max_retries": max_retries,
+        }
+        return b"jpeg-bytes"
+
+    def save_clip(
+        self,
+        serial: str,
+        output: str | Path | BinaryIO,
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        self.save_clip_request = {"serial": serial, "output": output, **kwargs}
+        if isinstance(output, str | Path):
+            path = Path(output)
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_bytes(b"mpegts")
+            output_name = str(path)
+            byte_count = path.stat().st_size
+        else:
+            output.write(b"mpegts")
+            output.flush()
+            output_name = getattr(output, "name", None)
+            byte_count = len(b"mpegts")
+        return {
+            "ok": True,
+            "kind": "clip",
+            "serial": serial,
+            "channel": kwargs.get("channel", 1),
+            "output": output_name,
+            "bytes": byte_count,
+            "source": kwargs.get("source", "local-sdk"),
+            "format": kwargs.get("output_format", "mpegts"),
+            "duration_seconds": kwargs.get("duration_seconds"),
+            "content_type": "video/mp2t",
+            **(
+                {"command_port": kwargs.get("command_port") or 8000}
+                if kwargs.get("source") == "hcnetsdk-command-port"
+                else {}
+            ),
+        }
+
+    def save_image(
+        self,
+        serial: str,
+        output: str | Path | BinaryIO,
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        self.save_image_request = {"serial": serial, "output": output, **kwargs}
+        image_url = kwargs.get("image_url") or "https://image.example.test/capture.jpg"
+        if kwargs.get("image_url") is None:
+            self.capture_picture(serial, kwargs.get("channel", 1), max_retries=1)
+        payload = self.download_alarm_image(
+            image_url,
+            serial,
+            decrypt=kwargs.get("decrypt", True),
+            smscode=kwargs.get("smscode"),
+            max_retries=1,
+        )
+        if isinstance(output, str | Path):
+            path = Path(output)
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_bytes(payload)
+            output_name = str(path)
+        else:
+            output.write(payload)
+            output.flush()
+            output_name = getattr(output, "name", None)
+        return {
+            "ok": True,
+            "kind": "image",
+            "serial": serial,
+            "channel": kwargs.get("channel", 1),
+            "output": output_name,
+            "bytes": len(payload),
+            "content_type": "image/jpeg",
+            "image_url": image_url,
+            "triggered_capture": kwargs.get("image_url") is None,
+        }
 
     def export_token(self) -> dict[str, Any]:
         return dict(self.exported_token)

--- a/tests/cli_fakes.py
+++ b/tests/cli_fakes.py
@@ -264,6 +264,7 @@ class FakeClient:
         **kwargs: Any,
     ) -> dict[str, Any]:
         self.save_clip_request = {"serial": serial, "output": output, **kwargs}
+        output_name: str | None
         if isinstance(output, str | Path):
             path = Path(output)
             path.parent.mkdir(parents=True, exist_ok=True)
@@ -310,6 +311,7 @@ class FakeClient:
             smscode=kwargs.get("smscode"),
             max_retries=1,
         )
+        output_name: str | None
         if isinstance(output, str | Path):
             path = Path(output)
             path.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/cli_fakes.py
+++ b/tests/cli_fakes.py
@@ -292,6 +292,15 @@ class FakeClient:
                 if kwargs.get("source") == "hcnetsdk-command-port"
                 else {}
             ),
+            **(
+                {
+                    "cloud_client_type": kwargs.get("cloud_client_type", 9),
+                    "cloud_token_index": kwargs.get("cloud_token_index", 0),
+                    "cloud_refresh_vtm": kwargs.get("cloud_refresh_vtm", True),
+                }
+                if kwargs.get("source") == "cloud"
+                else {}
+            ),
         }
 
     def save_image(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1104,6 +1104,87 @@ def test_save_clip_can_use_hcnetsdk_command_port_source(
     }
 
 
+def test_save_clip_can_use_cloud_source(
+    monkeypatch,
+    tmp_path,
+    capsys,
+) -> None:
+    fake_client = _install_fake_client(monkeypatch)
+    output_path = tmp_path / "www" / "front.ts"
+
+    assert (
+        cli_module.main(
+            [
+                "--token-file",
+                _token_file(tmp_path),
+                "--json",
+                "save",
+                "clip",
+                "--source",
+                "cloud",
+                "--serial",
+                "CAM123",
+                "--channel",
+                "2",
+                "--duration",
+                "3s",
+                "--max-packets",
+                "4",
+                "--output",
+                str(output_path),
+                "--ffmpeg-path",
+                "/usr/bin/ffmpeg",
+                "--client-type",
+                "7",
+                "--token-index",
+                "1",
+                "--no-refresh-vtm",
+            ]
+        )
+        == 0
+    )
+
+    client = fake_client.instances[0]
+    assert client.save_clip_request == {
+        "serial": "CAM123",
+        "output": str(output_path),
+        "source": "cloud",
+        "output_format": "mpegts",
+        "duration_seconds": HCNETSDK_TEST_SAVE_DURATION,
+        "max_packets": 4,
+        "channel": 2,
+        "ffmpeg_path": "/usr/bin/ffmpeg",
+        "decrypt_video": False,
+        "nalu_header_size": 0,
+        "cas_serial": None,
+        "timeout": HCNETSDK_DEFAULT_SAVE_TIMEOUT,
+        "smscode": None,
+        "host": None,
+        "command_port": None,
+        "hcnetsdk_command_frames": None,
+        "hcnetsdk_read_response_after_each": True,
+        "cloud_client_type": 7,
+        "cloud_token_index": 1,
+        "cloud_refresh_vtm": False,
+    }
+    assert output_path.read_bytes() == MPEGTS_PAYLOAD
+    assert json.loads(capsys.readouterr().out) == {
+        "ok": True,
+        "kind": "clip",
+        "serial": "CAM123",
+        "channel": 2,
+        "output": str(output_path),
+        "bytes": len(MPEGTS_PAYLOAD),
+        "source": "cloud",
+        "format": "mpegts",
+        "duration_seconds": HCNETSDK_TEST_SAVE_DURATION,
+        "content_type": "video/mp2t",
+        "cloud_client_type": 7,
+        "cloud_token_index": 1,
+        "cloud_refresh_vtm": False,
+    }
+
+
 def test_save_image_triggers_capture_and_downloads_url(
     monkeypatch,
     tmp_path,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -25,6 +25,9 @@ NATIVE_TRANSFORMED_PAYLOAD = b"decrypted"
 LOCAL_SDK_TEST_PAYLOAD = b"mpeg-ps"
 LOCAL_SDK_PRE_START_BODY = b"pre"
 LOCAL_SDK_DEFAULT_DURATION = 60.0
+HCNETSDK_DEFAULT_SAVE_TIMEOUT = 10.0
+HCNETSDK_TEST_SAVE_DURATION = 3.0
+IMAGE_PAYLOAD = b"jpeg-bytes"
 STRUCTURED_RECEIVER_INNER_ADDRESS_XML = b"<InnerAddress>192.0.2.20</InnerAddress>"
 STRUCTURED_RECEIVER_INNER_PORT_XML = b"<InnerPort>9020</InnerPort>"
 STRUCTURED_RECEIVER_AUTH_XML = b"<Authentication>"
@@ -945,6 +948,249 @@ def test_cloud_video_decrypt_rejects_missing_key(monkeypatch, tmp_path) -> None:
         )
         == 1
     )
+
+
+def test_save_clip_uses_direct_local_stream_and_outputs_json(
+    monkeypatch,
+    tmp_path,
+    capsys,
+) -> None:
+    fake_client = _install_fake_client(monkeypatch)
+    output_path = tmp_path / "www" / "front.ts"
+
+    assert (
+        cli_module.main(
+            [
+                "--token-file",
+                _token_file(tmp_path),
+                "--json",
+                "save",
+                "clip",
+                "--serial",
+                "CAM123",
+                "--channel",
+                "2",
+                "--duration",
+                "5s",
+                "--output",
+                str(output_path),
+                "--decrypt-video",
+                "--decrypt-codec",
+                "h264-encrypted-header",
+                "--ffmpeg-path",
+                "/usr/bin/ffmpeg",
+                "--sms-code",
+                "123456",
+            ]
+        )
+        == 0
+    )
+
+    client = fake_client.instances[0]
+    assert client.save_clip_request == {
+        "serial": "CAM123",
+        "output": str(output_path),
+        "source": "local-sdk",
+        "output_format": "mpegts",
+        "duration_seconds": 5.0,
+        "max_packets": None,
+        "channel": 2,
+        "ffmpeg_path": "/usr/bin/ffmpeg",
+        "decrypt_video": True,
+        "nalu_header_size": 0,
+        "cas_serial": None,
+        "timeout": 10.0,
+        "smscode": "123456",
+        "host": None,
+        "command_port": None,
+        "hcnetsdk_command_frames": None,
+        "hcnetsdk_read_response_after_each": True,
+    }
+    assert output_path.read_bytes() == MPEGTS_PAYLOAD
+    assert json.loads(capsys.readouterr().out) == {
+        "ok": True,
+        "kind": "clip",
+        "serial": "CAM123",
+        "channel": 2,
+        "output": str(output_path),
+        "bytes": len(MPEGTS_PAYLOAD),
+        "source": "local-sdk",
+        "format": "mpegts",
+        "duration_seconds": 5.0,
+        "content_type": "video/mp2t",
+    }
+
+
+def test_save_clip_can_use_hcnetsdk_command_port_source(
+    monkeypatch,
+    tmp_path,
+    capsys,
+) -> None:
+    fake_client = _install_fake_client(monkeypatch)
+    output_path = tmp_path / "www" / "front.ts"
+    frames_path = tmp_path / "frames.json"
+    frames_path.write_text(
+        json.dumps({"command_frames": [{"frame_hex": "00000010"}, "00000011"]}),
+        encoding="utf-8",
+    )
+
+    assert (
+        cli_module.main(
+            [
+                "--token-file",
+                _token_file(tmp_path),
+                "--json",
+                "save",
+                "clip",
+                "--source",
+                "hcnetsdk-command-port",
+                "--serial",
+                "CAM123",
+                "--host",
+                "192.0.2.10",
+                "--command-port",
+                "8000",
+                "--duration",
+                "3s",
+                "--max-packets",
+                "4",
+                "--output",
+                str(output_path),
+                "--hcnetsdk-command-frames-file",
+                str(frames_path),
+                "--hcnetsdk-read-responses",
+                "true,false",
+            ]
+        )
+        == 0
+    )
+
+    client = fake_client.instances[0]
+    assert client.save_clip_request == {
+        "serial": "CAM123",
+        "output": str(output_path),
+        "source": "hcnetsdk-command-port",
+        "output_format": "mpegts",
+        "duration_seconds": HCNETSDK_TEST_SAVE_DURATION,
+        "max_packets": 4,
+        "channel": 1,
+        "ffmpeg_path": "ffmpeg",
+        "decrypt_video": False,
+        "nalu_header_size": 0,
+        "cas_serial": None,
+        "timeout": HCNETSDK_DEFAULT_SAVE_TIMEOUT,
+        "smscode": None,
+        "host": "192.0.2.10",
+        "command_port": 8000,
+        "hcnetsdk_command_frames": (
+            bytes.fromhex("00000010"),
+            bytes.fromhex("00000011"),
+        ),
+        "hcnetsdk_read_response_after_each": (True, False),
+    }
+    assert output_path.read_bytes() == MPEGTS_PAYLOAD
+    assert json.loads(capsys.readouterr().out) == {
+        "ok": True,
+        "kind": "clip",
+        "serial": "CAM123",
+        "channel": 1,
+        "output": str(output_path),
+        "bytes": len(MPEGTS_PAYLOAD),
+        "source": "hcnetsdk-command-port",
+        "format": "mpegts",
+        "duration_seconds": HCNETSDK_TEST_SAVE_DURATION,
+        "content_type": "video/mp2t",
+        "command_port": 8000,
+    }
+
+
+def test_save_image_triggers_capture_and_downloads_url(
+    monkeypatch,
+    tmp_path,
+    capsys,
+) -> None:
+    fake_client = _install_fake_client(monkeypatch)
+    output_path = tmp_path / "snapshots" / "front.jpg"
+
+    assert (
+        cli_module.main(
+            [
+                "--token-file",
+                _token_file(tmp_path),
+                "--json",
+                "save",
+                "image",
+                "--serial",
+                "CAM123",
+                "--channel",
+                "2",
+                "--output",
+                str(output_path),
+                "--sms-code",
+                "654321",
+            ]
+        )
+        == 0
+    )
+
+    client = fake_client.instances[0]
+    assert client.capture_picture_request == {
+        "serial": "CAM123",
+        "channel": 2,
+        "max_retries": 1,
+    }
+    assert client.download_alarm_image_request == {
+        "image_url": "https://image.example.test/capture.jpg",
+        "serial": "CAM123",
+        "encryption_key": None,
+        "smscode": "654321",
+        "decrypt": True,
+        "max_retries": 1,
+    }
+    assert output_path.read_bytes() == IMAGE_PAYLOAD
+    assert json.loads(capsys.readouterr().out) == {
+        "ok": True,
+        "kind": "image",
+        "serial": "CAM123",
+        "channel": 2,
+        "output": str(output_path),
+        "bytes": len(IMAGE_PAYLOAD),
+        "content_type": "image/jpeg",
+        "image_url": "https://image.example.test/capture.jpg",
+        "triggered_capture": True,
+    }
+
+
+def test_save_image_can_download_existing_url_without_capture(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    fake_client = _install_fake_client(monkeypatch)
+    output_path = tmp_path / "alarm.jpg"
+
+    assert (
+        cli_module.main(
+            [
+                "--token-file",
+                _token_file(tmp_path),
+                "save",
+                "image",
+                "--serial",
+                "CAM123",
+                "--output",
+                str(output_path),
+                "--image-url",
+                "https://image.example.test/alarm.jpg",
+                "--no-decrypt",
+            ]
+        )
+        == 0
+    )
+
+    client = fake_client.instances[0]
+    assert client.capture_picture_request == {}
+    assert client.download_alarm_image_request["image_url"] == "https://image.example.test/alarm.jpg"
+    assert client.download_alarm_image_request["decrypt"] is False
 
 
 def test_stream_trace_outputs_sanitized_json_lines(monkeypatch, tmp_path, capsys) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1104,6 +1104,53 @@ def test_save_clip_can_use_hcnetsdk_command_port_source(
     }
 
 
+def test_save_clip_command_port_source_does_not_require_cloud_credentials(
+    monkeypatch,
+    tmp_path,
+    capsys,
+) -> None:
+    fake_client = _install_fake_client(monkeypatch)
+    output_path = tmp_path / "www" / "front.ts"
+    missing_token = tmp_path / "missing-token.json"
+
+    assert (
+        cli_module.main(
+            [
+                "--token-file",
+                str(missing_token),
+                "--json",
+                "save",
+                "clip",
+                "--source",
+                "hcnetsdk-command-port",
+                "--serial",
+                "CAM123",
+                "--host",
+                "192.0.2.10",
+                "--output",
+                str(output_path),
+                "--hcnetsdk-command-frame-hex",
+                "00000010",
+            ]
+        )
+        == 0
+    )
+
+    client = fake_client.instances[0]
+    assert client.account is None
+    assert client.password is None
+    assert client.token is None
+    assert client.login_calls == []
+    assert client.closed is True
+    assert client.save_clip_request["source"] == "hcnetsdk-command-port"
+    assert client.save_clip_request["host"] == "192.0.2.10"
+    assert client.save_clip_request["hcnetsdk_command_frames"] == (
+        bytes.fromhex("00000010"),
+    )
+    assert output_path.read_bytes() == MPEGTS_PAYLOAD
+    assert json.loads(capsys.readouterr().out)["source"] == "hcnetsdk-command-port"
+
+
 def test_save_clip_can_use_cloud_source(
     monkeypatch,
     tmp_path,

--- a/tests/test_hcnetsdk.py
+++ b/tests/test_hcnetsdk.py
@@ -54,6 +54,7 @@ from pyezvizapi.hcnetsdk import (
     EzvizLocalReceiverInfoEx,
     EzvizLocalSdkClient,
     HcNetSdkClientInfo,
+    HcNetSdkCommandPortClient,
     HcNetSdkDvrCommand,
     HcNetSdkLanEndpoint,
     HcNetSdkRealDataPacket,
@@ -93,9 +94,9 @@ from pyezvizapi.hcnetsdk import (
     ezviz_lan_settings_login_succeeded,
     ezviz_lan_settings_updates_services_switch,
     ezviz_lan_video_qualities,
-   ezviz_local_sdk_iv,
+    ezviz_local_sdk_iv,
     ezviz_local_sdk_ssl_iv,
-   ezviz_native_video_level,
+    ezviz_native_video_level,
     hcnetsdk_command_candidate_role,
     hcnetsdk_real_data_type_is_media,
     hcnetsdk_real_play_request,
@@ -114,6 +115,7 @@ from pyezvizapi.hcnetsdk import (
     read_ezviz_interleaved_rtp_frame,
     read_ezviz_interleaved_rtp_frame_after_prefix,
     read_ezviz_local_sdk_frame,
+    read_hcnetsdk_command_port_interleaved_frame_after_prefix,
     summarize_hcnetsdk_command_trace,
 )
 
@@ -1085,6 +1087,81 @@ def test_read_ezviz_interleaved_rtp_frame_after_prefix_rejects_long_preface() ->
 
     with pytest.raises(PyEzvizError, match="prefix exceeded"):
         read_ezviz_interleaved_rtp_frame_after_prefix(sock, max_prefix_bytes=3)
+
+
+def test_read_hcnetsdk_command_port_interleaved_frame_uses_total_length() -> None:
+    prefix = b"preface"
+    payload = b"a" * 1460
+    next_payload = b"next"
+    sock = _FragmentedSocket(
+        [
+            prefix,
+            bytes.fromhex("24 00 b8 05"),
+            payload,
+            bytes.fromhex("24 00 08 00"),
+            next_payload,
+        ]
+    )
+
+    first = read_hcnetsdk_command_port_interleaved_frame_after_prefix(sock)
+    second = read_hcnetsdk_command_port_interleaved_frame_after_prefix(sock)
+
+    assert first.prefix == prefix
+    assert first.frame.header.channel == 0
+    assert first.frame.header.payload_length == len(payload)
+    assert first.frame.payload == payload
+    assert not second.prefix
+    assert second.frame.header.payload_length == len(next_payload)
+    assert second.frame.payload == next_payload
+
+
+def test_read_hcnetsdk_command_port_interleaved_frame_rejects_short_length() -> None:
+    sock = _FragmentedSocket([bytes.fromhex("24 00 03 00")])
+
+    with pytest.raises(PyEzvizError, match="length is invalid"):
+        read_hcnetsdk_command_port_interleaved_frame_after_prefix(sock)
+
+
+def test_hcnetsdk_command_port_client_bootstraps_first_media() -> None:
+    expected_timeout = 3.0
+    request_1 = build_hcnetsdk_tcp_frame(b"login-1", field_4=90)
+    request_2 = build_hcnetsdk_tcp_frame(b"play", field_4=99)
+    response_1 = build_hcnetsdk_tcp_frame(b"ok-1", field_4=1)
+    response_2 = build_hcnetsdk_tcp_frame(b"ok-2", field_4=1)
+    prefix = b"preface"
+    media_payload = b"\x80\x60\x00\x01" + (b"\x00" * 8) + b"\x00\x00\x01\xbaabc"
+    media_frame = (
+        prefix
+        + b"\x24\x00"
+        + (len(media_payload) + 4).to_bytes(2, "little")
+        + media_payload
+    )
+    sock = _FakeSocket([response_1, response_2, media_frame])
+
+    def socket_factory(address: tuple[str, int], timeout: float | None) -> _FakeSocket:
+        assert address == ("192.0.2.10", 8000)
+        assert timeout == expected_timeout
+        return sock
+
+    client = HcNetSdkCommandPortClient(
+        HcNetSdkLanEndpoint(serial="CAM123", host="192.0.2.10"),
+        timeout=expected_timeout,
+        socket_factory=socket_factory,
+    )
+
+    bootstrap = client.bootstrap_media_stream(
+        [request_1, request_2],
+        max_prefix_bytes=16,
+    )
+
+    assert sock.sent == [request_1, request_2]
+    assert [exchange.response.body for exchange in bootstrap.exchanges if exchange.response] == [
+        b"ok-1",
+        b"ok-2",
+    ]
+    assert bootstrap.first_media is not None
+    assert bootstrap.first_media.prefix == prefix
+    assert bootstrap.first_media.frame.payload == media_payload
 
 
 def test_ezviz_local_sdk_client_bootstraps_preview_and_first_media() -> None:

--- a/tests/test_http_helpers.py
+++ b/tests/test_http_helpers.py
@@ -2683,6 +2683,77 @@ def test_save_clip_uses_hcnetsdk_command_port_source(monkeypatch, tmp_path) -> N
     }
 
 
+def test_save_clip_uses_cloud_source(monkeypatch, tmp_path) -> None:
+    client = _client()
+    output_path = tmp_path / "www" / "front.ts"
+    calls: list[dict[str, Any]] = []
+
+    def fake_copy_cloud_stream_to_mpegts(
+        source_client: EzvizClient,
+        serial: str,
+        output: BinaryIO,
+        **kwargs: Any,
+    ) -> None:
+        calls.append({"client": source_client, "serial": serial, **kwargs})
+        output.write(SAVE_CLIP_PAYLOAD)
+
+    monkeypatch.setattr(
+        "pyezvizapi.client.copy_cloud_stream_to_mpegts",
+        fake_copy_cloud_stream_to_mpegts,
+    )
+
+    result = client.save_clip(
+        "CAM123",
+        output_path,
+        source="cloud",
+        duration_seconds=HCNETSDK_SAVE_DURATION,
+        max_packets=4,
+        channel=2,
+        ffmpeg_path="/usr/bin/ffmpeg",
+        decrypt_video=True,
+        media_key="MEDIAKEY",
+        nalu_header_size=1,
+        timeout=5.0,
+        cloud_client_type=7,
+        cloud_token_index=1,
+        cloud_refresh_vtm=False,
+    )
+
+    assert calls == [
+        {
+            "client": client,
+            "serial": "CAM123",
+            "channel": 2,
+            "client_type": 7,
+            "token_index": 1,
+            "refresh_vtm": False,
+            "timeout": 5.0,
+            "max_packets": 4,
+            "duration_seconds": HCNETSDK_SAVE_DURATION,
+            "decrypt_video": True,
+            "media_key": "MEDIAKEY",
+            "nalu_header_size": 1,
+            "ffmpeg_path": "/usr/bin/ffmpeg",
+        }
+    ]
+    assert output_path.read_bytes() == SAVE_CLIP_PAYLOAD
+    assert result == {
+        "ok": True,
+        "kind": "clip",
+        "serial": "CAM123",
+        "channel": 2,
+        "output": str(output_path),
+        "bytes": len(SAVE_CLIP_PAYLOAD),
+        "source": "cloud",
+        "format": "mpegts",
+        "duration_seconds": HCNETSDK_SAVE_DURATION,
+        "content_type": "video/mp2t",
+        "cloud_client_type": 7,
+        "cloud_token_index": 1,
+        "cloud_refresh_vtm": False,
+    }
+
+
 def test_save_image_triggers_capture_and_downloads(monkeypatch, tmp_path) -> None:
     client = _client()
     output_path = tmp_path / "snapshots" / "front.jpg"

--- a/tests/test_http_helpers.py
+++ b/tests/test_http_helpers.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 import datetime as dt
+import io
 import json
 from pathlib import Path
-from typing import Any, cast
+from typing import Any, BinaryIO, cast
 
 import pytest
 import requests
@@ -23,6 +24,11 @@ from pyezvizapi.exceptions import (
     HTTPError,
     PyEzvizError,
 )
+
+DEFAULT_SAVE_TIMEOUT = 10.0
+HCNETSDK_SAVE_DURATION = 3.0
+SAVE_CLIP_PAYLOAD = b"mpegts"
+SAVE_IMAGE_PAYLOAD = b"jpeg-bytes"
 
 
 def _client() -> EzvizClient:
@@ -2532,6 +2538,246 @@ def test_download_alarm_image_requires_serial_or_key_for_encrypted_payload(
 
     with pytest.raises(PyEzvizError, match="Camera serial or encryption key"):
         client.download_alarm_image("https://image.example.test/encrypted.jpg")
+
+
+def test_save_clip_uses_local_sdk_convenience(monkeypatch, tmp_path) -> None:
+    client = _client()
+    output_path = tmp_path / "www" / "front.ts"
+    calls: list[dict[str, Any]] = []
+
+    def fake_copy_local_sdk_stream_from_client(
+        source_client: EzvizClient,
+        serial: str,
+        output: BinaryIO,
+        **kwargs: Any,
+    ) -> object:
+        calls.append({"client": source_client, "serial": serial, **kwargs})
+        output.write(SAVE_CLIP_PAYLOAD)
+        return object()
+
+    monkeypatch.setattr(
+        "pyezvizapi.client.copy_local_sdk_stream_from_client",
+        fake_copy_local_sdk_stream_from_client,
+    )
+
+    result = client.save_clip(
+        "CAM123",
+        output_path,
+        duration_seconds=5.0,
+        channel=2,
+        decrypt_video=True,
+        nalu_header_size=0,
+        ffmpeg_path="/usr/bin/ffmpeg",
+        smscode="123456",
+    )
+
+    assert calls == [
+        {
+            "client": client,
+            "serial": "CAM123",
+            "output_format": "mpegts",
+            "decrypt_video": True,
+            "media_key": None,
+            "nalu_header_size": 0,
+            "channel": 2,
+            "cas_serial": None,
+            "timeout": DEFAULT_SAVE_TIMEOUT,
+            "max_packets": None,
+            "duration_seconds": 5.0,
+            "ffmpeg_path": "/usr/bin/ffmpeg",
+            "smscode": "123456",
+        }
+    ]
+    assert output_path.read_bytes() == SAVE_CLIP_PAYLOAD
+    assert result == {
+        "ok": True,
+        "kind": "clip",
+        "serial": "CAM123",
+        "channel": 2,
+        "output": str(output_path),
+        "bytes": len(SAVE_CLIP_PAYLOAD),
+        "source": "local-sdk",
+        "format": "mpegts",
+        "duration_seconds": 5.0,
+        "content_type": "video/mp2t",
+    }
+
+
+def test_save_clip_uses_hcnetsdk_command_port_source(monkeypatch, tmp_path) -> None:
+    client = _client()
+    output_path = tmp_path / "www" / "front.ts"
+    calls: list[dict[str, Any]] = []
+
+    class FakeCommandPortStream:
+        def __enter__(self) -> FakeCommandPortStream:
+            return self
+
+        def __exit__(self, *_args: object) -> None:
+            return None
+
+    def fake_open_hcnetsdk_command_port_stream(
+        endpoint: Any,
+        command_frames: tuple[bytes, ...],
+        **kwargs: Any,
+    ) -> FakeCommandPortStream:
+        calls.append(
+            {
+                "endpoint": endpoint,
+                "command_frames": command_frames,
+                **kwargs,
+            }
+        )
+        return FakeCommandPortStream()
+
+    def fake_copy_local_stream_to_mpegts(
+        stream: FakeCommandPortStream,
+        output: BinaryIO,
+        **kwargs: Any,
+    ) -> None:
+        calls.append({"stream": stream, **kwargs})
+        output.write(b"mpegts")
+
+    monkeypatch.setattr(
+        "pyezvizapi.client.open_hcnetsdk_command_port_stream",
+        fake_open_hcnetsdk_command_port_stream,
+    )
+    monkeypatch.setattr(
+        "pyezvizapi.client.copy_local_stream_to_mpegts",
+        fake_copy_local_stream_to_mpegts,
+    )
+
+    result = client.save_clip(
+        "CAM123",
+        output_path,
+        source="hcnetsdk-command-port",
+        host="192.0.2.10",
+        command_port=8000,
+        hcnetsdk_command_frames=(bytes.fromhex("00000010"),),
+        hcnetsdk_read_response_after_each=(False,),
+        duration_seconds=HCNETSDK_SAVE_DURATION,
+        max_packets=4,
+    )
+
+    endpoint = calls[0]["endpoint"]
+    assert endpoint.host == "192.0.2.10"
+    assert endpoint.command_port == 8000
+    assert calls[0]["command_frames"] == (bytes.fromhex("00000010"),)
+    assert calls[0]["timeout"] == DEFAULT_SAVE_TIMEOUT
+    assert calls[0]["read_response_after_each"] == (False,)
+    assert calls[1]["ffmpeg_path"] == "ffmpeg"
+    assert calls[1]["max_packets"] == 4
+    assert calls[1]["duration_seconds"] == HCNETSDK_SAVE_DURATION
+    assert output_path.read_bytes() == SAVE_CLIP_PAYLOAD
+    assert result == {
+        "ok": True,
+        "kind": "clip",
+        "serial": "CAM123",
+        "channel": 1,
+        "output": str(output_path),
+        "bytes": len(SAVE_CLIP_PAYLOAD),
+        "source": "hcnetsdk-command-port",
+        "format": "mpegts",
+        "duration_seconds": HCNETSDK_SAVE_DURATION,
+        "content_type": "video/mp2t",
+        "command_port": 8000,
+    }
+
+
+def test_save_image_triggers_capture_and_downloads(monkeypatch, tmp_path) -> None:
+    client = _client()
+    output_path = tmp_path / "snapshots" / "front.jpg"
+    calls: dict[str, Any] = {}
+
+    def fake_capture_picture(
+        serial: str,
+        channel: int,
+        *,
+        max_retries: int = 0,
+    ) -> dict[str, Any]:
+        calls["capture"] = {
+            "serial": serial,
+            "channel": channel,
+            "max_retries": max_retries,
+        }
+        return {
+            "data": {
+                "picUrl": "https://image.example.test/capture.jpg",
+            },
+            "meta": {"code": 200},
+        }
+
+    def fake_download_alarm_image(
+        image_url: str,
+        serial: str | None = None,
+        **kwargs: Any,
+    ) -> bytes:
+        calls["download"] = {"image_url": image_url, "serial": serial, **kwargs}
+        return SAVE_IMAGE_PAYLOAD
+
+    monkeypatch.setattr(client, "capture_picture", fake_capture_picture)
+    monkeypatch.setattr(client, "download_alarm_image", fake_download_alarm_image)
+
+    result = client.save_image(
+        "CAM123",
+        output_path,
+        channel=2,
+        smscode="654321",
+    )
+
+    assert calls["capture"] == {
+        "serial": "CAM123",
+        "channel": 2,
+        "max_retries": 1,
+    }
+    assert calls["download"] == {
+        "image_url": "https://image.example.test/capture.jpg",
+        "serial": "CAM123",
+        "decrypt": True,
+        "smscode": "654321",
+        "max_retries": 1,
+    }
+    assert output_path.read_bytes() == SAVE_IMAGE_PAYLOAD
+    assert result == {
+        "ok": True,
+        "kind": "image",
+        "serial": "CAM123",
+        "channel": 2,
+        "output": str(output_path),
+        "bytes": len(SAVE_IMAGE_PAYLOAD),
+        "content_type": "image/jpeg",
+        "image_url": "https://image.example.test/capture.jpg",
+        "triggered_capture": True,
+    }
+
+
+def test_save_image_can_write_to_binary_file(monkeypatch) -> None:
+    client = _client()
+    output = io.BytesIO()
+
+    def fake_download_alarm_image(*_args: Any, **_kwargs: Any) -> bytes:
+        return SAVE_IMAGE_PAYLOAD
+
+    monkeypatch.setattr(client, "download_alarm_image", fake_download_alarm_image)
+
+    result = client.save_image(
+        "CAM123",
+        output,
+        image_url="https://image.example.test/alarm.jpg",
+        decrypt=False,
+    )
+
+    assert output.getvalue() == SAVE_IMAGE_PAYLOAD
+    assert result == {
+        "ok": True,
+        "kind": "image",
+        "serial": "CAM123",
+        "channel": 1,
+        "output": None,
+        "bytes": len(SAVE_IMAGE_PAYLOAD),
+        "content_type": "image/jpeg",
+        "image_url": "https://image.example.test/alarm.jpg",
+        "triggered_capture": False,
+    }
 
 
 def test_download_cloud_video_fetches_direct_http_url(monkeypatch) -> None:

--- a/tests/test_http_helpers.py
+++ b/tests/test_http_helpers.py
@@ -2714,6 +2714,7 @@ def test_save_clip_uses_cloud_source(monkeypatch, tmp_path) -> None:
         media_key="MEDIAKEY",
         nalu_header_size=1,
         timeout=5.0,
+        smscode="654321",
         cloud_client_type=7,
         cloud_token_index=1,
         cloud_refresh_vtm=False,
@@ -2733,6 +2734,7 @@ def test_save_clip_uses_cloud_source(monkeypatch, tmp_path) -> None:
             "decrypt_video": True,
             "media_key": "MEDIAKEY",
             "nalu_header_size": 1,
+            "smscode": "654321",
             "ffmpeg_path": "/usr/bin/ffmpeg",
         }
     ]

--- a/tests/test_local_stream.py
+++ b/tests/test_local_stream.py
@@ -21,6 +21,7 @@ from pyezvizapi.hcnetsdk import (
 )
 from pyezvizapi.local_stream import (
     EzvizLocalSdkMediaStream,
+    HcNetSdkCommandPortMediaStream,
     collect_local_stream_mpegps,
     copy_hcnetsdk_real_data_to_mpegts,
     copy_local_sdk_stream_from_client,
@@ -102,6 +103,34 @@ class _FakeSdkClient:
         self.closed = True
 
 
+class _FakeCommandPortClient:
+    def __init__(self, *media: EzvizInterleavedRtpFrameWithPrefix) -> None:
+        self.media = list(media)
+        self.bootstrap_calls: list[dict[str, Any]] = []
+        self.read_prefix_limits: list[int] = []
+        self.closed = False
+
+    def bootstrap_media_stream(
+        self,
+        command_frames: tuple[bytes, ...],
+        **kwargs: Any,
+    ) -> Any:
+        self.bootstrap_calls.append(
+            {
+                "command_frames": command_frames,
+                **kwargs,
+            }
+        )
+        return SimpleNamespace(first_media=self.media.pop(0))
+
+    def read_media_frame_after_prefix(self, *, max_prefix_bytes: int) -> Any:
+        self.read_prefix_limits.append(max_prefix_bytes)
+        return self.media.pop(0)
+
+    def close(self) -> None:
+        self.closed = True
+
+
 def test_local_sdk_media_stream_yields_mpeg_ps_payloads() -> None:
     first_payload = b"\x00\x00\x01\xbaabc"
     second_payload = b"\x00\x00\x01\xbadef"
@@ -150,6 +179,28 @@ def test_local_sdk_media_stream_strips_ezviz_fragment_headers() -> None:
         b"\x00\x00\x01\xbaabc",
         b"def",
     ]
+
+
+def test_hcnetsdk_command_port_media_stream_strips_rtp_continuation_fragments() -> None:
+    first_payload = b"\x1c\x80\x00\x00\x01\xbaabc"
+    continuation_payload = b"\x1c\x00def"
+    command_client = _FakeCommandPortClient(
+        _media(first_payload, sequence=1),
+        _media(continuation_payload, sequence=2),
+    )
+    stream = HcNetSdkCommandPortMediaStream(
+        command_client,  # type: ignore[arg-type]
+        (b"preview-start",),
+        max_prefix_bytes=128,
+    )
+
+    packets = list(stream.iter_packets(max_packets=2))
+
+    assert [packet.body for packet in packets] == [
+        b"\x00\x00\x01\xbaabc",
+        b"def",
+    ]
+    assert command_client.read_prefix_limits == [128]
 
 
 def test_local_sdk_media_stream_respects_zero_packet_limit() -> None:

--- a/tests/test_local_stream.py
+++ b/tests/test_local_stream.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Iterator
 import io
 from types import SimpleNamespace
 from typing import Any, cast
@@ -669,7 +670,8 @@ def test_copy_local_stream_to_decrypted_mpegts_decrypts_idmx_payload(
     fake_ffmpeg.write_text(
         "#!/usr/bin/env python3\n"
         "import sys\n"
-        "sys.stdout.buffer.write(b'ts:' + sys.stdin.buffer.read())\n",
+        "codec = sys.argv[sys.argv.index('-f') + 1]\n"
+        "sys.stdout.buffer.write(codec.encode() + b':' + sys.stdin.buffer.read())\n",
         encoding="utf-8",
     )
     fake_ffmpeg.chmod(0o755)
@@ -714,7 +716,7 @@ def test_copy_local_stream_to_decrypted_mpegts_decrypts_idmx_payload(
     )
 
     assert output.getvalue() == (
-        b"ts:\x00\x00\x00\x01"
+        b"hevc:\x00\x00\x00\x01"
         + vps_plain
         + b"\x00\x00\x00\x01"
         + b"\x26\x01"
@@ -783,6 +785,22 @@ def test_copy_local_stream_to_decrypted_mpegts_requires_bounded_capture() -> Non
             io.BytesIO(),
             "media-secret",
         )
+
+
+def test_copy_local_stream_to_mpegts_rejects_unbounded_clear_idmx_payload() -> None:
+    idmx_header = b"\x80\x01\x02\x03\x04\x05\x06\x07\x55\x66\x77\x88"
+    sps = b"\x67\x4d\x00"
+    frame = idmx_header + sps
+    idmx_packet = len(frame).to_bytes(4, "little") + frame
+
+    class FakeStream:
+        def iter_packets(self, *, max_packets: int | None = None) -> Iterator[Any]:
+            assert max_packets is None
+            yield SimpleNamespace(body=idmx_packet)
+            raise AssertionError("clear IDMX remux should require a bounded capture")
+
+    with pytest.raises(PyEzvizError, match="IDMX stream remux requires"):
+        copy_local_stream_to_mpegts(FakeStream(), io.BytesIO())
 
 
 def test_copy_local_stream_to_mpegts_pipes_payloads(tmp_path) -> None:

--- a/tests/test_local_stream.py
+++ b/tests/test_local_stream.py
@@ -762,7 +762,7 @@ def test_copy_local_stream_to_decrypted_mpegts_rejects_unknown_idmx_before_ffmpe
                 )
             ]
 
-    with pytest.raises(PyEzvizError, match="did not include HEVC media frames"):
+    with pytest.raises(PyEzvizError, match="did not include media frames"):
         copy_local_stream_to_decrypted_mpegts(
             FakeStream(),
             io.BytesIO(),
@@ -815,20 +815,144 @@ def test_copy_local_stream_to_mpegts_pipes_payloads(tmp_path) -> None:
     assert output.getvalue() == MPEG_PS_PAYLOAD
 
 
-def test_copy_local_stream_to_mpegts_rejects_idmx_payload_without_decrypt() -> None:
+def test_copy_local_stream_to_mpegts_remuxes_clear_h264_idmx_payload(tmp_path) -> None:
+    fake_ffmpeg = tmp_path / "fake-ffmpeg"
+    fake_ffmpeg.write_text(
+        "#!/usr/bin/env python3\n"
+        "import sys\n"
+        "sys.stdout.buffer.write(b'ts:' + sys.stdin.buffer.read())\n",
+        encoding="utf-8",
+    )
+    fake_ffmpeg.chmod(0o755)
+    idmx_header = b"\x80\x01\x02\x03\x04\x05\x06\x07\x55\x66\x77\x88"
+    sps = b"\x67\x4d\x00"
+    pps = b"\x68\xee\x38"
+
+    def idmx_frame(body: bytes) -> bytes:
+        frame = idmx_header + body
+        return len(frame).to_bytes(4, "little") + frame
+
+    class FakeStream:
+        def iter_packets(self, *, max_packets: int | None = None) -> list[Any]:
+            assert max_packets == 2
+            return [SimpleNamespace(body=idmx_frame(sps)), SimpleNamespace(body=idmx_frame(pps))]
+
+    output = io.BytesIO()
+
+    copy_local_stream_to_mpegts(
+        FakeStream(),
+        output,
+        ffmpeg_path=str(fake_ffmpeg),
+        max_packets=2,
+    )
+
+    assert output.getvalue() == (
+        b"ts:\x00\x00\x00\x01" + sps + b"\x00\x00\x00\x01" + pps
+    )
+
+
+def test_copy_local_stream_to_mpegts_models_command_port_h264_fu_a(tmp_path) -> None:
+    fake_ffmpeg = tmp_path / "fake-ffmpeg"
+    fake_ffmpeg.write_text(
+        "#!/usr/bin/env python3\n"
+        "import sys\n"
+        "sys.stdout.buffer.write(b'ts:' + sys.stdin.buffer.read())\n",
+        encoding="utf-8",
+    )
+    fake_ffmpeg.chmod(0o755)
+    idmx_header = b"\x80\x60\x5d\x5c\x7d\x52\x2a\x3e\x55\x66\x77\x88"
+    first_fu = b"\x7c\x85\x88\x80\x00\x00\x1a\x48native-first"
+    next_fu = b"\x7c\x05native-middle"
+    last_fu = b"\x7c\x45native-last"
+
+    def idmx_frame(body: bytes) -> bytes:
+        frame = idmx_header + body
+        return len(frame).to_bytes(4, "little") + frame
+
     class FakeStream:
         def iter_packets(self, *, max_packets: int | None = None) -> list[Any]:
             assert max_packets == 1
             return [
                 SimpleNamespace(
-                    body=b"\x0d\x90\x00\x00\x00\x00\x00\x00\x00\x55\x66\x77\x88"
+                    body=idmx_frame(first_fu)
+                    + idmx_frame(next_fu)
+                    + idmx_frame(last_fu)
                 )
             ]
 
     output = io.BytesIO()
 
-    with pytest.raises(PyEzvizError, match="decrypt-video is required"):
-        copy_local_stream_to_mpegts(FakeStream(), output, max_packets=1)
+    copy_local_stream_to_mpegts(
+        FakeStream(),
+        output,
+        ffmpeg_path=str(fake_ffmpeg),
+        max_packets=1,
+    )
+
+    assert output.getvalue() == (
+        b"ts:\x00\x00\x00\x01"
+        b"\x65"
+        + first_fu[2:]
+        + next_fu[2:]
+        + last_fu[2:]
+    )
+
+
+def test_copy_local_stream_to_mpegts_flattens_command_port_idmx_aggregates(
+    tmp_path,
+) -> None:
+    fake_ffmpeg = tmp_path / "fake-ffmpeg"
+    fake_ffmpeg.write_text(
+        "#!/usr/bin/env python3\n"
+        "import sys\n"
+        "sys.stdout.buffer.write(b'ts:' + sys.stdin.buffer.read())\n",
+        encoding="utf-8",
+    )
+    fake_ffmpeg.chmod(0o755)
+    outer_header = b"\x80\x60\x5d\x5c\x7d\x52\x2a\x3e\x55\x66\x77\x88"
+    inner_header = b"\xa0\xe8\xb7\x12\x16\x54\x77\xeb\x55\x66\x77\x88"
+    sps = b"\x67\x4d\x00\x29"
+    pps = b"\x68\xee\x38\x80"
+    first_fu = b"\x7c\x85aggregate-first"
+    last_fu = b"\x7c\x45aggregate-last"
+
+    def inner_frame(body: bytes) -> bytes:
+        frame = inner_header + body
+        return len(frame).to_bytes(4, "little") + frame
+
+    aggregate_body = (
+        b"\x00\x10aggregate-sidecar"
+        + inner_frame(sps)
+        + inner_frame(pps)
+        + inner_frame(first_fu)
+        + inner_frame(last_fu)
+    )
+    outer_frame = outer_header + aggregate_body
+    packet = len(outer_frame).to_bytes(4, "little") + outer_frame
+
+    class FakeStream:
+        def iter_packets(self, *, max_packets: int | None = None) -> list[Any]:
+            assert max_packets == 1
+            return [SimpleNamespace(body=packet)]
+
+    output = io.BytesIO()
+
+    copy_local_stream_to_mpegts(
+        FakeStream(),
+        output,
+        ffmpeg_path=str(fake_ffmpeg),
+        max_packets=1,
+    )
+
+    assert output.getvalue() == (
+        b"ts:\x00\x00\x00\x01"
+        + sps
+        + b"\x00\x00\x00\x01"
+        + pps
+        + b"\x00\x00\x00\x01\x65"
+        + first_fu[2:]
+        + last_fu[2:]
+    )
 
 
 def test_copy_hcnetsdk_real_data_to_mpegts_filters_and_pipes_payloads(tmp_path) -> None:

--- a/tests/test_package_exports.py
+++ b/tests/test_package_exports.py
@@ -21,6 +21,8 @@ def test_command_port_helpers_are_runtime_exports() -> None:
         "HcNetSdkCommandPortMediaStream",
         "HcNetSdkCommandPortStreamBootstrap",
         "open_hcnetsdk_command_port_stream",
+        "read_hcnetsdk_command_port_interleaved_frame_after_prefix",
+        "read_hcnetsdk_tcp_frame",
     }
 
     assert expected <= set(pyezvizapi.__all__)

--- a/tests/test_package_exports.py
+++ b/tests/test_package_exports.py
@@ -14,6 +14,20 @@ def test_package_all_exports_resolve() -> None:
     assert missing == []
 
 
+def test_command_port_helpers_are_runtime_exports() -> None:
+    expected = {
+        "HcNetSdkCommandPortClient",
+        "HcNetSdkCommandPortExchange",
+        "HcNetSdkCommandPortMediaStream",
+        "HcNetSdkCommandPortStreamBootstrap",
+        "open_hcnetsdk_command_port_stream",
+    }
+
+    assert expected <= set(pyezvizapi.__all__)
+    for name in expected:
+        assert getattr(pyezvizapi, name) is not None
+
+
 def test_dir_includes_lazy_exports() -> None:
     exported = set(pyezvizapi.__all__)
     visible = set(dir(pyezvizapi))

--- a/tests/test_package_exports.py
+++ b/tests/test_package_exports.py
@@ -30,6 +30,17 @@ def test_command_port_helpers_are_runtime_exports() -> None:
         assert getattr(pyezvizapi, name) is not None
 
 
+def test_cloud_stream_copy_helpers_are_runtime_exports() -> None:
+    expected = {
+        "copy_cloud_stream_to_mpegps",
+        "copy_cloud_stream_to_mpegts",
+    }
+
+    assert expected <= set(pyezvizapi.__all__)
+    for name in expected:
+        assert getattr(pyezvizapi, name) is not None
+
+
 def test_dir_includes_lazy_exports() -> None:
     exported = set(pyezvizapi.__all__)
     visible = set(dir(pyezvizapi))

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import base64
 import importlib
+import io
 import json
 from typing import Any
 
@@ -12,6 +13,7 @@ import requests
 import pyezvizapi
 from pyezvizapi.client import EzvizClient
 from pyezvizapi.cloud_stream import (
+    copy_cloud_stream_to_mpegps,
     get_cloud_stream_info,
     get_vtdu_token_v2,
     get_vtm_info,
@@ -23,6 +25,7 @@ from pyezvizapi.stream import (
     StreamTransport,
     VtmChannel,
     VtmMessageCode,
+    VtmPacket,
     VtmStreamClient,
     VtmTraceEvent,
     _find_hevc_nal_start_codes,
@@ -2340,6 +2343,81 @@ def test_open_cloud_stream_returns_unstarted_vtm_client(monkeypatch) -> None:
     assert stream.stream_url == "ysproto://vtm.example.test:8554/live?dev=CAM123"
     assert stream.timeout == 3
     assert not stream.connected
+
+
+def test_copy_cloud_stream_to_mpegps_writes_clear_payloads(monkeypatch) -> None:
+    client = _client()
+    output = io.BytesIO()
+    expected_payload = b"ps-1ps-2"
+    calls: list[dict[str, Any]] = []
+
+    class FakeCloudStream:
+        started = False
+
+        def __enter__(self) -> FakeCloudStream:
+            return self
+
+        def __exit__(self, *_args: object) -> None:
+            return None
+
+        def start(self) -> None:
+            self.started = True
+
+        def iter_packets(self, *, max_packets: int | None = None) -> Any:
+            assert self.started
+            assert max_packets == 2
+            yield VtmPacket(
+                channel=VtmChannel.STREAM,
+                length=4,
+                sequence=1,
+                message_code=0,
+                body=b"ps-1",
+            )
+            yield VtmPacket(
+                channel=VtmChannel.STREAM,
+                length=4,
+                sequence=2,
+                message_code=0,
+                body=b"ps-2",
+            )
+
+    def fake_open_cloud_stream(
+        source_client: EzvizClient,
+        serial: str,
+        **kwargs: Any,
+    ) -> FakeCloudStream:
+        calls.append({"client": source_client, "serial": serial, **kwargs})
+        return FakeCloudStream()
+
+    monkeypatch.setattr(
+        "pyezvizapi.cloud_stream.open_cloud_stream",
+        fake_open_cloud_stream,
+    )
+
+    copy_cloud_stream_to_mpegps(
+        client,
+        "CAM123",
+        output,
+        channel=2,
+        client_type=7,
+        token_index=1,
+        refresh_vtm=False,
+        timeout=3.0,
+        max_packets=2,
+    )
+
+    assert calls == [
+        {
+            "client": client,
+            "serial": "CAM123",
+            "channel": 2,
+            "client_type": 7,
+            "token_index": 1,
+            "refresh_vtm": False,
+            "timeout": 3.0,
+        }
+    ]
+    assert output.getvalue() == expected_payload
 
 
 def test_get_cloud_stream_info_uses_requested_channel_resource(monkeypatch) -> None:

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -4,6 +4,7 @@ import base64
 import importlib
 import io
 import json
+import subprocess
 from typing import Any
 
 from Crypto.Cipher import AES
@@ -14,6 +15,7 @@ import pyezvizapi
 from pyezvizapi.client import EzvizClient
 from pyezvizapi.cloud_stream import (
     copy_cloud_stream_to_mpegps,
+    copy_cloud_stream_to_mpegts,
     get_cloud_stream_info,
     get_vtdu_token_v2,
     get_vtm_info,
@@ -55,6 +57,7 @@ from pyezvizapi.stream import (
 )
 
 BODY = b"abc"
+cloud_stream_module = importlib.import_module("pyezvizapi.cloud_stream")
 stream_module = importlib.import_module("pyezvizapi.stream")
 CAMERA_SERIAL_BYTES = b"CAM123"
 KEEPALIVE_REQ = b"\x0a\x07ssn-123"
@@ -2418,6 +2421,309 @@ def test_copy_cloud_stream_to_mpegps_writes_clear_payloads(monkeypatch) -> None:
         }
     ]
     assert output.getvalue() == expected_payload
+
+
+def test_copy_cloud_stream_to_mpegps_decrypts_bounded_payloads(monkeypatch) -> None:
+    client = _client()
+    output = io.BytesIO()
+    clear_payload = b"clear-ps"
+    decrypt_calls: list[dict[str, Any]] = []
+
+    class FakeCloudStream:
+        def __enter__(self) -> FakeCloudStream:
+            return self
+
+        def __exit__(self, *_args: object) -> None:
+            return None
+
+        def start(self) -> None:
+            return None
+
+        def iter_packets(self, *, max_packets: int | None = None) -> Any:
+            assert max_packets == 2
+            yield VtmPacket(
+                channel=VtmChannel.STREAM,
+                length=4,
+                sequence=1,
+                message_code=0,
+                body=b"enc1",
+            )
+            yield VtmPacket(
+                channel=VtmChannel.STREAM,
+                length=4,
+                sequence=2,
+                message_code=0,
+                body=b"enc2",
+            )
+
+    def fake_decrypt(
+        data: bytes,
+        key: str | bytes,
+        *,
+        nalu_header_size: int | None = None,
+    ) -> bytes:
+        decrypt_calls.append(
+            {
+                "data": data,
+                "key": key,
+                "nalu_header_size": nalu_header_size,
+            }
+        )
+        return clear_payload
+
+    monkeypatch.setattr(
+        "pyezvizapi.cloud_stream.open_cloud_stream",
+        lambda *_args, **_kwargs: FakeCloudStream(),
+    )
+    monkeypatch.setattr("pyezvizapi.cloud_stream.decrypt_hikvision_ps_video", fake_decrypt)
+
+    copy_cloud_stream_to_mpegps(
+        client,
+        "CAM123",
+        output,
+        max_packets=2,
+        decrypt_video=True,
+        media_key="MEDIAKEY",
+        nalu_header_size=1,
+    )
+
+    assert decrypt_calls == [
+        {"data": b"enc1enc2", "key": "MEDIAKEY", "nalu_header_size": 1}
+    ]
+    assert output.getvalue() == clear_payload
+
+
+def test_copy_cloud_stream_to_mpegps_requires_bounded_decrypt() -> None:
+    with pytest.raises(PyEzvizError, match="requires duration_seconds or max_packets"):
+        copy_cloud_stream_to_mpegps(
+            _client(),
+            "CAM123",
+            io.BytesIO(),
+            duration_seconds=None,
+            max_packets=None,
+            decrypt_video=True,
+            media_key="MEDIAKEY",
+        )
+
+
+def test_copy_cloud_stream_to_mpegts_pipes_clear_payloads(monkeypatch) -> None:
+    client = _client()
+    output = io.BytesIO()
+    expected_payload = b"ps-1ps-2"
+    open_calls: list[str] = []
+
+    class FakeCloudStream:
+        def __enter__(self) -> FakeCloudStream:
+            return self
+
+        def __exit__(self, *_args: object) -> None:
+            return None
+
+        def start(self) -> None:
+            return None
+
+        def iter_packets(self, *, max_packets: int | None = None) -> Any:
+            assert max_packets == 2
+            yield VtmPacket(
+                channel=VtmChannel.STREAM,
+                length=4,
+                sequence=1,
+                message_code=0,
+                body=b"ps-1",
+            )
+            yield VtmPacket(
+                channel=VtmChannel.STREAM,
+                length=4,
+                sequence=2,
+                message_code=0,
+                body=b"ps-2",
+            )
+
+    def fake_open_remux(ffmpeg_path: str) -> subprocess.Popen[bytes]:
+        open_calls.append(ffmpeg_path)
+        return subprocess.Popen(
+            ["cat"],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+        )
+
+    monkeypatch.setattr(
+        "pyezvizapi.cloud_stream.open_cloud_stream",
+        lambda *_args, **_kwargs: FakeCloudStream(),
+    )
+    monkeypatch.setattr(
+        "pyezvizapi.cloud_stream._open_cloud_mpegts_remux_process",
+        fake_open_remux,
+    )
+
+    copy_cloud_stream_to_mpegts(
+        client,
+        "CAM123",
+        output,
+        ffmpeg_path="/usr/bin/ffmpeg",
+        max_packets=2,
+    )
+
+    assert open_calls == ["/usr/bin/ffmpeg"]
+    assert output.getvalue() == expected_payload
+
+
+def test_copy_cloud_stream_to_mpegts_decrypts_and_remuxes(monkeypatch) -> None:
+    client = _client()
+    output = io.BytesIO()
+    expected_payload = b"ts:clear"
+    calls: dict[str, Any] = {}
+
+    class FakeCloudStream:
+        def __enter__(self) -> FakeCloudStream:
+            return self
+
+        def __exit__(self, *_args: object) -> None:
+            return None
+
+        def start(self) -> None:
+            return None
+
+        def iter_packets(self, *, max_packets: int | None = None) -> Any:
+            assert max_packets == 1
+            yield VtmPacket(
+                channel=VtmChannel.STREAM,
+                length=3,
+                sequence=1,
+                message_code=0,
+                body=b"enc",
+            )
+
+    class FakeRemuxProcess:
+        returncode = 0
+
+        def communicate(self, data: bytes) -> tuple[bytes, bytes]:
+            calls["remux_input"] = data
+            return (b"ts:" + data, b"")
+
+    def fake_decrypt(
+        data: bytes,
+        key: str | bytes,
+        *,
+        nalu_header_size: int | None = None,
+    ) -> bytes:
+        calls["decrypt"] = {
+            "data": data,
+            "key": key,
+            "nalu_header_size": nalu_header_size,
+        }
+        return b"clear"
+
+    monkeypatch.setattr(
+        "pyezvizapi.cloud_stream.open_cloud_stream",
+        lambda *_args, **_kwargs: FakeCloudStream(),
+    )
+    monkeypatch.setattr("pyezvizapi.cloud_stream.decrypt_hikvision_ps_video", fake_decrypt)
+    monkeypatch.setattr(
+        "pyezvizapi.cloud_stream._open_cloud_mpegts_remux_process",
+        lambda _ffmpeg_path: FakeRemuxProcess(),
+    )
+
+    copy_cloud_stream_to_mpegts(
+        client,
+        "CAM123",
+        output,
+        max_packets=1,
+        decrypt_video=True,
+        media_key=b"MEDIAKEY",
+        nalu_header_size=2,
+    )
+
+    assert calls == {
+        "decrypt": {"data": b"enc", "key": b"MEDIAKEY", "nalu_header_size": 2},
+        "remux_input": b"clear",
+    }
+    assert output.getvalue() == expected_payload
+
+
+def test_copy_cloud_stream_rejects_encrypted_vtm_packets(monkeypatch) -> None:
+    class FakeCloudStream:
+        def __enter__(self) -> FakeCloudStream:
+            return self
+
+        def __exit__(self, *_args: object) -> None:
+            return None
+
+        def start(self) -> None:
+            return None
+
+        def iter_packets(self, *, max_packets: int | None = None) -> Any:
+            yield VtmPacket(
+                channel=VtmChannel.ENCRYPTED_STREAM,
+                length=3,
+                sequence=1,
+                message_code=0,
+                body=b"enc",
+            )
+
+    monkeypatch.setattr(
+        "pyezvizapi.cloud_stream.open_cloud_stream",
+        lambda *_args, **_kwargs: FakeCloudStream(),
+    )
+
+    with pytest.raises(PyEzvizError, match="Received encrypted VTM stream packet"):
+        copy_cloud_stream_to_mpegps(_client(), "CAM123", io.BytesIO(), max_packets=1)
+
+
+def test_open_cloud_mpegts_remux_process_builds_ffmpeg_command(monkeypatch) -> None:
+    calls: list[dict[str, Any]] = []
+
+    class FakeProcess:
+        pass
+
+    def fake_popen(args: list[str], **kwargs: Any) -> FakeProcess:
+        calls.append({"args": args, **kwargs})
+        return FakeProcess()
+
+    monkeypatch.setattr("pyezvizapi.cloud_stream.subprocess.Popen", fake_popen)
+
+    process = cloud_stream_module._open_cloud_mpegts_remux_process(  # noqa: SLF001
+        "/bin/ffmpeg"
+    )
+
+    assert isinstance(process, FakeProcess)
+    assert calls == [
+        {
+            "args": [
+                "/bin/ffmpeg",
+                "-hide_banner",
+                "-loglevel",
+                "error",
+                "-f",
+                "mpeg",
+                "-i",
+                "pipe:0",
+                "-c",
+                "copy",
+                "-f",
+                "mpegts",
+                "pipe:1",
+            ],
+            "stdin": subprocess.PIPE,
+            "stdout": subprocess.PIPE,
+            "stderr": subprocess.DEVNULL,
+        }
+    ]
+
+
+def test_open_cloud_mpegts_remux_process_reports_launch_errors(
+    monkeypatch,
+) -> None:
+    def fake_popen(_args: list[str], **_kwargs: Any) -> None:
+        raise OSError("missing")
+
+    monkeypatch.setattr("pyezvizapi.cloud_stream.subprocess.Popen", fake_popen)
+
+    with pytest.raises(PyEzvizError, match="Could not launch FFmpeg"):
+        cloud_stream_module._open_cloud_mpegts_remux_process(  # noqa: SLF001
+            "/missing/ffmpeg"
+        )
 
 
 def test_get_cloud_stream_info_uses_requested_channel_resource(monkeypatch) -> None:

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -2493,6 +2493,63 @@ def test_copy_cloud_stream_to_mpegps_decrypts_bounded_payloads(monkeypatch) -> N
     assert output.getvalue() == clear_payload
 
 
+def test_copy_cloud_stream_to_mpegps_fetches_media_key_with_smscode(monkeypatch) -> None:
+    client = _client()
+    output = io.BytesIO()
+    expected_payload = b"enc:camera-secret"
+    calls: dict[str, Any] = {}
+
+    class FakeCloudStream:
+        def __enter__(self) -> FakeCloudStream:
+            return self
+
+        def __exit__(self, *_args: object) -> None:
+            return None
+
+        def start(self) -> None:
+            return None
+
+        def iter_packets(self, *, max_packets: int | None = None) -> Any:
+            assert max_packets == 1
+            yield VtmPacket(
+                channel=VtmChannel.STREAM,
+                length=3,
+                sequence=1,
+                message_code=0,
+                body=b"enc",
+            )
+
+    def fake_get_cam_key(
+        serial: str,
+        *,
+        smscode: str | int | None = None,
+    ) -> str:
+        calls["get_cam_key"] = {"serial": serial, "smscode": smscode}
+        return "camera-secret"
+
+    monkeypatch.setattr(client, "get_cam_key", fake_get_cam_key)
+    monkeypatch.setattr(
+        "pyezvizapi.cloud_stream.open_cloud_stream",
+        lambda *_args, **_kwargs: FakeCloudStream(),
+    )
+    monkeypatch.setattr(
+        "pyezvizapi.cloud_stream.decrypt_hikvision_ps_video",
+        lambda data, key, **_kwargs: b":".join((data, str(key).encode())),
+    )
+
+    copy_cloud_stream_to_mpegps(
+        client,
+        "CAM123",
+        output,
+        max_packets=1,
+        decrypt_video=True,
+        smscode="123456",
+    )
+
+    assert calls == {"get_cam_key": {"serial": "CAM123", "smscode": "123456"}}
+    assert output.getvalue() == expected_payload
+
+
 def test_copy_cloud_stream_to_mpegps_requires_bounded_decrypt() -> None:
     with pytest.raises(PyEzvizError, match="requires duration_seconds or max_packets"):
         copy_cloud_stream_to_mpegps(
@@ -2615,6 +2672,15 @@ def test_copy_cloud_stream_to_mpegts_decrypts_and_remuxes(monkeypatch) -> None:
         }
         return b"clear"
 
+    def fake_get_cam_key(
+        serial: str,
+        *,
+        smscode: str | int | None = None,
+    ) -> str:
+        calls["get_cam_key"] = {"serial": serial, "smscode": smscode}
+        return "camera-secret"
+
+    monkeypatch.setattr(client, "get_cam_key", fake_get_cam_key)
     monkeypatch.setattr(
         "pyezvizapi.cloud_stream.open_cloud_stream",
         lambda *_args, **_kwargs: FakeCloudStream(),
@@ -2631,12 +2697,13 @@ def test_copy_cloud_stream_to_mpegts_decrypts_and_remuxes(monkeypatch) -> None:
         output,
         max_packets=1,
         decrypt_video=True,
-        media_key=b"MEDIAKEY",
+        smscode="654321",
         nalu_header_size=2,
     )
 
     assert calls == {
-        "decrypt": {"data": b"enc", "key": b"MEDIAKEY", "nalu_header_size": 2},
+        "get_cam_key": {"serial": "CAM123", "smscode": "654321"},
+        "decrypt": {"data": b"enc", "key": "camera-secret", "nalu_header_size": 2},
         "remux_input": b"clear",
     }
     assert output.getvalue() == expected_payload


### PR DESCRIPTION
## Summary

- Simplifies PR #241 down to package-facing native-Python changes only.
- Parses HCNetSDK command-port `$` media frames as little-endian total frame lengths, keeping this separate from the stream-port big-endian payload-length reader.
- Adds clear H.264 IDMX remux handling for command-port media packets.
- Adds person-friendly `pyezvizapi save clip` / `save image` commands for writing clips and images to filesystem paths, including direct-local 9010/9020 SDK, VTM cloud live streaming, and full-local HCNetSDK command-port media on port 8000 from caller-supplied command frames.
- Adds `EzvizClient.save_clip()` and `EzvizClient.save_image()` so Home Assistant or similar integrations can consume the same behavior directly through `client.py` with path or binary file-object outputs.
- Exports cloud live copy helpers for reusable API consumers: `copy_cloud_stream_to_mpegps()` and `copy_cloud_stream_to_mpegts()`.
- Keeps reverse-engineering/operator tooling under `tools/apk-re`; it is not included in release package artifacts.
- Addresses Codex review feedback by exporting command-port and HCNetSDK read helpers at runtime, bounding clear-IDMX remux captures, routing decrypted HEVC IDMX before the H.264 remuxer, threading SMS codes through cloud clip decryption, unwrapping command-port RTP continuation fragments, and allowing explicit command-port saves without cloud credentials.

## Validation

- `.venv/bin/python -m pytest -q tests/test_local_stream.py -q`
- `.venv/bin/python -m pytest -q tests/test_cli.py -q`
- `.venv/bin/python -m pytest -q tests/test_cli.py -q -k 'save_clip_command_port_source or save_clip_can_use_hcnetsdk_command_port_source or main_requires_existing_token'`
- `.venv/bin/python -m pytest -q`
- `.venv/bin/python -m pytest --cov=pyezvizapi --cov-report=term-missing --cov-report=xml --cov-fail-under=85`
- `.venv/bin/python -m ruff check pyezvizapi tests`
- `.venv/bin/python -m mypy pyezvizapi tests`
- `.venv/bin/python -m py_compile pyezvizapi/cloud_stream.py pyezvizapi/client.py pyezvizapi/__main__.py`
- `.venv/bin/python -m py_compile pyezvizapi/__main__.py tests/test_cli.py`
- `git diff --check`
- Earlier package build/archive inspection confirmed release artifacts do not include `tools/apk-re`, bytecode, Frida strings, reverse-engineering wording, or diagnostic command names.

## GitHub Checks

- CI, CodeQL, and Dependency Review are green on commit `2cc6382`.
