### PR TITLE
Add HCNetSDK command live matrix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ This project follows [Semantic Versioning](https://semver.org/) for published re
 - Added sanitized H.264 Annex-B NAL-unit and IDR-window summarizers, plus an offline `stream h264-annexb-summary` CLI, for comparing native player dumps with generated command-port diagnostics without storing media contents.
 - Added offline `stream hcnetsdk-command-dump-summary` support for summarizing Frida command-frame, inbound-media, and PlayM4 input dump artifacts without printing frame bodies or credentials.
 - Added optional IDR-window FFmpeg decode checks to `stream hcnetsdk-command-dump-summary` so native command-port dumps can show startup corruption and later clean windows directly.
+- Added `tools/apk-re/bin/hcnetsdk-command-live-check`, an owner-run port-8000 compatibility matrix runner that loads ignored inventory secrets, runs the built-in native LAN live-view plan, validates MPEG-TS output with FFprobe, and writes sanitized per-camera verdicts.
 - Added `EZVIZ_FRIDA_WITH_STREAM_TRANSFORM=1` support to the command-shape Frida runner so command-port and PlayM4 input artifacts can be captured in one native session.
 - Added `EZVIZ_HCNETSDK_FORCE_PREVIEW_AFTER_LOGIN=1` for Frida command-shape diagnostics that need to route a LAN login into the native preview activity.
 - Added Frida command-shape runner env injection for target and dump settings, and fixed TCP-shape fingerprint logging on Frida runtimes without `Uint8Array.slice()`.

--- a/README.md
+++ b/README.md
@@ -232,6 +232,23 @@ media packets, along with a bounded IDMX/H.264 frame-shape summary that reports
 counts, NAL/FU-A types, RTP-like sequence/timestamp continuity, and hashes
 without storing media bytes. Media-socket keepalive send attempts are recorded
 as bounded command id/timing/success metadata when a plan includes keepalives.
+For owner-run live compatibility checks across multiple cameras,
+`tools/apk-re/bin/hcnetsdk-command-live-check` wraps the same native-plan save
+path, validates each MPEG-TS output with FFprobe, and writes a sanitized matrix
+report. Pass inventory through `EZVIZ_CAMERA_INVENTORY_JSON` or an ignored
+`.env` file, and provide host overrides when mDNS resolution is not enough:
+
+```bash
+tools/apk-re/bin/hcnetsdk-command-live-check \
+  --inventory-file ../secrets/ezviz-camera-inventory.env \
+  --host BC380557=192.0.2.10 \
+  --duration 8s
+```
+
+The tool skips battery and out-of-use cameras by default, redacts
+`--hcnetsdk-command-password` in dry-run output, and classifies common failure
+stages such as host resolution, bootstrap/login, missing media packets,
+unreadable media, or playable MPEG-TS.
 For offline Frida artifacts, the `hcnetsdk-command-dump-summary` stream helper
 can summarize dumped
 `ezviz-hcnetsdk-command-frame-*.bin` files and raw

--- a/tests/test_hcnetsdk_command_live_check.py
+++ b/tests/test_hcnetsdk_command_live_check.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+import argparse
+from importlib.machinery import SourceFileLoader
+from importlib.util import module_from_spec, spec_from_loader
+import json
+from pathlib import Path
+import sys
+from typing import Any
+
+
+def _load_tool() -> Any:
+    path = (
+        Path(__file__).resolve().parents[1]
+        / "tools"
+        / "apk-re"
+        / "bin"
+        / "hcnetsdk-command-live-check"
+    )
+    loader = SourceFileLoader("hcnetsdk_command_live_check", str(path))
+    spec = spec_from_loader(loader.name, loader)
+    assert spec is not None
+    module = module_from_spec(spec)
+    sys.modules[loader.name] = module
+    loader.exec_module(module)
+    return module
+
+
+def test_load_inventory_reads_shell_quoted_env_file(tmp_path: Path) -> None:
+    tool = _load_tool()
+    inventory = [
+        {
+            "name": "EZVIZ LC1C - Renier's Study Gate",
+            "mdns": "G15225550",
+            "password": "KKNUGT",
+            "enc_key": "MlH9FXc_z7bd",
+            "battery": False,
+            "in_use": True,
+        },
+        {
+            "name": "EZVIZ C3A - 3",
+            "mdns": "D78293648",
+            "password": "UAWZHE",
+            "enc_key": "q:62W8*Se{t[",
+            "battery": True,
+            "in_use": False,
+        },
+    ]
+    env_file = tmp_path / "inventory.env"
+    env_file.write_text(
+        "EZVIZ_CAMERA_INVENTORY_JSON="
+        + sh_single_quote(json.dumps(inventory))
+        + "\n",
+        encoding="utf-8",
+    )
+
+    items = tool._load_inventory(  # noqa: SLF001
+        argparse.Namespace(
+            inventory_file=str(env_file),
+            inventory_env="EZVIZ_CAMERA_INVENTORY_JSON",
+        )
+    )
+
+    assert [item.serial for item in items] == ["G15225550", "D78293648"]
+    assert items[0].name == "EZVIZ LC1C - Renier's Study Gate"
+    assert items[1].enc_key == "q:62W8*Se{t["
+
+
+def test_filtered_items_skip_unused_and_battery_by_default() -> None:
+    tool = _load_tool()
+    items = [
+        tool.CameraInventoryItem(name="wired", serial="A", password="one"),
+        tool.CameraInventoryItem(name="unused", serial="B", password="two", in_use=False),
+        tool.CameraInventoryItem(name="battery", serial="C", password="three", battery=True),
+    ]
+
+    selected = tool._filtered_items(  # noqa: SLF001
+        items,
+        serials=[],
+        include_unused=False,
+        include_battery=False,
+        max_cameras=None,
+    )
+
+    assert [item.serial for item in selected] == ["A"]
+
+
+def test_dry_run_redacts_command_password(tmp_path: Path) -> None:
+    tool = _load_tool()
+    args = argparse.Namespace(
+        python="python",
+        command_port="8000",
+        channel="1",
+        native_plan="app-lan-live-view",
+        duration="5s",
+        timeout="12",
+        ffmpeg_path="ffmpeg",
+        local_ip=None,
+        no_skip_initial_idr=False,
+        dry_run=True,
+    )
+    item = tool.CameraInventoryItem(
+        name="Garage",
+        serial="BC380557",
+        password="PQKIOZ",
+    )
+
+    result = tool._check_item(  # noqa: SLF001
+        args=args,
+        item=item,
+        output_dir=tmp_path,
+        host="192.0.2.10",
+        host_source="override",
+    )
+
+    rendered = json.dumps(result)
+    assert result["ok"] is None
+    assert "<redacted>" in rendered
+    assert "PQKIOZ" not in rendered
+
+
+def test_diagnose_save_failure_prioritizes_connection_refused(tmp_path: Path) -> None:
+    tool = _load_tool()
+
+    diagnosis = tool._diagnose_save_failure(  # noqa: SLF001
+        "File local_stream.py, in _login_client\nConnectionRefusedError: [Errno 111] Connection refused\n",
+        tmp_path / "missing.metadata.json",
+    )
+
+    assert diagnosis == "connection_refused"
+
+
+def test_diagnose_save_failure_labels_short_idr_capture(tmp_path: Path) -> None:
+    tool = _load_tool()
+
+    diagnosis = tool._diagnose_save_failure(  # noqa: SLF001
+        "ERROR: H.264 stream did not contain enough IDR windows to skip 1 startup window(s)\n",
+        tmp_path / "missing.metadata.json",
+    )
+
+    assert diagnosis == "insufficient_idr_windows"
+
+
+def test_stdout_summary_compacts_packet_metadata() -> None:
+    tool = _load_tool()
+    summary = {
+        "ok": True,
+        "results": [
+            {
+                "ok": True,
+                "metadata": {
+                    "bootstrap_complete": True,
+                    "command_port_exchanges": [{"request_command_id": 1}],
+                    "packets": {
+                        "packet_count": 2,
+                        "last_packet_elapsed_seconds": 1.5,
+                        "samples": [{"body_sha256": "x"}],
+                        "idmx_h264": {
+                            "packet_count": 2,
+                            "nal_type_counts": {"1": 1},
+                            "rtp_payload_type_counts": {"96": 2},
+                            "sequence_gap_count": 0,
+                            "invalid_media_marker_count": 0,
+                            "samples": [{"body_sha256": "y"}],
+                        },
+                    },
+                },
+            }
+        ],
+    }
+
+    compact = tool._stdout_summary(summary, include_metadata=False)  # noqa: SLF001
+
+    metadata = compact["results"][0]["metadata"]
+    assert metadata["command_port_exchange_count"] == 1
+    assert metadata["packets"]["packet_count"] == 2
+    assert "samples" not in metadata["packets"]
+    assert "samples" not in metadata["packets"]["idmx_h264"]
+
+
+def sh_single_quote(value: str) -> str:
+    return "'" + value.replace("'", "'\\''") + "'"

--- a/tools/apk-re/bin/hcnetsdk-command-live-check
+++ b/tools/apk-re/bin/hcnetsdk-command-live-check
@@ -1,0 +1,637 @@
+#!/usr/bin/env python3
+"""Run a bounded HCNetSDK command-port live-view compatibility matrix.
+
+This operator tool wraps ``pyezvizapi save clip --source hcnetsdk-command-port``
+with the built-in native LAN live-view plan, then validates the MPEG-TS output
+with FFprobe. It is intended for owner-run compatibility checks against real
+cameras on the local network; it never prints camera passwords.
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+import json
+import os
+from pathlib import Path
+import re
+import shlex
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+DEFAULT_INVENTORY_ENV = "EZVIZ_CAMERA_INVENTORY_JSON"
+DEFAULT_NATIVE_PLAN = "app-lan-live-view"
+
+
+@dataclass(frozen=True)
+class CameraInventoryItem:
+    """One sanitized camera inventory entry."""
+
+    name: str
+    serial: str
+    password: str
+    enc_key: str = ""
+    battery: bool = False
+    in_use: bool = True
+    host: str | None = None
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(prog="hcnetsdk-command-live-check")
+    parser.add_argument(
+        "--python",
+        default=_default_python(),
+        help="Python executable used for `python -m pyezvizapi` (default: repo .venv if present)",
+    )
+    parser.add_argument(
+        "--inventory-file",
+        help=(
+            "Optional .env file containing EZVIZ_CAMERA_INVENTORY_JSON. "
+            "If omitted, the process environment is used."
+        ),
+    )
+    parser.add_argument(
+        "--inventory-env",
+        default=DEFAULT_INVENTORY_ENV,
+        help=f"Environment variable containing inventory JSON (default: {DEFAULT_INVENTORY_ENV})",
+    )
+    parser.add_argument(
+        "--output-dir",
+        default=None,
+        help="Directory for per-camera clips, metadata, logs, and matrix report",
+    )
+    parser.add_argument(
+        "--duration",
+        default="8s",
+        help="Capture duration passed to save clip (default: 8s)",
+    )
+    parser.add_argument(
+        "--timeout",
+        default="12",
+        help="Command-port socket timeout passed to save clip (default: 12)",
+    )
+    parser.add_argument(
+        "--command-port",
+        default="8000",
+        help="HCNetSDK command port passed to save clip (default: 8000)",
+    )
+    parser.add_argument(
+        "--channel",
+        default="1",
+        help="Camera channel passed to save clip (default: 1)",
+    )
+    parser.add_argument(
+        "--native-plan",
+        default=DEFAULT_NATIVE_PLAN,
+        help=f"Built-in native command-port plan (default: {DEFAULT_NATIVE_PLAN})",
+    )
+    parser.add_argument(
+        "--ffmpeg-path",
+        default="ffmpeg",
+        help="FFmpeg executable passed to save clip (default: ffmpeg)",
+    )
+    parser.add_argument(
+        "--ffprobe-path",
+        default="ffprobe",
+        help="FFprobe executable for stream inspection (default: ffprobe)",
+    )
+    parser.add_argument(
+        "--local-ip",
+        help="Optional client LAN IPv4 to patch into generated command-port frames",
+    )
+    parser.add_argument(
+        "--host",
+        action="append",
+        default=[],
+        metavar="SERIAL=HOST",
+        help="Camera host override. May be passed more than once.",
+    )
+    parser.add_argument(
+        "--serial",
+        action="append",
+        default=[],
+        help="Limit the matrix to this camera serial/mDNS id. May be repeated.",
+    )
+    parser.add_argument(
+        "--include-unused",
+        action="store_true",
+        help="Include inventory entries marked not in use",
+    )
+    parser.add_argument(
+        "--include-battery",
+        action="store_true",
+        help="Include battery cameras. Default skips them to avoid waking devices unnecessarily.",
+    )
+    parser.add_argument(
+        "--max-cameras",
+        type=int,
+        help="Optional cap after filters are applied",
+    )
+    parser.add_argument(
+        "--no-skip-initial-idr",
+        action="store_true",
+        help="Do not pass --hcnetsdk-h264-skip-initial-idr-windows 1",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Resolve/filter cameras and print the sanitized plan without contacting devices",
+    )
+    parser.add_argument(
+        "--include-metadata-in-stdout",
+        action="store_true",
+        help="Include full packet metadata in stdout. The report file always keeps full metadata.",
+    )
+    return parser.parse_args()
+
+
+def _default_python() -> str:
+    venv_python = REPO_ROOT / ".venv" / "bin" / "python"
+    if venv_python.exists():
+        return str(venv_python)
+    return sys.executable
+
+
+def _artifact_dir(value: str | None) -> Path:
+    if value:
+        path = Path(value)
+    else:
+        path = Path(tempfile.gettempdir()) / f"pyezvizapi-hcnetsdk-command-check-{int(time.time())}"
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def _inventory_json_from_env_file(path: str, env_name: str) -> str:
+    for raw_line in Path(path).read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        try:
+            parsed = shlex.split(line, comments=True, posix=True)
+        except ValueError:
+            parsed = [line]
+        for token in parsed:
+            key, _, value = token.partition("=")
+            if key == env_name:
+                return value
+    raise ValueError(f"{env_name} was not found in {path}")
+
+
+def _load_inventory(args: argparse.Namespace) -> list[CameraInventoryItem]:
+    text = (
+        _inventory_json_from_env_file(args.inventory_file, args.inventory_env)
+        if args.inventory_file
+        else os.environ.get(args.inventory_env, "")
+    )
+    if not text:
+        raise ValueError(
+            f"provide --inventory-file or set {args.inventory_env} with camera inventory JSON"
+        )
+    try:
+        raw_items = json.loads(text)
+    except json.JSONDecodeError as err:
+        raise ValueError("camera inventory JSON is invalid") from err
+    if not isinstance(raw_items, list):
+        raise ValueError("camera inventory JSON must be a list")
+
+    items: list[CameraInventoryItem] = []
+    for index, raw_item in enumerate(raw_items):
+        if not isinstance(raw_item, dict):
+            raise ValueError(f"camera inventory entry {index} must be an object")
+        serial = str(raw_item.get("mdns") or raw_item.get("serial") or "").strip()
+        password = str(raw_item.get("password") or "").strip()
+        if not serial or not password:
+            raise ValueError(f"camera inventory entry {index} requires serial/mdns and password")
+        items.append(
+            CameraInventoryItem(
+                name=str(raw_item.get("name") or serial),
+                serial=serial,
+                password=password,
+                enc_key=str(raw_item.get("enc_key") or ""),
+                battery=bool(raw_item.get("battery")),
+                in_use=bool(raw_item.get("in_use", True)),
+                host=(str(raw_item["host"]).strip() if raw_item.get("host") else None),
+            )
+        )
+    return items
+
+
+def _host_overrides(values: list[str]) -> dict[str, str]:
+    overrides: dict[str, str] = {}
+    for value in values:
+        serial, sep, host = value.partition("=")
+        if not sep or not serial.strip() or not host.strip():
+            raise ValueError("--host values must use SERIAL=HOST")
+        overrides[serial.strip()] = host.strip()
+    return overrides
+
+
+def _filtered_items(
+    items: list[CameraInventoryItem],
+    *,
+    serials: list[str],
+    include_unused: bool,
+    include_battery: bool,
+    max_cameras: int | None,
+) -> list[CameraInventoryItem]:
+    selected = items
+    if serials:
+        wanted = set(serials)
+        selected = [item for item in selected if item.serial in wanted]
+    if not include_unused:
+        selected = [item for item in selected if item.in_use]
+    if not include_battery:
+        selected = [item for item in selected if not item.battery]
+    if max_cameras is not None:
+        if max_cameras < 1:
+            raise ValueError("--max-cameras must be positive")
+        selected = selected[:max_cameras]
+    return selected
+
+
+def _safe_name(value: str) -> str:
+    text = re.sub(r"[^A-Za-z0-9_.-]+", "-", value.strip()).strip("-")
+    return text or "camera"
+
+
+def _resolve_host(item: CameraInventoryItem, overrides: dict[str, str]) -> tuple[str | None, str]:
+    host = overrides.get(item.serial) or item.host
+    if host:
+        return host, "override"
+    for candidate in (f"{item.serial}.local", item.serial):
+        try:
+            return socket.gethostbyname(candidate), candidate
+        except OSError:
+            continue
+    return None, "unresolved"
+
+
+def _run(command: list[str], *, cwd: Path) -> subprocess.CompletedProcess[bytes]:
+    return subprocess.run(command, cwd=cwd, capture_output=True, check=False)
+
+
+def _tail_text(data: bytes, *, max_chars: int = 4000) -> str:
+    text = data.decode("utf-8", errors="replace")
+    if len(text) <= max_chars:
+        return text
+    return text[-max_chars:]
+
+
+def _ffprobe(ffprobe_path: str, capture_path: Path) -> subprocess.CompletedProcess[bytes]:
+    return _run(
+        [
+            ffprobe_path,
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-print_format",
+            "json",
+            "-show_format",
+            "-show_streams",
+            str(capture_path),
+        ],
+        cwd=REPO_ROOT,
+    )
+
+
+def _stream_summary(ffprobe_stdout: bytes) -> dict[str, Any]:
+    try:
+        payload = json.loads(ffprobe_stdout.decode("utf-8"))
+    except json.JSONDecodeError:
+        return {"streams": []}
+    streams: list[dict[str, Any]] = []
+    for stream in payload.get("streams", []):
+        if not isinstance(stream, dict):
+            continue
+        streams.append(
+            {
+                "index": stream.get("index"),
+                "codec_type": stream.get("codec_type"),
+                "codec_name": stream.get("codec_name"),
+                "width": stream.get("width"),
+                "height": stream.get("height"),
+                "duration": stream.get("duration"),
+            }
+        )
+    return {
+        "streams": streams,
+        "format_duration": (payload.get("format") or {}).get("duration"),
+    }
+
+
+def _diagnose_save_failure(stderr_tail: str, metadata_path: Path) -> str:
+    metadata = _read_metadata(metadata_path)
+    lower_tail = stderr_tail.lower()
+    if "modulenotfounderror" in lower_tail or "importerror" in lower_tail:
+        return "environment_error"
+    if "connection refused" in lower_tail:
+        return "connection_refused"
+    if "did not contain enough idr windows" in lower_tail:
+        return "insufficient_idr_windows"
+    if not metadata.get("bootstrap_complete"):
+        diagnosis = "bootstrap_failed"
+        if "login" in lower_tail:
+            diagnosis = "login_failed"
+        elif "timed out" in lower_tail or "timeout" in lower_tail:
+            diagnosis = "bootstrap_timeout"
+        return diagnosis
+
+    diagnosis = "save_clip_failed"
+    packets = metadata.get("packets")
+    if isinstance(packets, dict):
+        if packets.get("packet_count", 0) == 0:
+            diagnosis = "no_media_packets"
+        elif packets.get("h264_idr_windows"):
+            diagnosis = "remux_failed_after_media"
+    elif "clean h.264 idr" in stderr_tail.lower():
+        diagnosis = "no_clean_idr_window"
+    return diagnosis
+
+
+def _read_metadata(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {}
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _save_command(
+    *,
+    args: argparse.Namespace,
+    item: CameraInventoryItem,
+    host: str,
+    capture_path: Path,
+    metadata_path: Path,
+) -> list[str]:
+    command = [
+        args.python,
+        "-m",
+        "pyezvizapi",
+        "--json",
+        "save",
+        "clip",
+        "--serial",
+        item.serial,
+        "--source",
+        "hcnetsdk-command-port",
+        "--host",
+        host,
+        "--command-port",
+        args.command_port,
+        "--channel",
+        args.channel,
+        "--hcnetsdk-command-native-plan",
+        args.native_plan,
+        "--hcnetsdk-command-password",
+        item.password,
+        "--duration",
+        args.duration,
+        "--timeout",
+        args.timeout,
+        "--format",
+        "mpegts",
+        "--ffmpeg-path",
+        args.ffmpeg_path,
+        "--output",
+        str(capture_path),
+        "--hcnetsdk-command-metadata-output",
+        str(metadata_path),
+    ]
+    if args.local_ip:
+        command.extend(["--hcnetsdk-local-ip", args.local_ip])
+    if not args.no_skip_initial_idr:
+        command.extend(["--hcnetsdk-h264-skip-initial-idr-windows", "1"])
+    return command
+
+
+def _sanitized_command(command: list[str]) -> list[str]:
+    sanitized = list(command)
+    for index, value in enumerate(sanitized[:-1]):
+        if value == "--hcnetsdk-command-password":
+            sanitized[index + 1] = "<redacted>"
+    return sanitized
+
+
+def _check_item(
+    *,
+    args: argparse.Namespace,
+    item: CameraInventoryItem,
+    output_dir: Path,
+    host: str,
+    host_source: str,
+) -> dict[str, Any]:
+    base = output_dir / f"{_safe_name(item.serial)}-{_safe_name(item.name)}"
+    capture_path = base.with_suffix(".ts")
+    metadata_path = base.with_suffix(".metadata.json")
+    stderr_path = base.with_suffix(".save.stderr.txt")
+    stdout_path = base.with_suffix(".save.stdout.json")
+    command = _save_command(
+        args=args,
+        item=item,
+        host=host,
+        capture_path=capture_path,
+        metadata_path=metadata_path,
+    )
+    result: dict[str, Any] = {
+        "name": item.name,
+        "serial": item.serial,
+        "host": host,
+        "host_source": host_source,
+        "battery": item.battery,
+        "in_use": item.in_use,
+        "artifacts": {
+            "capture": str(capture_path),
+            "metadata": str(metadata_path),
+            "save_stdout": str(stdout_path),
+            "save_stderr": str(stderr_path),
+        },
+    }
+    if args.dry_run:
+        result.update({"ok": None, "stage": "dry-run", "command": _sanitized_command(command)})
+        return result
+
+    save = _run(command, cwd=REPO_ROOT)
+    stdout_path.write_bytes(save.stdout)
+    stderr_path.write_bytes(save.stderr)
+    if save.returncode != 0:
+        stderr_tail = _tail_text(save.stderr)
+        result.update(
+            {
+                "ok": False,
+                "stage": "save-clip",
+                "returncode": save.returncode,
+                "diagnosis": _diagnose_save_failure(stderr_tail, metadata_path),
+                "stderr_tail": stderr_tail,
+            }
+        )
+        return result
+
+    probe = _ffprobe(args.ffprobe_path, capture_path)
+    (base.with_suffix(".ffprobe.stdout.json")).write_bytes(probe.stdout)
+    (base.with_suffix(".ffprobe.stderr.txt")).write_bytes(probe.stderr)
+    result["artifacts"].update(
+        {
+            "ffprobe_stdout": str(base.with_suffix(".ffprobe.stdout.json")),
+            "ffprobe_stderr": str(base.with_suffix(".ffprobe.stderr.txt")),
+        }
+    )
+    if probe.returncode != 0:
+        result.update(
+            {
+                "ok": False,
+                "stage": "ffprobe",
+                "returncode": probe.returncode,
+                "diagnosis": "unreadable_media",
+                "stderr_tail": _tail_text(probe.stderr),
+                "capture_size": capture_path.stat().st_size if capture_path.exists() else 0,
+                "metadata": _read_metadata(metadata_path),
+            }
+        )
+        return result
+
+    result.update(
+        {
+            "ok": True,
+            "stage": "complete",
+            "diagnosis": "playable_mpegts",
+            "capture_size": capture_path.stat().st_size,
+            "metadata": _read_metadata(metadata_path),
+            **_stream_summary(probe.stdout),
+        }
+    )
+    return result
+
+
+def _stdout_result(result: dict[str, Any], *, include_metadata: bool) -> dict[str, Any]:
+    if include_metadata or "metadata" not in result:
+        return result
+    compact = dict(result)
+    metadata = result.get("metadata")
+    if isinstance(metadata, dict):
+        packets = metadata.get("packets")
+        compact_metadata: dict[str, Any] = {
+            "bootstrap_complete": metadata.get("bootstrap_complete"),
+            "command_port_exchange_count": len(metadata.get("command_port_exchanges", [])),
+        }
+        if isinstance(packets, dict):
+            compact_metadata["packets"] = {
+                "packet_count": packets.get("packet_count"),
+                "last_packet_elapsed_seconds": packets.get("last_packet_elapsed_seconds"),
+                "idmx_h264": _compact_idmx_h264_summary(packets.get("idmx_h264")),
+            }
+        compact["metadata"] = compact_metadata
+    return compact
+
+
+def _compact_idmx_h264_summary(value: Any) -> dict[str, Any] | None:
+    if not isinstance(value, dict):
+        return None
+    return {
+        "packet_count": value.get("packet_count"),
+        "nal_type_counts": value.get("nal_type_counts"),
+        "rtp_payload_type_counts": value.get("rtp_payload_type_counts"),
+        "sequence_gap_count": value.get("sequence_gap_count"),
+        "invalid_media_marker_count": value.get("invalid_media_marker_count"),
+    }
+
+
+def _stdout_summary(summary: dict[str, Any], *, include_metadata: bool) -> dict[str, Any]:
+    compact = dict(summary)
+    results = summary.get("results", [])
+    if isinstance(results, list):
+        compact["results"] = [
+            _stdout_result(result, include_metadata=include_metadata)
+            if isinstance(result, dict)
+            else result
+            for result in results
+        ]
+    return compact
+
+
+def main() -> int:
+    args = _parse_args()
+    try:
+        inventory = _load_inventory(args)
+        overrides = _host_overrides(args.host)
+        selected = _filtered_items(
+            inventory,
+            serials=args.serial,
+            include_unused=args.include_unused,
+            include_battery=args.include_battery,
+            max_cameras=args.max_cameras,
+        )
+        output_dir = _artifact_dir(args.output_dir)
+        results: list[dict[str, Any]] = []
+        for item in selected:
+            host, host_source = _resolve_host(item, overrides)
+            if host is None:
+                results.append(
+                    {
+                        "name": item.name,
+                        "serial": item.serial,
+                        "ok": None if args.dry_run else False,
+                        "stage": "resolve-host",
+                        "diagnosis": "host_unresolved",
+                        "battery": item.battery,
+                        "in_use": item.in_use,
+                    }
+                )
+                continue
+            results.append(
+                _check_item(
+                    args=args,
+                    item=item,
+                    output_dir=output_dir,
+                    host=host,
+                    host_source=host_source,
+                )
+            )
+
+        summary = {
+            "ok": all(result.get("ok") in (True, None) for result in results),
+            "dry_run": args.dry_run,
+            "output_dir": str(output_dir),
+            "selected": len(selected),
+            "results": results,
+        }
+        report_path = output_dir / "hcnetsdk-command-live-check.report.json"
+        report_path.write_text(json.dumps(summary, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        summary["report"] = str(report_path)
+        print(
+            json.dumps(
+                _stdout_summary(
+                    summary,
+                    include_metadata=args.include_metadata_in_stdout,
+                ),
+                indent=2,
+                sort_keys=True,
+            )
+        )
+        return 0 if summary["ok"] else 1
+    except Exception as err:
+        print(
+            json.dumps(
+                {
+                    "ok": False,
+                    "stage": "argument-validation",
+                    "error_type": type(err).__name__,
+                    "error": str(err),
+                },
+                indent=2,
+                sort_keys=True,
+            ),
+            file=sys.stderr,
+        )
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- add an owner-run HCNetSDK command-port live matrix wrapper for the built-in native LAN live-view plan
- load ignored camera inventory secrets from env/.env, redact passwords in dry-run output, and classify common failures
- document the workflow and cover parsing/filtering/redaction/diagnosis/compact-stdout behavior

## Validation

- .venv/bin/python -m pytest tests/test_hcnetsdk_command_live_check.py -q
- .venv/bin/python -m ruff check tools/apk-re/bin/hcnetsdk-command-live-check tests/test_hcnetsdk_command_live_check.py README.md CHANGELOG.md
- python -m py_compile tools/apk-re/bin/hcnetsdk-command-live-check
- git diff --check

## Live notes

- Saved local inventory privately at /home/node/.openclaw/workspace/secrets/ezviz-camera-inventory.env; not committed.
- Husky at 192.168.1.30 produced playable MPEG-TS on a 6s run with skip-initial-IDR enabled.
- Patio H3, Garage C8C, and X80 hosts had port 8000 open but failed command-port login with the supplied passwords.
