### PR TITLE
Add HCNetSDK command live matrix and stream compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ This project follows [Semantic Versioning](https://semver.org/) for published re
 - Added sanitized H.264 Annex-B NAL-unit and IDR-window summarizers, plus an offline `stream h264-annexb-summary` CLI, for comparing native player dumps with generated command-port diagnostics without storing media contents.
 - Added offline `stream hcnetsdk-command-dump-summary` support for summarizing Frida command-frame, inbound-media, and PlayM4 input dump artifacts without printing frame bodies or credentials.
 - Added optional IDR-window FFmpeg decode checks to `stream hcnetsdk-command-dump-summary` so native command-port dumps can show startup corruption and later clean windows directly.
+- Added `tools/apk-re/bin/hcnetsdk-command-live-check`, an owner-run port-8000 compatibility matrix runner that loads ignored inventory secrets, runs the built-in native LAN live-view plan, validates MPEG-TS output with FFprobe, and writes per-camera verdicts without exposing passwords, serials, or encryption keys.
 - Added `EZVIZ_FRIDA_WITH_STREAM_TRANSFORM=1` support to the command-shape Frida runner so command-port and PlayM4 input artifacts can be captured in one native session.
 - Added `EZVIZ_HCNETSDK_FORCE_PREVIEW_AFTER_LOGIN=1` for Frida command-shape diagnostics that need to route a LAN login into the native preview activity.
 - Added Frida command-shape runner env injection for target and dump settings, and fixed TCP-shape fingerprint logging on Frida runtimes without `Uint8Array.slice()`.

--- a/README.md
+++ b/README.md
@@ -232,6 +232,23 @@ media packets, along with a bounded IDMX/H.264 frame-shape summary that reports
 counts, NAL/FU-A types, RTP-like sequence/timestamp continuity, and hashes
 without storing media bytes. Media-socket keepalive send attempts are recorded
 as bounded command id/timing/success metadata when a plan includes keepalives.
+For owner-run live compatibility checks across multiple cameras,
+`tools/apk-re/bin/hcnetsdk-command-live-check` wraps the same native-plan save
+path, validates each MPEG-TS output with FFprobe, and writes a sanitized matrix
+report. Pass inventory through `EZVIZ_CAMERA_INVENTORY_JSON` or an ignored
+`.env` file, and provide host overrides when mDNS resolution is not enough:
+
+```bash
+tools/apk-re/bin/hcnetsdk-command-live-check \
+  --inventory-file ../secrets/ezviz-camera-inventory.env \
+  --host SERIAL_ALIAS=192.0.2.10 \
+  --duration 8s
+```
+
+The tool skips battery and out-of-use cameras by default, keeps passwords,
+camera serials, and encryption keys out of dry-run/report output and artifact
+filenames, and classifies common failure stages such as host resolution,
+bootstrap/login, missing media packets, unreadable media, or playable MPEG-TS.
 For offline Frida artifacts, the `hcnetsdk-command-dump-summary` stream helper
 can summarize dumped
 `ezviz-hcnetsdk-command-frame-*.bin` files and raw

--- a/pyezvizapi/__main__.py
+++ b/pyezvizapi/__main__.py
@@ -694,6 +694,20 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help="Video codec transform for --decrypt-video (default: encrypted-header)",
     )
     parser_save_clip.add_argument(
+        "--media-key",
+        help=(
+            "Camera media decrypt key, or EZVIZ_LOCAL_MEDIA_KEY. This is used "
+            "when --decrypt-video is set."
+        ),
+    )
+    parser_save_clip.add_argument(
+        "--media-key-hex",
+        help=(
+            "Hex-encoded binary media decrypt key, or EZVIZ_LOCAL_MEDIA_KEY_HEX. "
+            "Use this when the native local media key is not printable text."
+        ),
+    )
+    parser_save_clip.add_argument(
         "--cas-serial",
         help="Device serial to send to cloud CAS when it differs from --serial",
     )
@@ -2215,6 +2229,8 @@ def _handle_save_clip(args: argparse.Namespace, client: EzvizClient) -> int:
                 "cloud_refresh_vtm": not args.no_refresh_vtm,
             }
         )
+    if args.decrypt_video:
+        save_kwargs["media_key"] = _local_sdk_media_key(args, client)
     result = client.save_clip(args.serial, args.output, **save_kwargs)
     _write_save_result(args, result)
     return 0
@@ -4809,6 +4825,7 @@ def _save_clip_can_run_without_cloud_credentials(args: argparse.Namespace) -> bo
         args.action == "save"
         and getattr(args, "save_action", None) == "clip"
         and getattr(args, "source", None) == "hcnetsdk-command-port"
+        and (not args.decrypt_video or _local_sdk_has_static_media_key(args))
     )
 
 

--- a/pyezvizapi/__main__.py
+++ b/pyezvizapi/__main__.py
@@ -2229,7 +2229,9 @@ def _handle_save_clip(args: argparse.Namespace, client: EzvizClient) -> int:
                 "cloud_refresh_vtm": not args.no_refresh_vtm,
             }
         )
-    if args.decrypt_video:
+    if args.decrypt_video and (
+        args.source == "hcnetsdk-command-port" or _local_sdk_has_static_media_key(args)
+    ):
         save_kwargs["media_key"] = _local_sdk_media_key(args, client)
     result = client.save_clip(args.serial, args.output, **save_kwargs)
     _write_save_result(args, result)
@@ -3620,7 +3622,15 @@ def _local_sdk_media_key(
         serial = str(
             _required_local_sdk_arg_or_credentials(args, "serial", ("serial",))
         )
-        cloud_key = client.get_cam_key(serial, max_retries=1)
+        sms_code = getattr(args, "sms_code", None)
+        if sms_code is None:
+            cloud_key = client.get_cam_key(serial, max_retries=1)
+        else:
+            cloud_key = client.get_cam_key(
+                serial,
+                smscode=sms_code,
+                max_retries=1,
+            )
         if cloud_key:
             return str(cloud_key)
     raise PyEzvizError(

--- a/pyezvizapi/client.py
+++ b/pyezvizapi/client.py
@@ -3223,6 +3223,20 @@ class EzvizClient:
                             ffmpeg_path=ffmpeg_path,
                             max_packets=max_packets,
                             duration_seconds=duration_seconds,
+                            h264_skip_initial_idr_windows=(
+                                h264_skip_initial_idr_windows
+                            ),
+                            h264_trim_to_clean_idr_window=(
+                                h264_trim_to_clean_idr_window
+                            ),
+                            h264_clean_idr_preroll_seconds=(
+                                h264_clean_idr_preroll_seconds
+                            ),
+                            h264_clean_idr_max_windows=h264_clean_idr_max_windows,
+                            h264_wait_for_clean_idr_window=(
+                                h264_wait_for_clean_idr_window
+                            ),
+                            h264_clean_idr_wait_seconds=h264_clean_idr_wait_seconds,
                         )
                     else:
                         copy_local_stream_to_mpegts(
@@ -3277,6 +3291,20 @@ class EzvizClient:
                             ffmpeg_path=ffmpeg_path,
                             max_packets=max_packets,
                             duration_seconds=duration_seconds,
+                            h264_skip_initial_idr_windows=(
+                                h264_skip_initial_idr_windows
+                            ),
+                            h264_trim_to_clean_idr_window=(
+                                h264_trim_to_clean_idr_window
+                            ),
+                            h264_clean_idr_preroll_seconds=(
+                                h264_clean_idr_preroll_seconds
+                            ),
+                            h264_clean_idr_max_windows=h264_clean_idr_max_windows,
+                            h264_wait_for_clean_idr_window=(
+                                h264_wait_for_clean_idr_window
+                            ),
+                            h264_clean_idr_wait_seconds=h264_clean_idr_wait_seconds,
                         )
                     else:
                         copy_local_stream_to_mpegts(

--- a/pyezvizapi/client.py
+++ b/pyezvizapi/client.py
@@ -145,6 +145,7 @@ from .local_stream import (
     HcNetSdkCommandPortGeneratedMultiSocketPlan,
     HcNetSdkCommandPortMultiSocketPlan,
     copy_local_sdk_stream_from_client,
+    copy_local_stream_to_decrypted_mpegts,
     copy_local_stream_to_mpegts,
     open_hcnetsdk_command_port_generated_multi_socket_stream,
     open_hcnetsdk_command_port_multi_socket_stream,
@@ -3002,6 +3003,7 @@ class EzvizClient:
                 channel=channel,
                 ffmpeg_path=ffmpeg_path,
                 decrypt_video=decrypt_video,
+                media_key=media_key,
                 timeout=timeout,
                 host=host,
                 command_port=command_port,
@@ -3126,7 +3128,7 @@ class EzvizClient:
             ),
         }
 
-    def _save_hcnetsdk_command_port_clip(  # noqa: PLR0913
+    def _save_hcnetsdk_command_port_clip(  # noqa: PLR0912, PLR0913
         self,
         serial: str,
         output: str | Path | BinaryIO,
@@ -3137,6 +3139,7 @@ class EzvizClient:
         channel: int,
         ffmpeg_path: str,
         decrypt_video: bool,
+        media_key: str | bytes | None,
         timeout: float | None,
         host: str | None,
         command_port: int | None,
@@ -3160,9 +3163,9 @@ class EzvizClient:
             raise PyEzvizError(
                 "source='hcnetsdk-command-port' currently writes MPEG-TS only"
             )
-        if decrypt_video:
+        if decrypt_video and media_key is None:
             raise PyEzvizError(
-                "decrypt_video is not needed for the clear H.264 IDMX command-port path"
+                "source='hcnetsdk-command-port' decrypt_video requires media_key"
             )
 
         frames = tuple(command_frames or ())
@@ -3211,23 +3214,38 @@ class EzvizClient:
                     else stream
                 )
                 try:
-                    copy_local_stream_to_mpegts(
-                        metadata_stream,
-                        output_file,
-                        ffmpeg_path=ffmpeg_path,
-                        max_packets=max_packets,
-                        duration_seconds=duration_seconds,
-                        h264_skip_initial_idr_windows=h264_skip_initial_idr_windows,
-                        h264_trim_to_clean_idr_window=h264_trim_to_clean_idr_window,
-                        h264_clean_idr_preroll_seconds=(
-                            h264_clean_idr_preroll_seconds
-                        ),
-                        h264_clean_idr_max_windows=h264_clean_idr_max_windows,
-                        h264_wait_for_clean_idr_window=(
-                            h264_wait_for_clean_idr_window
-                        ),
-                        h264_clean_idr_wait_seconds=h264_clean_idr_wait_seconds,
-                    )
+                    if decrypt_video:
+                        assert media_key is not None
+                        copy_local_stream_to_decrypted_mpegts(
+                            metadata_stream,
+                            output_file,
+                            media_key,
+                            ffmpeg_path=ffmpeg_path,
+                            max_packets=max_packets,
+                            duration_seconds=duration_seconds,
+                        )
+                    else:
+                        copy_local_stream_to_mpegts(
+                            metadata_stream,
+                            output_file,
+                            ffmpeg_path=ffmpeg_path,
+                            max_packets=max_packets,
+                            duration_seconds=duration_seconds,
+                            h264_skip_initial_idr_windows=(
+                                h264_skip_initial_idr_windows
+                            ),
+                            h264_trim_to_clean_idr_window=(
+                                h264_trim_to_clean_idr_window
+                            ),
+                            h264_clean_idr_preroll_seconds=(
+                                h264_clean_idr_preroll_seconds
+                            ),
+                            h264_clean_idr_max_windows=h264_clean_idr_max_windows,
+                            h264_wait_for_clean_idr_window=(
+                                h264_wait_for_clean_idr_window
+                            ),
+                            h264_clean_idr_wait_seconds=h264_clean_idr_wait_seconds,
+                        )
                 finally:
                     if metadata_callback is not None:
                         metadata_callback(metadata_stream)
@@ -3250,23 +3268,38 @@ class EzvizClient:
                     else stream
                 )
                 try:
-                    copy_local_stream_to_mpegts(
-                        metadata_stream,
-                        output,
-                        ffmpeg_path=ffmpeg_path,
-                        max_packets=max_packets,
-                        duration_seconds=duration_seconds,
-                        h264_skip_initial_idr_windows=h264_skip_initial_idr_windows,
-                        h264_trim_to_clean_idr_window=h264_trim_to_clean_idr_window,
-                        h264_clean_idr_preroll_seconds=(
-                            h264_clean_idr_preroll_seconds
-                        ),
-                        h264_clean_idr_max_windows=h264_clean_idr_max_windows,
-                        h264_wait_for_clean_idr_window=(
-                            h264_wait_for_clean_idr_window
-                        ),
-                        h264_clean_idr_wait_seconds=h264_clean_idr_wait_seconds,
-                    )
+                    if decrypt_video:
+                        assert media_key is not None
+                        copy_local_stream_to_decrypted_mpegts(
+                            metadata_stream,
+                            output,
+                            media_key,
+                            ffmpeg_path=ffmpeg_path,
+                            max_packets=max_packets,
+                            duration_seconds=duration_seconds,
+                        )
+                    else:
+                        copy_local_stream_to_mpegts(
+                            metadata_stream,
+                            output,
+                            ffmpeg_path=ffmpeg_path,
+                            max_packets=max_packets,
+                            duration_seconds=duration_seconds,
+                            h264_skip_initial_idr_windows=(
+                                h264_skip_initial_idr_windows
+                            ),
+                            h264_trim_to_clean_idr_window=(
+                                h264_trim_to_clean_idr_window
+                            ),
+                            h264_clean_idr_preroll_seconds=(
+                                h264_clean_idr_preroll_seconds
+                            ),
+                            h264_clean_idr_max_windows=h264_clean_idr_max_windows,
+                            h264_wait_for_clean_idr_window=(
+                                h264_wait_for_clean_idr_window
+                            ),
+                            h264_clean_idr_wait_seconds=h264_clean_idr_wait_seconds,
+                        )
                 finally:
                     if metadata_callback is not None:
                         metadata_callback(metadata_stream)

--- a/pyezvizapi/local_stream.py
+++ b/pyezvizapi/local_stream.py
@@ -1618,6 +1618,41 @@ def copy_local_stream_to_decrypted_mpegts(  # noqa: PLR0913
     h264_clean_idr_wait_seconds: float = 60.0,
 ) -> None:
     """Collect, decrypt, remux and write local MPEG-TS bytes."""
+    if h264_wait_for_clean_idr_window:
+        _h264_clean_idr_capture_duration_seconds(
+            duration_seconds=duration_seconds,
+            h264_skip_initial_idr_windows=h264_skip_initial_idr_windows,
+            h264_trim_to_clean_idr_window=h264_trim_to_clean_idr_window,
+            h264_clean_idr_preroll_seconds=h264_clean_idr_preroll_seconds,
+            h264_clean_idr_max_windows=h264_clean_idr_max_windows,
+            h264_wait_for_clean_idr_window=h264_wait_for_clean_idr_window,
+            h264_clean_idr_wait_seconds=h264_clean_idr_wait_seconds,
+        )
+        assert duration_seconds is not None
+        payload_duration_seconds = duration_seconds + h264_clean_idr_wait_seconds
+        _require_bounded_decrypt_capture(
+            max_packets=max_packets,
+            duration_seconds=payload_duration_seconds,
+        )
+        payloads = _iter_local_stream_payloads(
+            stream,
+            max_packets=max_packets,
+            duration_seconds=payload_duration_seconds,
+            monotonic=monotonic,
+        )
+        annexb = collect_decrypted_h264_idmx_annexb_after_first_clean_idr_window(
+            payloads,
+            media_key,
+            duration_seconds=duration_seconds,
+            monotonic=monotonic,
+            ffmpeg_path=ffmpeg_path,
+            max_windows=h264_clean_idr_max_windows,
+            wait_seconds=h264_clean_idr_wait_seconds,
+        )
+        process = _open_local_h264_mpegts_remux_process(ffmpeg_path)
+        _copy_mpegps_payloads_to_mpegts([annexb], output, process=process)
+        return
+
     capture_duration_seconds = _h264_clean_idr_capture_duration_seconds(
         duration_seconds=duration_seconds,
         h264_skip_initial_idr_windows=h264_skip_initial_idr_windows,
@@ -1627,9 +1662,6 @@ def copy_local_stream_to_decrypted_mpegts(  # noqa: PLR0913
         h264_wait_for_clean_idr_window=h264_wait_for_clean_idr_window,
         h264_clean_idr_wait_seconds=h264_clean_idr_wait_seconds,
     )
-    if h264_wait_for_clean_idr_window:
-        assert duration_seconds is not None
-        capture_duration_seconds = duration_seconds + h264_clean_idr_wait_seconds
     _require_bounded_decrypt_capture(
         max_packets=max_packets,
         duration_seconds=capture_duration_seconds,
@@ -2340,6 +2372,72 @@ def collect_h264_idmx_annexb_after_first_clean_idr_window(
     return annexb[clean_start_offset:]
 
 
+def collect_decrypted_h264_idmx_annexb_after_first_clean_idr_window(
+    packets: Iterable[bytes],
+    media_key: str | bytes,
+    *,
+    duration_seconds: float | None,
+    monotonic: Callable[[], float] = time.monotonic,
+    ffmpeg_path: str = "ffmpeg",
+    max_windows: int = 32,
+    wait_seconds: float = 60.0,
+) -> bytes:
+    """Collect decrypted IDMX H.264 from the first clean IDR window onward."""
+
+    if duration_seconds is None:
+        raise PyEzvizError("duration_seconds is required when waiting for clean IDR")
+    if wait_seconds < 0:
+        raise PyEzvizError("wait_seconds cannot be negative")
+    if max_windows <= 0:
+        raise PyEzvizError("max_windows must be positive")
+
+    wait_deadline = monotonic() + wait_seconds
+    capture_deadline: float | None = None
+    collected: list[bytes] = []
+    clean_start_offset: int | None = None
+    first_decode_error: str | None = None
+    last_probe = _H264CleanIdrProbeResult(start_offset=None)
+
+    for packet in packets:
+        now = monotonic()
+        if clean_start_offset is None and now >= wait_deadline:
+            suffix = _h264_clean_idr_timeout_suffix(
+                first_decode_error=first_decode_error,
+                probe=last_probe,
+            )
+            raise PyEzvizError(
+                "Timed out waiting for a clean H.264 IDR window" + suffix
+            )
+        if capture_deadline is not None and now >= capture_deadline:
+            break
+        collected.append(packet)
+        if clean_start_offset is None:
+            probe = _try_first_clean_decrypted_h264_annexb_idr_window_offset(
+                collected,
+                media_key,
+                ffmpeg_path=ffmpeg_path,
+                max_windows=max_windows,
+            )
+            last_probe = probe
+            clean_start_offset = probe.start_offset
+            if first_decode_error is None and probe.first_decode_error is not None:
+                first_decode_error = probe.first_decode_error
+            if clean_start_offset is not None:
+                capture_deadline = now + duration_seconds
+            continue
+
+    if clean_start_offset is None:
+        suffix = _h264_clean_idr_timeout_suffix(
+            first_decode_error=first_decode_error,
+            probe=last_probe,
+        )
+        raise PyEzvizError(
+            "H.264 stream ended before a clean IDR window was found" + suffix
+        )
+    annexb = _decrypt_idmx_local_packets_to_annexb(collected, media_key)
+    return annexb[clean_start_offset:]
+
+
 def _h264_clean_idr_timeout_suffix(
     *,
     first_decode_error: str | None,
@@ -2404,6 +2502,41 @@ def _try_first_clean_h264_annexb_idr_window_offset(
         annexb = _idmx_local_packets_to_h264_annexb(packets)
     except PyEzvizError:
         return _H264CleanIdrProbeResult(start_offset=None)
+    return _try_first_clean_h264_annexb_idr_window_offset_from_annexb(
+        annexb,
+        ffmpeg_path=ffmpeg_path,
+        max_windows=max_windows,
+    )
+
+
+def _try_first_clean_decrypted_h264_annexb_idr_window_offset(
+    packets: list[bytes],
+    media_key: str | bytes,
+    *,
+    ffmpeg_path: str,
+    max_windows: int,
+) -> _H264CleanIdrProbeResult:
+    """Return the first clean IDR offset for partial encrypted IDMX packets."""
+
+    try:
+        annexb = _decrypt_idmx_local_packets_to_annexb(packets, media_key)
+    except PyEzvizError:
+        return _H264CleanIdrProbeResult(start_offset=None)
+    return _try_first_clean_h264_annexb_idr_window_offset_from_annexb(
+        annexb,
+        ffmpeg_path=ffmpeg_path,
+        max_windows=max_windows,
+    )
+
+
+def _try_first_clean_h264_annexb_idr_window_offset_from_annexb(
+    annexb: bytes,
+    *,
+    ffmpeg_path: str,
+    max_windows: int,
+) -> _H264CleanIdrProbeResult:
+    """Return the first clean IDR window offset for Annex-B H.264 bytes."""
+
     idr_summary = summarize_h264_annexb_idr_windows(annexb, max_windows=max_windows)
     samples = idr_summary.get("samples")
     if not isinstance(samples, list):

--- a/pyezvizapi/local_stream.py
+++ b/pyezvizapi/local_stream.py
@@ -1803,11 +1803,10 @@ def copy_local_stream_to_mpegts(  # noqa: PLR0912, PLR0913
             if _idmx_local_packets_have_direct_hevc_media(packets):
                 annexb = _idmx_local_packets_to_hevc_annexb(packets)
             elif is_h264_startup_options:
-                try:
-                    annexb = _idmx_local_packets_to_h264_annexb(packets)
-                    annexb_is_h264 = True
-                except PyEzvizError:
-                    annexb = _idmx_local_packets_to_annexb(packets)
+                annexb, annexb_codec = _idmx_local_packets_to_h264_annexb_with_codec(
+                    packets
+                )
+                annexb_is_h264 = annexb_codec == "h264"
             else:
                 annexb, annexb_codec = _idmx_local_packets_to_annexb_with_codec(
                     packets
@@ -3195,6 +3194,18 @@ def _idmx_local_packets_to_annexb_with_codec(
             if _annexb_looks_like_hevc(hevc_annexb):
                 return hevc_annexb, "hevc"
     return h264_annexb, "h264"
+
+
+def _idmx_local_packets_to_h264_annexb_with_codec(
+    packets: list[bytes],
+) -> tuple[bytes, str]:
+    try:
+        h264_annexb = _idmx_local_packets_to_h264_annexb(packets)
+    except PyEzvizError:
+        return _idmx_local_packets_to_annexb_with_codec(packets)
+    if _annexb_has_h264_vcl(h264_annexb):
+        return h264_annexb, "h264"
+    return _idmx_local_packets_to_annexb_with_codec(packets)
 
 
 def _idmx_local_packets_have_direct_hevc_media(packets: list[bytes]) -> bool:

--- a/pyezvizapi/local_stream.py
+++ b/pyezvizapi/local_stream.py
@@ -1740,7 +1740,10 @@ def copy_local_stream_to_mpegts(  # noqa: PLR0912, PLR0913
                 except PyEzvizError:
                     annexb = _idmx_local_packets_to_annexb(packets)
             else:
-                annexb = _idmx_local_packets_to_annexb(packets)
+                annexb, annexb_codec = _idmx_local_packets_to_annexb_with_codec(
+                    packets
+                )
+                annexb_is_h264 = annexb_codec == "h264"
         if (
             not annexb_is_h264
             and not h264_wait_for_clean_idr_window
@@ -2958,16 +2961,23 @@ def _idmx_local_packets_to_hevc_annexb(packets: list[bytes]) -> bytes:
 
 
 def _idmx_local_packets_to_annexb(packets: list[bytes]) -> bytes:
+    annexb, _codec = _idmx_local_packets_to_annexb_with_codec(packets)
+    return annexb
+
+
+def _idmx_local_packets_to_annexb_with_codec(
+    packets: list[bytes],
+) -> tuple[bytes, str]:
     if _idmx_local_packets_have_direct_hevc_media(packets):
         try:
-            return _idmx_local_packets_to_hevc_annexb(packets)
+            return _idmx_local_packets_to_hevc_annexb(packets), "hevc"
         except PyEzvizError:
             pass
     try:
-        return _idmx_local_packets_to_h264_annexb(packets)
+        return _idmx_local_packets_to_h264_annexb(packets), "h264"
     except PyEzvizError as h264_error:
         try:
-            return _idmx_local_packets_to_hevc_annexb(packets)
+            return _idmx_local_packets_to_hevc_annexb(packets), "hevc"
         except PyEzvizError as hevc_error:
             raise h264_error from hevc_error
 

--- a/pyezvizapi/local_stream.py
+++ b/pyezvizapi/local_stream.py
@@ -92,6 +92,7 @@ class _H264CleanIdrProbeResult:
     """Result of probing partial H.264 Annex-B IDR windows."""
 
     start_offset: int | None
+    idr_start_offset: int | None = None
     first_decode_error: str | None = None
     idr_count: int = 0
     sampled_window_count: int = 0
@@ -2394,7 +2395,9 @@ def collect_decrypted_h264_idmx_annexb_after_first_clean_idr_window(
     wait_deadline = monotonic() + wait_seconds
     capture_deadline: float | None = None
     collected: list[bytes] = []
+    packet_times: list[float] = []
     clean_start_offset: int | None = None
+    clean_idr_time: float | None = None
     first_decode_error: str | None = None
     last_probe = _H264CleanIdrProbeResult(start_offset=None)
 
@@ -2411,6 +2414,7 @@ def collect_decrypted_h264_idmx_annexb_after_first_clean_idr_window(
         if capture_deadline is not None and now >= capture_deadline:
             break
         collected.append(packet)
+        packet_times.append(now)
         if clean_start_offset is None:
             probe = _try_first_clean_decrypted_h264_annexb_idr_window_offset(
                 collected,
@@ -2423,7 +2427,13 @@ def collect_decrypted_h264_idmx_annexb_after_first_clean_idr_window(
             if first_decode_error is None and probe.first_decode_error is not None:
                 first_decode_error = probe.first_decode_error
             if clean_start_offset is not None:
-                capture_deadline = now + duration_seconds
+                clean_idr_packet_index = _decrypted_h264_annexb_packet_index_for_offset(
+                    collected,
+                    media_key,
+                    probe.idr_start_offset or clean_start_offset,
+                )
+                clean_idr_time = packet_times[clean_idr_packet_index]
+                capture_deadline = clean_idr_time + duration_seconds
             continue
 
     if clean_start_offset is None:
@@ -2434,6 +2444,12 @@ def collect_decrypted_h264_idmx_annexb_after_first_clean_idr_window(
         raise PyEzvizError(
             "H.264 stream ended before a clean IDR window was found" + suffix
         )
+    if capture_deadline is not None and clean_idr_time is not None:
+        collected = [
+            packet
+            for packet, packet_time in zip(collected, packet_times, strict=True)
+            if packet_time < capture_deadline or packet_time == clean_idr_time
+        ]
     annexb = _decrypt_idmx_local_packets_to_annexb(collected, media_key)
     return annexb[clean_start_offset:]
 
@@ -2529,6 +2545,26 @@ def _try_first_clean_decrypted_h264_annexb_idr_window_offset(
     )
 
 
+def _decrypted_h264_annexb_packet_index_for_offset(
+    packets: list[bytes],
+    media_key: str | bytes,
+    offset: int,
+) -> int:
+    """Return the packet index that first contributes the given Annex-B offset."""
+
+    for index in range(len(packets)):
+        try:
+            annexb = _decrypt_idmx_local_packets_to_annexb(
+                packets[: index + 1],
+                media_key,
+            )
+        except PyEzvizError:
+            continue
+        if len(annexb) > offset:
+            return index
+    return max(len(packets) - 1, 0)
+
+
 def _try_first_clean_h264_annexb_idr_window_offset_from_annexb(
     annexb: bytes,
     *,
@@ -2572,6 +2608,7 @@ def _try_first_clean_h264_annexb_idr_window_offset_from_annexb(
         if not decode_errors:
             return _H264CleanIdrProbeResult(
                 start_offset=start_offset,
+                idr_start_offset=int(sample["idr_start_code_offset"]),
                 first_decode_error=first_decode_error,
                 idr_count=int(idr_summary.get("idr_count", 0)),
                 sampled_window_count=len(samples),
@@ -3143,12 +3180,21 @@ def _idmx_local_packets_to_annexb_with_codec(
         except PyEzvizError:
             pass
     try:
-        return _idmx_local_packets_to_h264_annexb(packets), "h264"
+        h264_annexb = _idmx_local_packets_to_h264_annexb(packets)
     except PyEzvizError as h264_error:
         try:
             return _idmx_local_packets_to_hevc_annexb(packets), "hevc"
         except PyEzvizError as hevc_error:
             raise h264_error from hevc_error
+    if not _annexb_has_h264_vcl(h264_annexb):
+        try:
+            hevc_annexb = _idmx_local_packets_to_hevc_annexb(packets)
+        except PyEzvizError:
+            pass
+        else:
+            if _annexb_looks_like_hevc(hevc_annexb):
+                return hevc_annexb, "hevc"
+    return h264_annexb, "h264"
 
 
 def _idmx_local_packets_have_direct_hevc_media(packets: list[bytes]) -> bool:
@@ -3419,6 +3465,13 @@ def _trim_trailing_h264_non_vcl_nals(data: bytes) -> bytes:
 def _annexb_looks_like_h264(data: bytes) -> bool:
     return any(
         _h264_nal_type(data[nal_start:end]) in {1, 5, 6, 7, 8, 9}
+        for _offset, nal_start, end in _h264_annexb_nal_spans(data)
+    )
+
+
+def _annexb_has_h264_vcl(data: bytes) -> bool:
+    return any(
+        _h264_nal_type(data[nal_start:end]) in {1, 5}
         for _offset, nal_start, end in _h264_annexb_nal_spans(data)
     )
 

--- a/pyezvizapi/local_stream.py
+++ b/pyezvizapi/local_stream.py
@@ -1600,7 +1600,7 @@ def copy_local_stream_to_decrypted_mpegps(
     output.flush()
 
 
-def copy_local_stream_to_decrypted_mpegts(
+def copy_local_stream_to_decrypted_mpegts(  # noqa: PLR0913
     stream: Any,
     output: BinaryIO,
     media_key: str | bytes,
@@ -1610,16 +1610,34 @@ def copy_local_stream_to_decrypted_mpegts(
     max_packets: int | None = None,
     duration_seconds: float | None = None,
     monotonic: Callable[[], float] = time.monotonic,
+    h264_skip_initial_idr_windows: int = 0,
+    h264_trim_to_clean_idr_window: bool = False,
+    h264_clean_idr_preroll_seconds: float = 0.0,
+    h264_clean_idr_max_windows: int = 32,
+    h264_wait_for_clean_idr_window: bool = False,
+    h264_clean_idr_wait_seconds: float = 60.0,
 ) -> None:
     """Collect, decrypt, remux and write local MPEG-TS bytes."""
+    capture_duration_seconds = _h264_clean_idr_capture_duration_seconds(
+        duration_seconds=duration_seconds,
+        h264_skip_initial_idr_windows=h264_skip_initial_idr_windows,
+        h264_trim_to_clean_idr_window=h264_trim_to_clean_idr_window,
+        h264_clean_idr_preroll_seconds=h264_clean_idr_preroll_seconds,
+        h264_clean_idr_max_windows=h264_clean_idr_max_windows,
+        h264_wait_for_clean_idr_window=h264_wait_for_clean_idr_window,
+        h264_clean_idr_wait_seconds=h264_clean_idr_wait_seconds,
+    )
+    if h264_wait_for_clean_idr_window:
+        assert duration_seconds is not None
+        capture_duration_seconds = duration_seconds + h264_clean_idr_wait_seconds
     _require_bounded_decrypt_capture(
         max_packets=max_packets,
-        duration_seconds=duration_seconds,
+        duration_seconds=capture_duration_seconds,
     )
     packets = collect_local_stream_media_packets(
         stream,
         max_packets=max_packets,
-        duration_seconds=duration_seconds,
+        duration_seconds=capture_duration_seconds,
         monotonic=monotonic,
     )
     if _local_stream_packets_are_idmx(packets):
@@ -1627,11 +1645,29 @@ def copy_local_stream_to_decrypted_mpegts(
         if _annexb_looks_like_hevc(annexb):
             process = _open_local_hevc_mpegts_remux_process(ffmpeg_path)
         elif _annexb_looks_like_h264(annexb):
+            annexb = skip_h264_annexb_initial_idr_windows(
+                annexb,
+                h264_skip_initial_idr_windows,
+            )
+            if h264_trim_to_clean_idr_window or h264_wait_for_clean_idr_window:
+                annexb = trim_h264_annexb_to_first_clean_idr_window(
+                    annexb,
+                    ffmpeg_path=ffmpeg_path,
+                    max_windows=h264_clean_idr_max_windows,
+                )
             process = _open_local_h264_mpegts_remux_process(ffmpeg_path)
         else:
             raise PyEzvizError("EZVIZ local IDMX stream did not include video frames")
         _copy_mpegps_payloads_to_mpegts([annexb], output, process=process)
         return
+    if (
+        h264_skip_initial_idr_windows
+        or h264_trim_to_clean_idr_window
+        or h264_wait_for_clean_idr_window
+    ):
+        raise PyEzvizError(
+            "H.264 startup trim options require a decrypted H.264 IDMX stream"
+        )
     decrypted = decrypt_hikvision_ps_video(
         b"".join(packets),
         media_key,
@@ -3076,14 +3112,17 @@ def _append_idmx_hevc_media_payload(
     is_start = bool(fu_header & 0x80)
     is_end = bool(fu_header & 0x40)
     original_type = fu_header & 0x3F
+    if active_fu is None and not is_start:
+        return None
     reconstructed_header = bytes(
         [
             (payload[0] & 0x81) | (original_type << 1),
             payload[1],
         ]
     )
-    if is_start or active_fu is None:
+    if is_start:
         active_fu = bytearray(reconstructed_header)
+    assert active_fu is not None
     active_fu.extend(payload[3:])
     if is_end:
         _append_decrypted_hevc_nal(output, bytes(active_fu), aes_key)
@@ -3110,14 +3149,17 @@ def _append_idmx_hevc_clear_payload(
     is_start = bool(fu_header & 0x80)
     is_end = bool(fu_header & 0x40)
     original_type = fu_header & 0x3F
+    if active_fu is None and not is_start:
+        return None
     reconstructed_header = bytes(
         [
             (payload[0] & 0x81) | (original_type << 1),
             payload[1],
         ]
     )
-    if is_start or active_fu is None:
+    if is_start:
         active_fu = bytearray(reconstructed_header)
+    assert active_fu is not None
     active_fu.extend(payload[3:])
     if is_end:
         _append_hevc_nal(output, bytes(active_fu))

--- a/pyezvizapi/local_stream.py
+++ b/pyezvizapi/local_stream.py
@@ -1675,9 +1675,7 @@ def copy_local_stream_to_decrypted_mpegts(  # noqa: PLR0913
     )
     if _local_stream_packets_are_idmx(packets):
         annexb = _decrypt_idmx_local_packets_to_annexb(packets, media_key)
-        if _annexb_looks_like_hevc(annexb):
-            process = _open_local_hevc_mpegts_remux_process(ffmpeg_path)
-        elif _annexb_looks_like_h264(annexb):
+        if _annexb_has_h264_vcl(annexb):
             annexb = skip_h264_annexb_initial_idr_windows(
                 annexb,
                 h264_skip_initial_idr_windows,
@@ -1688,6 +1686,10 @@ def copy_local_stream_to_decrypted_mpegts(  # noqa: PLR0913
                     ffmpeg_path=ffmpeg_path,
                     max_windows=h264_clean_idr_max_windows,
                 )
+            process = _open_local_h264_mpegts_remux_process(ffmpeg_path)
+        elif _annexb_looks_like_hevc(annexb):
+            process = _open_local_hevc_mpegts_remux_process(ffmpeg_path)
+        elif _annexb_looks_like_h264(annexb):
             process = _open_local_h264_mpegts_remux_process(ffmpeg_path)
         else:
             raise PyEzvizError("EZVIZ local IDMX stream did not include video frames")

--- a/pyezvizapi/local_stream.py
+++ b/pyezvizapi/local_stream.py
@@ -1802,9 +1802,7 @@ def copy_local_stream_to_mpegts(  # noqa: PLR0912, PLR0913
             )
         else:
             packets = list(chain((first_payload,), payloads))
-            if _idmx_local_packets_have_direct_hevc_media(packets):
-                annexb = _idmx_local_packets_to_hevc_annexb(packets)
-            elif is_h264_startup_options:
+            if is_h264_startup_options:
                 annexb, annexb_codec = _idmx_local_packets_to_h264_annexb_with_codec(
                     packets
                 )
@@ -3175,11 +3173,6 @@ def _idmx_local_packets_to_annexb(packets: list[bytes]) -> bytes:
 def _idmx_local_packets_to_annexb_with_codec(
     packets: list[bytes],
 ) -> tuple[bytes, str]:
-    if _idmx_local_packets_have_direct_hevc_media(packets):
-        try:
-            return _idmx_local_packets_to_hevc_annexb(packets), "hevc"
-        except PyEzvizError:
-            pass
     try:
         h264_annexb = _idmx_local_packets_to_h264_annexb(packets)
     except PyEzvizError as h264_error:
@@ -3187,14 +3180,20 @@ def _idmx_local_packets_to_annexb_with_codec(
             return _idmx_local_packets_to_hevc_annexb(packets), "hevc"
         except PyEzvizError as hevc_error:
             raise h264_error from hevc_error
-    if not _annexb_has_h264_vcl(h264_annexb):
+    if _annexb_has_h264_vcl(h264_annexb):
+        return h264_annexb, "h264"
+    if _idmx_local_packets_have_direct_hevc_media(packets):
         try:
-            hevc_annexb = _idmx_local_packets_to_hevc_annexb(packets)
+            return _idmx_local_packets_to_hevc_annexb(packets), "hevc"
         except PyEzvizError:
             pass
-        else:
-            if _annexb_looks_like_hevc(hevc_annexb):
-                return hevc_annexb, "hevc"
+    try:
+        hevc_annexb = _idmx_local_packets_to_hevc_annexb(packets)
+    except PyEzvizError:
+        pass
+    else:
+        if _annexb_looks_like_hevc(hevc_annexb):
+            return hevc_annexb, "hevc"
     return h264_annexb, "h264"
 
 

--- a/pyezvizapi/local_stream.py
+++ b/pyezvizapi/local_stream.py
@@ -1731,7 +1731,9 @@ def copy_local_stream_to_mpegts(  # noqa: PLR0912, PLR0913
             )
         else:
             packets = list(chain((first_payload,), payloads))
-            if is_h264_startup_options:
+            if _idmx_local_packets_have_direct_hevc_media(packets):
+                annexb = _idmx_local_packets_to_hevc_annexb(packets)
+            elif is_h264_startup_options:
                 try:
                     annexb = _idmx_local_packets_to_h264_annexb(packets)
                     annexb_is_h264 = True
@@ -2956,6 +2958,11 @@ def _idmx_local_packets_to_hevc_annexb(packets: list[bytes]) -> bytes:
 
 
 def _idmx_local_packets_to_annexb(packets: list[bytes]) -> bytes:
+    if _idmx_local_packets_have_direct_hevc_media(packets):
+        try:
+            return _idmx_local_packets_to_hevc_annexb(packets)
+        except PyEzvizError:
+            pass
     try:
         return _idmx_local_packets_to_h264_annexb(packets)
     except PyEzvizError as h264_error:
@@ -2963,6 +2970,19 @@ def _idmx_local_packets_to_annexb(packets: list[bytes]) -> bytes:
             return _idmx_local_packets_to_hevc_annexb(packets)
         except PyEzvizError as hevc_error:
             raise h264_error from hevc_error
+
+
+def _idmx_local_packets_have_direct_hevc_media(packets: list[bytes]) -> bool:
+    for frame in _iter_idmx_local_frames(b"".join(packets)):
+        header_size = _idmx_local_frame_header_size(frame)
+        if header_size is None:
+            continue
+        body = _strip_idmx_command_h264_record_trailer(frame[header_size:])
+        if not _idmx_local_frame_is_h264_transport(frame, header_size):
+            continue
+        if _looks_like_idmx_hevc_evidence_frame(body):
+            return True
+    return False
 
 
 def _local_media_aes_key(media_key: str | bytes) -> bytes:
@@ -2989,6 +3009,15 @@ def _looks_like_idmx_hevc_direct_frame(body: bytes) -> bool:
         return False
     nal_type = _hevc_nal_type(body)
     return nal_type <= 40 or nal_type == 49
+
+
+def _looks_like_idmx_hevc_evidence_frame(body: bytes) -> bool:
+    if not _looks_like_idmx_hevc_direct_frame(body):
+        return False
+    nal_type = _hevc_nal_type(body)
+    if nal_type in {32, 33, 34}:
+        return body[1] & 0xF8 == 0
+    return nal_type == 49
 
 
 def _looks_like_idmx_h264_fu_a_frame(body: bytes) -> bool:

--- a/pyezvizapi/local_stream.py
+++ b/pyezvizapi/local_stream.py
@@ -1663,7 +1663,7 @@ def _require_bounded_idmx_capture(
         )
 
 
-def copy_local_stream_to_mpegts(  # noqa: PLR0913
+def copy_local_stream_to_mpegts(  # noqa: PLR0912, PLR0913
     stream: Any,
     output: BinaryIO,
     *,
@@ -1716,6 +1716,10 @@ def copy_local_stream_to_mpegts(  # noqa: PLR0913
             max_packets=max_packets,
             duration_seconds=duration_seconds,
         )
+        is_h264_startup_options = bool(
+            h264_skip_initial_idr_windows or h264_trim_to_clean_idr_window
+        )
+        annexb_is_h264 = False
         if h264_wait_for_clean_idr_window:
             annexb = collect_h264_idmx_annexb_after_first_clean_idr_window(
                 chain((first_payload,), payloads),
@@ -1727,18 +1731,32 @@ def copy_local_stream_to_mpegts(  # noqa: PLR0913
             )
         else:
             packets = list(chain((first_payload,), payloads))
-            annexb = _idmx_local_packets_to_h264_annexb(packets)
-        annexb = skip_h264_annexb_initial_idr_windows(
-            annexb,
-            h264_skip_initial_idr_windows,
-        )
-        if h264_trim_to_clean_idr_window:
-            annexb = trim_h264_annexb_to_first_clean_idr_window(
+            if is_h264_startup_options:
+                try:
+                    annexb = _idmx_local_packets_to_h264_annexb(packets)
+                    annexb_is_h264 = True
+                except PyEzvizError:
+                    annexb = _idmx_local_packets_to_annexb(packets)
+            else:
+                annexb = _idmx_local_packets_to_annexb(packets)
+        if (
+            not annexb_is_h264
+            and not h264_wait_for_clean_idr_window
+            and _annexb_looks_like_hevc(annexb)
+        ):
+            process = _open_local_hevc_mpegts_remux_process(ffmpeg_path)
+        else:
+            annexb = skip_h264_annexb_initial_idr_windows(
                 annexb,
-                ffmpeg_path=ffmpeg_path,
-                max_windows=h264_clean_idr_max_windows,
+                h264_skip_initial_idr_windows,
             )
-        process = _open_local_h264_mpegts_remux_process(ffmpeg_path)
+            if h264_trim_to_clean_idr_window:
+                annexb = trim_h264_annexb_to_first_clean_idr_window(
+                    annexb,
+                    ffmpeg_path=ffmpeg_path,
+                    max_windows=h264_clean_idr_max_windows,
+                )
+            process = _open_local_h264_mpegts_remux_process(ffmpeg_path)
         _copy_mpegps_payloads_to_mpegts([annexb], output, process=process)
         return
     if (
@@ -2444,7 +2462,7 @@ def _h264_annexb_idr_window_start_index(
     return start
 
 
-def _summarize_idmx_h264_local_frame(
+def _summarize_idmx_h264_local_frame(  # noqa: PLR0911
     frame: bytes,
     frame_index: int,
 ) -> dict[str, Any]:
@@ -2482,6 +2500,10 @@ def _summarize_idmx_h264_local_frame(
         return sample
     if _looks_like_idmx_hevc_media_frame(body):
         sample["kind"] = "hevc_media"
+        return sample
+    if is_h264_transport and _looks_like_idmx_hevc_direct_frame(body):
+        sample["kind"] = "hevc_media"
+        sample["hevc_nal_type"] = _hevc_nal_type(body)
         return sample
     sample["kind"] = "unknown"
     return sample
@@ -2816,6 +2838,7 @@ def _idmx_local_frame_contains_media(frame: bytes) -> bool:
     return (
         _looks_like_idmx_hevc_parameter_frame(body)
         or _looks_like_idmx_hevc_media_frame(body)
+        or (h264_transport and _looks_like_idmx_hevc_direct_frame(body))
         or (h264_transport and _looks_like_idmx_h264_fu_a_frame(body))
         or (h264_transport and _looks_like_idmx_h264_clear_nal(body))
     )
@@ -2910,6 +2933,38 @@ def _idmx_local_packets_to_h264_annexb(packets: list[bytes]) -> bytes:
     return _trim_trailing_h264_non_vcl_nals(bytes(output))
 
 
+def _idmx_local_packets_to_hevc_annexb(packets: list[bytes]) -> bytes:
+    output = bytearray()
+    active_fu: bytearray | None = None
+    for frame in _iter_idmx_local_frames(b"".join(packets)):
+        header_size = _idmx_local_frame_header_size(frame)
+        if header_size is None:
+            continue
+        body = _strip_idmx_command_h264_record_trailer(frame[header_size:])
+        if not _idmx_local_frame_is_h264_transport(frame, header_size):
+            continue
+        if not _looks_like_idmx_hevc_direct_frame(body):
+            continue
+        active_fu = _append_idmx_hevc_clear_payload(
+            output,
+            body,
+            active_fu=active_fu,
+        )
+    if not output:
+        raise PyEzvizError("EZVIZ local IDMX stream did not include clear HEVC media frames")
+    return bytes(output)
+
+
+def _idmx_local_packets_to_annexb(packets: list[bytes]) -> bytes:
+    try:
+        return _idmx_local_packets_to_h264_annexb(packets)
+    except PyEzvizError as h264_error:
+        try:
+            return _idmx_local_packets_to_hevc_annexb(packets)
+        except PyEzvizError as hevc_error:
+            raise h264_error from hevc_error
+
+
 def _local_media_aes_key(media_key: str | bytes) -> bytes:
     key_bytes = media_key.encode() if isinstance(media_key, str) else media_key
     return key_bytes.ljust(16, b"\0")[:16]
@@ -2927,6 +2982,13 @@ def _looks_like_idmx_hevc_media_frame(body: bytes) -> bool:
         len(body) > IDMX_HEVC_MEDIA_FRAME_NAL_OFFSET
         and body.startswith(b"\x40\x00\x00\x02\x80\x06")
     )
+
+
+def _looks_like_idmx_hevc_direct_frame(body: bytes) -> bool:
+    if len(body) < HEVC_NAL_HEADER_SIZE or body[0] & 0x80 or body[1] & 0x07 == 0:
+        return False
+    nal_type = _hevc_nal_type(body)
+    return nal_type <= 40 or nal_type == 49
 
 
 def _looks_like_idmx_h264_fu_a_frame(body: bytes) -> bool:
@@ -2990,6 +3052,40 @@ def _append_idmx_hevc_media_payload(
     return active_fu
 
 
+def _append_idmx_hevc_clear_payload(
+    output: bytearray,
+    payload: bytes,
+    *,
+    active_fu: bytearray | None,
+) -> bytearray | None:
+    if len(payload) < HEVC_NAL_HEADER_SIZE:
+        return active_fu
+    nal_type = _hevc_nal_type(payload)
+    if nal_type != 49:
+        _append_hevc_nal(output, payload)
+        return active_fu
+    if len(payload) < 3:
+        return active_fu
+
+    fu_header = payload[2]
+    is_start = bool(fu_header & 0x80)
+    is_end = bool(fu_header & 0x40)
+    original_type = fu_header & 0x3F
+    reconstructed_header = bytes(
+        [
+            (payload[0] & 0x81) | (original_type << 1),
+            payload[1],
+        ]
+    )
+    if is_start or active_fu is None:
+        active_fu = bytearray(reconstructed_header)
+    active_fu.extend(payload[3:])
+    if is_end:
+        _append_hevc_nal(output, bytes(active_fu))
+        return None
+    return active_fu
+
+
 def _append_idmx_h264_fu_a_payload(
     output: bytearray,
     payload: bytes,
@@ -3025,6 +3121,13 @@ def _append_decrypted_hevc_nal(
 
 def _append_h264_nal(output: bytearray, nal: bytes) -> None:
     if not _is_plausible_h264_nal(nal):
+        return
+    output.extend(ANNEX_B_LONG_START_CODE)
+    output.extend(nal)
+
+
+def _append_hevc_nal(output: bytearray, nal: bytes) -> None:
+    if not _is_plausible_hevc_nal(nal):
         return
     output.extend(ANNEX_B_LONG_START_CODE)
     output.extend(nal)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1012,7 +1012,6 @@ def test_save_clip_uses_direct_local_stream_and_outputs_json(
         "channel": 2,
         "ffmpeg_path": "/usr/bin/ffmpeg",
         "decrypt_video": True,
-        "media_key": "camera-secret",
         "nalu_header_size": 0,
         "cas_serial": None,
         "timeout": 10.0,
@@ -1747,6 +1746,41 @@ def test_save_clip_can_use_cloud_source(
         "cloud_token_index": 1,
         "cloud_refresh_vtm": False,
     }
+
+
+def test_save_clip_cloud_decrypt_keeps_sms_code_key_lookup(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    fake_client = _install_fake_client(monkeypatch)
+    output_path = tmp_path / "www" / "front.ts"
+
+    assert (
+        cli_module.main(
+            [
+                "--token-file",
+                _token_file(tmp_path),
+                "save",
+                "clip",
+                "--source",
+                "cloud",
+                "--serial",
+                "CAM123",
+                "--output",
+                str(output_path),
+                "--decrypt-video",
+                "--sms-code",
+                "654321",
+            ]
+        )
+        == 0
+    )
+
+    request = fake_client.instances[0].save_clip_request
+    assert request["source"] == "cloud"
+    assert request["decrypt_video"] is True
+    assert request["smscode"] == "654321"
+    assert "media_key" not in request
 
 
 def test_save_image_triggers_capture_and_downloads_url(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1012,6 +1012,7 @@ def test_save_clip_uses_direct_local_stream_and_outputs_json(
         "channel": 2,
         "ffmpeg_path": "/usr/bin/ffmpeg",
         "decrypt_video": True,
+        "media_key": "camera-secret",
         "nalu_header_size": 0,
         "cas_serial": None,
         "timeout": 10.0,

--- a/tests/test_hcnetsdk_command_live_check.py
+++ b/tests/test_hcnetsdk_command_live_check.py
@@ -353,6 +353,33 @@ def test_recursive_redaction_covers_serial_password_and_enc_key() -> None:
     assert rendered.count("<redacted>") == 4
 
 
+def test_redaction_handles_overlapping_sensitive_values() -> None:
+    tool = _load_tool()
+    item = tool.CameraInventoryItem(
+        name="Garage",
+        serial="dummy-secret",
+        password="dummy-secret-password",
+        enc_key="dummy-secret-password-key",
+    )
+
+    redacted = tool._redact_sensitive(  # noqa: SLF001
+        {
+            "stdout": "dummy-secret-password-key",
+            "stderr": "dummy-secret-password",
+            "metadata": ["dummy-secret"],
+        },
+        item,
+    )
+
+    rendered = json.dumps(redacted)
+    assert "dummy-secret" not in rendered
+    assert "dummy-secret-password" not in rendered
+    assert "dummy-secret-password-key" not in rendered
+    assert "<redacted>-password" not in rendered
+    assert "<redacted>-password-key" not in rendered
+    assert rendered.count("<redacted>") == 3
+
+
 def test_diagnose_save_failure_prioritizes_connection_refused(tmp_path: Path) -> None:
     tool = _load_tool()
 

--- a/tests/test_hcnetsdk_command_live_check.py
+++ b/tests/test_hcnetsdk_command_live_check.py
@@ -178,6 +178,54 @@ def test_dry_run_redacts_media_key_when_decrypting(tmp_path: Path) -> None:
     assert "dummy-enc-key-03" not in rendered
 
 
+def test_relative_output_dir_resolves_before_child_commands(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    tool = _load_tool()
+    caller_cwd = tmp_path / "caller"
+    caller_cwd.mkdir()
+    monkeypatch.chdir(caller_cwd)
+    output_dir = tool._artifact_dir("matrix-out")  # noqa: SLF001
+    args = argparse.Namespace(
+        python="python",
+        command_port="8000",
+        channel="1",
+        native_plan="app-lan-live-view",
+        duration="5s",
+        timeout="12",
+        ffmpeg_path="ffmpeg",
+        local_ip=None,
+        decrypt_video=False,
+        no_try_enc_key_password=True,
+        no_skip_initial_idr=False,
+        dry_run=True,
+    )
+    item = tool.CameraInventoryItem(
+        name="Garage",
+        serial="SERIAL-GARAGE-01",
+        password="dummy-camera-password-01",
+    )
+
+    result = tool._check_item(  # noqa: SLF001
+        args=args,
+        item=item,
+        output_dir=output_dir,
+        host="192.0.2.10",
+        host_source="override",
+        camera_index=1,
+    )
+
+    assert output_dir == caller_cwd / "matrix-out"
+    assert output_dir.is_absolute()
+    capture = result["artifacts"]["capture"]
+    metadata = result["artifacts"]["metadata"]
+    command = result["command"]
+    assert capture == str(caller_cwd / "matrix-out" / "camera-01-Garage.ts")
+    assert metadata == str(caller_cwd / "matrix-out" / "camera-01-Garage.metadata.json")
+    assert command[command.index("--output") + 1] == capture
+    assert command[command.index("--hcnetsdk-command-metadata-output") + 1] == metadata
+
+
 def test_credential_attempts_can_skip_encryption_key_password() -> None:
     tool = _load_tool()
     args = argparse.Namespace(no_try_enc_key_password=True)

--- a/tests/test_hcnetsdk_command_live_check.py
+++ b/tests/test_hcnetsdk_command_live_check.py
@@ -1,0 +1,280 @@
+from __future__ import annotations
+
+import argparse
+from importlib.machinery import SourceFileLoader
+from importlib.util import module_from_spec, spec_from_loader
+import json
+from pathlib import Path
+import sys
+from typing import Any
+
+
+def _load_tool() -> Any:
+    path = (
+        Path(__file__).resolve().parents[1]
+        / "tools"
+        / "apk-re"
+        / "bin"
+        / "hcnetsdk-command-live-check"
+    )
+    loader = SourceFileLoader("hcnetsdk_command_live_check", str(path))
+    spec = spec_from_loader(loader.name, loader)
+    assert spec is not None
+    module = module_from_spec(spec)
+    sys.modules[loader.name] = module
+    loader.exec_module(module)
+    return module
+
+
+def test_load_inventory_reads_shell_quoted_env_file(tmp_path: Path) -> None:
+    tool = _load_tool()
+    inventory = [
+        {
+            "name": "Camera One",
+            "mdns": "SERIAL-ONE",
+            "password": "dummy-camera-password-07",
+            "enc_key": "dummy-enc-key-01",
+            "battery": False,
+            "in_use": True,
+        },
+        {
+            "name": "Camera Two",
+            "mdns": "SERIAL-TWO",
+            "password": "dummy-camera-password-03",
+            "enc_key": "dummy-enc-key-02",
+            "battery": True,
+            "in_use": False,
+        },
+    ]
+    env_file = tmp_path / "inventory.env"
+    env_file.write_text(
+        "EZVIZ_CAMERA_INVENTORY_JSON="
+        + sh_single_quote(json.dumps(inventory))
+        + "\n",
+        encoding="utf-8",
+    )
+
+    items = tool._load_inventory(  # noqa: SLF001
+        argparse.Namespace(
+            inventory_file=str(env_file),
+            inventory_env="EZVIZ_CAMERA_INVENTORY_JSON",
+        )
+    )
+
+    assert [item.serial for item in items] == ["SERIAL-ONE", "SERIAL-TWO"]
+    assert items[0].name == "Camera One"
+    assert items[1].enc_key == "dummy-enc-key-02"
+
+
+def test_filtered_items_skip_unused_and_battery_by_default() -> None:
+    tool = _load_tool()
+    items = [
+        tool.CameraInventoryItem(name="wired", serial="A", password="one"),
+        tool.CameraInventoryItem(name="unused", serial="B", password="two", in_use=False),
+        tool.CameraInventoryItem(name="battery", serial="C", password="three", battery=True),
+    ]
+
+    selected = tool._filtered_items(  # noqa: SLF001
+        items,
+        serials=[],
+        include_unused=False,
+        include_battery=False,
+        max_cameras=None,
+    )
+
+    assert [item.serial for item in selected] == ["A"]
+
+
+def test_dry_run_redacts_sensitive_camera_fields(tmp_path: Path) -> None:
+    tool = _load_tool()
+    args = argparse.Namespace(
+        python="python",
+        command_port="8000",
+        channel="1",
+        native_plan="app-lan-live-view",
+        duration="5s",
+        timeout="12",
+        ffmpeg_path="ffmpeg",
+        local_ip=None,
+        decrypt_video=False,
+        no_try_enc_key_password=False,
+        no_skip_initial_idr=False,
+        dry_run=True,
+    )
+    item = tool.CameraInventoryItem(
+        name="Garage",
+        serial="SERIAL-GARAGE-01",
+        password="dummy-camera-password-01",
+        enc_key="dummy-enc-key-03",
+    )
+
+    result = tool._check_item(  # noqa: SLF001
+        args=args,
+        item=item,
+        output_dir=tmp_path,
+        host="192.0.2.10",
+        host_source="override",
+        camera_index=1,
+    )
+
+    rendered = json.dumps(result)
+    assert result["ok"] is None
+    assert "<redacted>" in rendered
+    assert "dummy-camera-password-01" not in rendered
+    assert "SERIAL-GARAGE-01" not in rendered
+    assert "dummy-enc-key-03" not in rendered
+    assert result["serial"] == "<redacted>"
+    assert result["command"][result["command"].index("--serial") + 1] == "<redacted>"
+    assert [attempt["credential_source"] for attempt in result["credential_attempts"]] == [
+        "inventory_password",
+        "encryption_key_password",
+    ]
+    for attempt in result["credential_attempts"]:
+        command = attempt["command"]
+        assert command[command.index("--hcnetsdk-command-password") + 1] == "<redacted>"
+    assert any(
+        value.endswith("camera-01-Garage-encryption_key_password.ts")
+        for value in result["credential_attempts"][1]["command"]
+    )
+    assert "camera-01-Garage" in result["artifacts"]["capture"]
+
+
+def test_dry_run_redacts_media_key_when_decrypting(tmp_path: Path) -> None:
+    tool = _load_tool()
+    args = argparse.Namespace(
+        python="python",
+        command_port="8000",
+        channel="1",
+        native_plan="app-lan-live-view",
+        duration="5s",
+        timeout="12",
+        ffmpeg_path="ffmpeg",
+        local_ip=None,
+        decrypt_video=True,
+        no_try_enc_key_password=False,
+        no_skip_initial_idr=False,
+        dry_run=True,
+    )
+    item = tool.CameraInventoryItem(
+        name="Garage",
+        serial="SERIAL-GARAGE-01",
+        password="dummy-camera-password-01",
+        enc_key="dummy-enc-key-03",
+    )
+
+    result = tool._check_item(  # noqa: SLF001
+        args=args,
+        item=item,
+        output_dir=tmp_path,
+        host="192.0.2.10",
+        host_source="override",
+        camera_index=1,
+    )
+
+    rendered = json.dumps(result)
+    assert "--decrypt-video" in result["command"]
+    assert result["command"][result["command"].index("--media-key") + 1] == "<redacted>"
+    assert len(result["credential_attempts"]) == 2
+    assert "dummy-enc-key-03" not in rendered
+
+
+def test_credential_attempts_can_skip_encryption_key_password() -> None:
+    tool = _load_tool()
+    args = argparse.Namespace(no_try_enc_key_password=True)
+    item = tool.CameraInventoryItem(
+        name="Garage",
+        serial="SERIAL-GARAGE-01",
+        password="dummy-camera-password-01",
+        enc_key="dummy-enc-key-03",
+    )
+
+    attempts = tool._credential_attempts(args, item)  # noqa: SLF001
+
+    assert attempts == [("inventory_password", "dummy-camera-password-01")]
+
+
+def test_recursive_redaction_covers_serial_password_and_enc_key() -> None:
+    tool = _load_tool()
+    item = tool.CameraInventoryItem(
+        name="Garage",
+        serial="SERIAL-GARAGE-01",
+        password="dummy-camera-password-01",
+        enc_key="dummy-enc-key-03",
+    )
+
+    redacted = tool._redact_sensitive(  # noqa: SLF001
+        {
+            "stderr": "SERIAL-GARAGE-01 dummy-camera-password-01 dummy-enc-key-03",
+            "nested": ["prefix-SERIAL-GARAGE-01"],
+        },
+        item,
+    )
+
+    rendered = json.dumps(redacted)
+    assert "SERIAL-GARAGE-01" not in rendered
+    assert "dummy-camera-password-01" not in rendered
+    assert "dummy-enc-key-03" not in rendered
+    assert rendered.count("<redacted>") == 4
+
+
+def test_diagnose_save_failure_prioritizes_connection_refused(tmp_path: Path) -> None:
+    tool = _load_tool()
+
+    diagnosis = tool._diagnose_save_failure(  # noqa: SLF001
+        "File local_stream.py, in _login_client\nConnectionRefusedError: [Errno 111] Connection refused\n",
+        tmp_path / "missing.metadata.json",
+    )
+
+    assert diagnosis == "connection_refused"
+
+
+def test_diagnose_save_failure_labels_short_idr_capture(tmp_path: Path) -> None:
+    tool = _load_tool()
+
+    diagnosis = tool._diagnose_save_failure(  # noqa: SLF001
+        "ERROR: H.264 stream did not contain enough IDR windows to skip 1 startup window(s)\n",
+        tmp_path / "missing.metadata.json",
+    )
+
+    assert diagnosis == "insufficient_idr_windows"
+
+
+def test_stdout_summary_compacts_packet_metadata() -> None:
+    tool = _load_tool()
+    summary = {
+        "ok": True,
+        "results": [
+            {
+                "ok": True,
+                "metadata": {
+                    "bootstrap_complete": True,
+                    "command_port_exchanges": [{"request_command_id": 1}],
+                    "packets": {
+                        "packet_count": 2,
+                        "last_packet_elapsed_seconds": 1.5,
+                        "samples": [{"body_sha256": "x"}],
+                        "idmx_h264": {
+                            "packet_count": 2,
+                            "nal_type_counts": {"1": 1},
+                            "rtp_payload_type_counts": {"96": 2},
+                            "sequence_gap_count": 0,
+                            "invalid_media_marker_count": 0,
+                            "samples": [{"body_sha256": "y"}],
+                        },
+                    },
+                },
+            }
+        ],
+    }
+
+    compact = tool._stdout_summary(summary, include_metadata=False)  # noqa: SLF001
+
+    metadata = compact["results"][0]["metadata"]
+    assert metadata["command_port_exchange_count"] == 1
+    assert metadata["packets"]["packet_count"] == 2
+    assert "samples" not in metadata["packets"]
+    assert "samples" not in metadata["packets"]["idmx_h264"]
+
+
+def sh_single_quote(value: str) -> str:
+    return "'" + value.replace("'", "'\\''") + "'"

--- a/tests/test_hcnetsdk_command_live_check.py
+++ b/tests/test_hcnetsdk_command_live_check.py
@@ -319,7 +319,7 @@ def test_relative_output_dir_resolves_before_child_commands(
     assert command[command.index("--hcnetsdk-command-metadata-output") + 1] == metadata
 
 
-def test_success_artifacts_redact_child_save_output(
+def test_success_artifacts_redact_child_save_artifacts(
     tmp_path: Path, monkeypatch: Any
 ) -> None:
     tool = _load_tool()
@@ -397,13 +397,15 @@ def test_success_artifacts_redact_child_save_output(
     assert result["ok"] is True
     stdout_text = Path(result["artifacts"]["save_stdout"]).read_text(encoding="utf-8")
     stderr_text = Path(result["artifacts"]["save_stderr"]).read_text(encoding="utf-8")
+    metadata_text = Path(result["artifacts"]["metadata"]).read_text(encoding="utf-8")
     rendered = json.dumps(result)
-    for text in (stdout_text, stderr_text, rendered):
+    for text in (stdout_text, stderr_text, metadata_text, rendered):
         assert "SERIAL-GARAGE-01" not in text
         assert "dummy-camera-password-01" not in text
         assert "dummy-enc-key-03" not in text
     assert stdout_text.count("<redacted>") == 2
     assert stderr_text.count("<redacted>") == 2
+    assert metadata_text.count("<redacted>") == 3
 
 
 def test_credential_attempts_can_skip_encryption_key_password() -> None:

--- a/tests/test_hcnetsdk_command_live_check.py
+++ b/tests/test_hcnetsdk_command_live_check.py
@@ -179,6 +179,57 @@ def test_dry_run_redacts_media_key_when_decrypting(tmp_path: Path) -> None:
     assert "dummy-enc-key-03" not in rendered
 
 
+def test_dotted_camera_name_preserves_retry_suffix_artifact_paths(tmp_path: Path) -> None:
+    tool = _load_tool()
+    args = argparse.Namespace(
+        python="python",
+        command_port="8000",
+        channel="1",
+        native_plan="app-lan-live-view",
+        duration="5s",
+        timeout="12",
+        ffmpeg_path="ffmpeg",
+        local_ip=None,
+        decrypt_video=False,
+        no_try_enc_key_password=False,
+        no_skip_initial_idr=False,
+        dry_run=True,
+    )
+    item = tool.CameraInventoryItem(
+        name="Front.Door",
+        serial="SERIAL-FRONT-DOOR-01",
+        password="dummy-camera-password-01",
+        enc_key="dummy-enc-key-03",
+    )
+
+    result = tool._check_item(  # noqa: SLF001
+        args=args,
+        item=item,
+        output_dir=tmp_path,
+        host="192.0.2.10",
+        host_source="override",
+        camera_index=1,
+    )
+
+    attempts = result["credential_attempts"]
+    inventory_command = attempts[0]["command"]
+    enc_key_command = attempts[1]["command"]
+    assert (
+        inventory_command[inventory_command.index("--output") + 1]
+        == str(tmp_path / "camera-01-Front.Door-inventory_password.ts")
+    )
+    assert (
+        inventory_command[
+            inventory_command.index("--hcnetsdk-command-metadata-output") + 1
+        ]
+        == str(tmp_path / "camera-01-Front.Door-inventory_password.metadata.json")
+    )
+    assert enc_key_command[enc_key_command.index("--output") + 1] == str(
+        tmp_path / "camera-01-Front.Door-encryption_key_password.ts"
+    )
+    assert result["artifacts"]["capture"] == str(tmp_path / "camera-01-Front.Door.ts")
+
+
 def test_relative_output_dir_resolves_before_child_commands(
     tmp_path: Path, monkeypatch: Any
 ) -> None:
@@ -440,4 +491,4 @@ def test_stdout_summary_compacts_packet_metadata() -> None:
 
 
 def sh_single_quote(value: str) -> str:
-    return "'" + value.replace("'", "'\\''") + "'"
+    return "'" + value.replace("'", "'\''") + "'"

--- a/tests/test_hcnetsdk_command_live_check.py
+++ b/tests/test_hcnetsdk_command_live_check.py
@@ -5,6 +5,7 @@ from importlib.machinery import SourceFileLoader
 from importlib.util import module_from_spec, spec_from_loader
 import json
 from pathlib import Path
+import subprocess
 import sys
 from typing import Any
 
@@ -224,6 +225,93 @@ def test_relative_output_dir_resolves_before_child_commands(
     assert metadata == str(caller_cwd / "matrix-out" / "camera-01-Garage.metadata.json")
     assert command[command.index("--output") + 1] == capture
     assert command[command.index("--hcnetsdk-command-metadata-output") + 1] == metadata
+
+
+def test_success_artifacts_redact_child_save_output(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    tool = _load_tool()
+    args = argparse.Namespace(
+        python="python",
+        command_port="8000",
+        channel="1",
+        native_plan="app-lan-live-view",
+        duration="5s",
+        timeout="12",
+        ffmpeg_path="ffmpeg",
+        ffprobe_path="ffprobe",
+        local_ip=None,
+        decrypt_video=True,
+        no_try_enc_key_password=True,
+        no_skip_initial_idr=False,
+        dry_run=False,
+    )
+    item = tool.CameraInventoryItem(
+        name="Garage",
+        serial="SERIAL-GARAGE-01",
+        password="dummy-camera-password-01",
+        enc_key="dummy-enc-key-03",
+    )
+
+    def fake_run(command: list[str], *, cwd: Path) -> subprocess.CompletedProcess[bytes]:
+        if command[0] == "ffprobe":
+            return subprocess.CompletedProcess(
+                command,
+                0,
+                stdout=(
+                    b'{"streams":[{"index":0,"codec_type":"video",'
+                    b'"codec_name":"h264","width":1920,"height":1080}],'
+                    b'"format":{"duration":"5.0"}}'
+                ),
+                stderr=b"",
+            )
+        capture_path = Path(command[command.index("--output") + 1])
+        metadata_path = Path(
+            command[command.index("--hcnetsdk-command-metadata-output") + 1]
+        )
+        capture_path.write_bytes(b"mpegts")
+        metadata_path.write_text(
+            json.dumps(
+                {
+                    "bootstrap_complete": True,
+                    "serial": "SERIAL-GARAGE-01",
+                    "password_hint": "dummy-camera-password-01",
+                    "media_key_hint": "dummy-enc-key-03",
+                }
+            ),
+            encoding="utf-8",
+        )
+        return subprocess.CompletedProcess(
+            command,
+            0,
+            stdout=(
+                b'{"ok":true,"serial":"SERIAL-GARAGE-01",'
+                b'"media_key":"dummy-enc-key-03"}\n'
+            ),
+            stderr=b"connected SERIAL-GARAGE-01 with dummy-camera-password-01\n",
+        )
+
+    monkeypatch.setattr(tool, "_run", fake_run)
+
+    result = tool._check_item(  # noqa: SLF001
+        args=args,
+        item=item,
+        output_dir=tmp_path,
+        host="192.0.2.10",
+        host_source="override",
+        camera_index=1,
+    )
+
+    assert result["ok"] is True
+    stdout_text = Path(result["artifacts"]["save_stdout"]).read_text(encoding="utf-8")
+    stderr_text = Path(result["artifacts"]["save_stderr"]).read_text(encoding="utf-8")
+    rendered = json.dumps(result)
+    for text in (stdout_text, stderr_text, rendered):
+        assert "SERIAL-GARAGE-01" not in text
+        assert "dummy-camera-password-01" not in text
+        assert "dummy-enc-key-03" not in text
+    assert stdout_text.count("<redacted>") == 2
+    assert stderr_text.count("<redacted>") == 2
 
 
 def test_credential_attempts_can_skip_encryption_key_password() -> None:

--- a/tests/test_hcnetsdk_command_live_check.py
+++ b/tests/test_hcnetsdk_command_live_check.py
@@ -179,6 +179,47 @@ def test_dry_run_redacts_media_key_when_decrypting(tmp_path: Path) -> None:
     assert "dummy-enc-key-03" not in rendered
 
 
+def test_decrypt_video_without_encryption_key_is_untestable(tmp_path: Path) -> None:
+    tool = _load_tool()
+    args = argparse.Namespace(
+        python="python",
+        command_port="8000",
+        channel="1",
+        native_plan="app-lan-live-view",
+        duration="5s",
+        timeout="12",
+        ffmpeg_path="ffmpeg",
+        local_ip=None,
+        decrypt_video=True,
+        no_try_enc_key_password=False,
+        no_skip_initial_idr=False,
+        dry_run=True,
+    )
+    item = tool.CameraInventoryItem(
+        name="Garage",
+        serial="SERIAL-GARAGE-01",
+        password="dummy-camera-password-01",
+    )
+
+    result = tool._check_item(  # noqa: SLF001
+        args=args,
+        item=item,
+        output_dir=tmp_path,
+        host="192.0.2.10",
+        host_source="override",
+        camera_index=1,
+    )
+
+    rendered = json.dumps(result)
+    assert result["ok"] is False
+    assert result["stage"] == "credential-validation"
+    assert result["diagnosis"] == "missing_encryption_key"
+    assert result["credential_attempts"] == []
+    assert "command" not in result
+    assert "SERIAL-GARAGE-01" not in rendered
+    assert "dummy-camera-password-01" not in rendered
+
+
 def test_dotted_camera_name_preserves_retry_suffix_artifact_paths(tmp_path: Path) -> None:
     tool = _load_tool()
     args = argparse.Namespace(

--- a/tests/test_hcnetsdk_command_live_check.py
+++ b/tests/test_hcnetsdk_command_live_check.py
@@ -491,4 +491,4 @@ def test_stdout_summary_compacts_packet_metadata() -> None:
 
 
 def sh_single_quote(value: str) -> str:
-    return "'" + value.replace("'", "'\''") + "'"
+    return "'" + value.replace("'", "'\\''") + "'"

--- a/tests/test_http_helpers.py
+++ b/tests/test_http_helpers.py
@@ -2726,6 +2726,82 @@ def test_save_clip_uses_hcnetsdk_command_port_source(monkeypatch, tmp_path) -> N
     }
 
 
+def test_save_clip_forwards_h264_options_to_decrypted_hcnetsdk_command_port(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    client = _client()
+    output_path = tmp_path / "front-decrypted.ts"
+    calls: list[dict[str, Any]] = []
+
+    class FakeCommandPortStream:
+        def __enter__(self) -> FakeCommandPortStream:
+            return self
+
+        def __exit__(self, *_args: object) -> None:
+            return None
+
+    def fake_open_hcnetsdk_command_port_stream(
+        endpoint: Any,
+        command_frames: tuple[bytes, ...],
+        **kwargs: Any,
+    ) -> FakeCommandPortStream:
+        calls.append(
+            {
+                "endpoint": endpoint,
+                "command_frames": command_frames,
+                **kwargs,
+            }
+        )
+        return FakeCommandPortStream()
+
+    def fake_copy_local_stream_to_decrypted_mpegts(
+        stream: Any,
+        output: BinaryIO,
+        media_key: str | bytes,
+        **kwargs: Any,
+    ) -> None:
+        calls.append({"stream": stream, "media_key": media_key, **kwargs})
+        output.write(SAVE_CLIP_PAYLOAD)
+
+    monkeypatch.setattr(
+        "pyezvizapi.client.open_hcnetsdk_command_port_stream",
+        fake_open_hcnetsdk_command_port_stream,
+    )
+    monkeypatch.setattr(
+        "pyezvizapi.client.copy_local_stream_to_decrypted_mpegts",
+        fake_copy_local_stream_to_decrypted_mpegts,
+    )
+
+    result = client.save_clip(
+        "CAM123",
+        output_path,
+        source="hcnetsdk-command-port",
+        host="192.0.2.10",
+        command_port=8000,
+        hcnetsdk_command_frames=(bytes.fromhex("00000010"),),
+        decrypt_video=True,
+        media_key="MEDIAKEY",
+        hcnetsdk_h264_skip_initial_idr_windows=1,
+        hcnetsdk_h264_trim_to_clean_idr_window=True,
+        hcnetsdk_h264_clean_idr_max_windows=HCNETSDK_CLEAN_IDR_MAX_WINDOWS,
+        duration_seconds=HCNETSDK_SAVE_DURATION,
+        max_packets=4,
+    )
+
+    assert calls[1]["media_key"] == "MEDIAKEY"
+    assert calls[1]["ffmpeg_path"] == "ffmpeg"
+    assert calls[1]["max_packets"] == 4
+    assert calls[1]["duration_seconds"] == HCNETSDK_SAVE_DURATION
+    assert calls[1]["h264_skip_initial_idr_windows"] == 1
+    assert calls[1]["h264_trim_to_clean_idr_window"] is True
+    assert (
+        calls[1]["h264_clean_idr_max_windows"] == HCNETSDK_CLEAN_IDR_MAX_WINDOWS
+    )
+    assert result.get("source") == "hcnetsdk-command-port"
+    assert output_path.read_bytes() == SAVE_CLIP_PAYLOAD
+
+
 def test_save_clip_uses_hcnetsdk_multi_socket_command_plan(
     monkeypatch,
     tmp_path,
@@ -2796,8 +2872,8 @@ def test_save_clip_uses_hcnetsdk_multi_socket_command_plan(
     assert calls[0]["timeout"] == DEFAULT_SAVE_TIMEOUT
     assert calls[1]["duration_seconds"] == HCNETSDK_SAVE_DURATION
     assert output_path.read_bytes() == SAVE_CLIP_PAYLOAD
-    assert result["source"] == "hcnetsdk-command-port"
-    assert result["command_port"] == 8000
+    assert result.get("source") == "hcnetsdk-command-port"
+    assert result.get("command_port") == 8000
 
 
 def test_save_clip_uses_cloud_source(monkeypatch, tmp_path) -> None:

--- a/tests/test_local_stream.py
+++ b/tests/test_local_stream.py
@@ -1605,6 +1605,67 @@ def test_copy_local_stream_to_mpegts_remuxes_direct_idmx_hevc_payload(
     )
 
 
+def test_copy_local_stream_to_mpegts_prefers_direct_hevc_over_partial_h264(
+    tmp_path,
+) -> None:
+    fake_ffmpeg = tmp_path / "fake-ffmpeg"
+    fake_ffmpeg.write_text(
+        "#!/usr/bin/env python3\n"
+        "import sys\n"
+        "codec = sys.argv[sys.argv.index('-f') + 1]\n"
+        "sys.stdout.buffer.write(codec.encode() + b':' + sys.stdin.buffer.read())\n",
+        encoding="utf-8",
+    )
+    fake_ffmpeg.chmod(0o755)
+    rtp_timestamp = 0x3601D1EF
+    sequence_base = 0x7000
+
+    def frame(body: bytes, *, sequence: int) -> bytes:
+        return (
+            b"\x80\x60"
+            + sequence.to_bytes(2, "big")
+            + rtp_timestamp.to_bytes(4, "big")
+            + b"\x55\x66\x77\x88"
+            + body
+        )
+
+    vps = b"\x40\x01vps"
+    sps = b"\x42\x01sps"
+    pps = b"\x44\x01pps"
+    idr = b"\x26\x01idr-slice"
+
+    class FakeStream:
+        def iter_packets(self, *, max_packets: int | None = None) -> list[Any]:
+            assert max_packets == 4
+            return [
+                SimpleNamespace(body=frame(vps, sequence=sequence_base)),
+                SimpleNamespace(body=frame(sps, sequence=sequence_base + 1)),
+                SimpleNamespace(body=frame(pps, sequence=sequence_base + 2)),
+                SimpleNamespace(body=frame(idr, sequence=sequence_base + 3)),
+            ]
+
+    output = io.BytesIO()
+
+    copy_local_stream_to_mpegts(
+        FakeStream(),
+        output,
+        ffmpeg_path=str(fake_ffmpeg),
+        max_packets=4,
+        h264_skip_initial_idr_windows=1,
+    )
+
+    assert output.getvalue() == (
+        b"hevc:\x00\x00\x00\x01"
+        + vps
+        + b"\x00\x00\x00\x01"
+        + sps
+        + b"\x00\x00\x00\x01"
+        + pps
+        + b"\x00\x00\x00\x01"
+        + idr
+    )
+
+
 def test_copy_local_stream_to_decrypted_mpegps_rejects_idmx_payload() -> None:
     idmx_frame = (
         b"\x0d\xb0\xf0\x50\x37\x03\xb5\xea\xee\x55\x66\x77\x88"

--- a/tests/test_local_stream.py
+++ b/tests/test_local_stream.py
@@ -1542,6 +1542,49 @@ def test_copy_local_stream_to_decrypted_mpegts_decrypts_idmx_payload(
     )
 
 
+def test_copy_local_stream_to_decrypted_mpegts_applies_h264_startup_trim(
+    tmp_path,
+) -> None:
+    fake_ffmpeg = tmp_path / "fake-ffmpeg"
+    fake_ffmpeg.write_text(
+        "#!/usr/bin/env python3\n"
+        "import sys\n"
+        "sys.stdout.buffer.write(b'ts:' + sys.stdin.buffer.read())\n",
+        encoding="utf-8",
+    )
+    fake_ffmpeg.chmod(0o755)
+    idmx_header = b"\x80\x60\x02\x03\x04\x05\x06\x07\x55\x66\x77\x88"
+    sps = b"\x67\x4d\x00"
+    pps = b"\x68\xee\x38"
+    first_idr = b"\x65bad"
+    second_idr = b"\x65good"
+
+    def idmx_frame(body: bytes) -> bytes:
+        frame = idmx_header + body
+        return len(frame).to_bytes(4, "little") + frame
+
+    class FakeStream:
+        def iter_packets(self, *, max_packets: int | None = None) -> list[Any]:
+            assert max_packets == 4
+            return [
+                SimpleNamespace(body=idmx_frame(body))
+                for body in (sps, pps, first_idr, second_idr)
+            ]
+
+    output = io.BytesIO()
+
+    copy_local_stream_to_decrypted_mpegts(
+        FakeStream(),
+        output,
+        IDMX_MEDIA_KEY,
+        ffmpeg_path=str(fake_ffmpeg),
+        max_packets=4,
+        h264_skip_initial_idr_windows=1,
+    )
+
+    assert output.getvalue() == b"ts:\x00\x00\x00\x01" + second_idr
+
+
 def test_copy_local_stream_to_mpegts_remuxes_direct_idmx_hevc_payload(
     tmp_path,
 ) -> None:
@@ -1600,6 +1643,64 @@ def test_copy_local_stream_to_mpegts_remuxes_direct_idmx_hevc_payload(
         + sps
         + b"\x00\x00\x00\x01"
         + pps
+        + b"\x00\x00\x00\x01"
+        + b"\x26\x01slice-payload"
+    )
+
+
+def test_copy_local_stream_to_mpegts_drops_hevc_fu_until_start(
+    tmp_path,
+) -> None:
+    fake_ffmpeg = tmp_path / "fake-ffmpeg"
+    fake_ffmpeg.write_text(
+        "#!/usr/bin/env python3\n"
+        "import sys\n"
+        "codec = sys.argv[sys.argv.index('-f') + 1]\n"
+        "sys.stdout.buffer.write(codec.encode() + b':' + sys.stdin.buffer.read())\n",
+        encoding="utf-8",
+    )
+    fake_ffmpeg.chmod(0o755)
+    rtp_timestamp = 0x3601D1EF
+    sequence_base = 0x7000
+
+    def frame(body: bytes, *, sequence: int) -> bytes:
+        return (
+            b"\x80\x60"
+            + sequence.to_bytes(2, "big")
+            + rtp_timestamp.to_bytes(4, "big")
+            + b"\x55\x66\x77\x88"
+            + body
+        )
+
+    vps = b"\x40\x01vps"
+    orphan_middle_fu = b"\x62\x01\x13orphan-"
+    orphan_end_fu = b"\x62\x01\x53tail"
+    valid_start_fu = b"\x62\x01\x93slice-"
+    valid_end_fu = b"\x62\x01\x53payload"
+
+    class FakeStream:
+        def iter_packets(self, *, max_packets: int | None = None) -> list[Any]:
+            assert max_packets == 5
+            return [
+                SimpleNamespace(body=frame(vps, sequence=sequence_base)),
+                SimpleNamespace(body=frame(orphan_middle_fu, sequence=sequence_base + 1)),
+                SimpleNamespace(body=frame(orphan_end_fu, sequence=sequence_base + 2)),
+                SimpleNamespace(body=frame(valid_start_fu, sequence=sequence_base + 3)),
+                SimpleNamespace(body=frame(valid_end_fu, sequence=sequence_base + 4)),
+            ]
+
+    output = io.BytesIO()
+
+    copy_local_stream_to_mpegts(
+        FakeStream(),
+        output,
+        ffmpeg_path=str(fake_ffmpeg),
+        max_packets=5,
+    )
+
+    assert output.getvalue() == (
+        b"hevc:\x00\x00\x00\x01"
+        + vps
         + b"\x00\x00\x00\x01"
         + b"\x26\x01slice-payload"
     )

--- a/tests/test_local_stream.py
+++ b/tests/test_local_stream.py
@@ -1585,6 +1585,43 @@ def test_copy_local_stream_to_decrypted_mpegts_applies_h264_startup_trim(
     assert output.getvalue() == b"ts:\x00\x00\x00\x01" + second_idr
 
 
+def test_copy_local_stream_to_decrypted_mpegts_prefers_h264_vcl_before_hevc_probe(
+    tmp_path,
+) -> None:
+    fake_ffmpeg = tmp_path / "fake-ffmpeg"
+    fake_ffmpeg.write_text(
+        "#!/usr/bin/env python3\n"
+        "import sys\n"
+        "codec = sys.argv[sys.argv.index('-f') + 1]\n"
+        "sys.stdout.buffer.write(codec.encode() + b':' + sys.stdin.buffer.read())\n",
+        encoding="utf-8",
+    )
+    fake_ffmpeg.chmod(0o755)
+    idmx_header = b"\x80\x60\x02\x03\x04\x05\x06\x07\x55\x66\x77\x88"
+    h264_non_idr = b"\x41\x01h264-slice"
+
+    def idmx_frame(body: bytes) -> bytes:
+        frame = idmx_header + body
+        return len(frame).to_bytes(4, "little") + frame
+
+    class FakeStream:
+        def iter_packets(self, *, max_packets: int | None = None) -> list[Any]:
+            assert max_packets == 1
+            return [SimpleNamespace(body=idmx_frame(h264_non_idr))]
+
+    output = io.BytesIO()
+
+    copy_local_stream_to_decrypted_mpegts(
+        FakeStream(),
+        output,
+        IDMX_MEDIA_KEY,
+        ffmpeg_path=str(fake_ffmpeg),
+        max_packets=1,
+    )
+
+    assert output.getvalue() == b"h264:\x00\x00\x00\x01" + h264_non_idr
+
+
 def test_copy_local_stream_to_decrypted_mpegts_wait_for_clean_idr_bounds_output(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path,

--- a/tests/test_local_stream.py
+++ b/tests/test_local_stream.py
@@ -1542,6 +1542,69 @@ def test_copy_local_stream_to_decrypted_mpegts_decrypts_idmx_payload(
     )
 
 
+def test_copy_local_stream_to_mpegts_remuxes_direct_idmx_hevc_payload(
+    tmp_path,
+) -> None:
+    fake_ffmpeg = tmp_path / "fake-ffmpeg"
+    fake_ffmpeg.write_text(
+        "#!/usr/bin/env python3\n"
+        "import sys\n"
+        "codec = sys.argv[sys.argv.index('-f') + 1]\n"
+        "sys.stdout.buffer.write(codec.encode() + b':' + sys.stdin.buffer.read())\n",
+        encoding="utf-8",
+    )
+    fake_ffmpeg.chmod(0o755)
+    rtp_timestamp = 0x3601D1EF
+    sequence_base = 0x7000
+
+    def frame(body: bytes, *, sequence: int) -> bytes:
+        return (
+            b"\x80\x60"
+            + sequence.to_bytes(2, "big")
+            + rtp_timestamp.to_bytes(4, "big")
+            + b"\x55\x66\x77\x88"
+            + body
+        )
+
+    vps = b"\x40\x01vps"
+    sps = b"\x42\x01sps"
+    pps = b"\x44\x01pps"
+    first_fu = b"\x62\x01\x93slice-"
+    last_fu = b"\x62\x01\x53payload"
+
+    class FakeStream:
+        def iter_packets(self, *, max_packets: int | None = None) -> list[Any]:
+            assert max_packets == 5
+            return [
+                SimpleNamespace(body=frame(vps, sequence=sequence_base)),
+                SimpleNamespace(body=frame(sps, sequence=sequence_base + 1)),
+                SimpleNamespace(body=frame(pps, sequence=sequence_base + 2)),
+                SimpleNamespace(body=frame(first_fu, sequence=sequence_base + 3)),
+                SimpleNamespace(body=frame(last_fu, sequence=sequence_base + 4)),
+            ]
+
+    output = io.BytesIO()
+
+    copy_local_stream_to_mpegts(
+        FakeStream(),
+        output,
+        ffmpeg_path=str(fake_ffmpeg),
+        max_packets=5,
+        h264_skip_initial_idr_windows=1,
+    )
+
+    assert output.getvalue() == (
+        b"hevc:\x00\x00\x00\x01"
+        + vps
+        + b"\x00\x00\x00\x01"
+        + sps
+        + b"\x00\x00\x00\x01"
+        + pps
+        + b"\x00\x00\x00\x01"
+        + b"\x26\x01slice-payload"
+    )
+
+
 def test_copy_local_stream_to_decrypted_mpegps_rejects_idmx_payload() -> None:
     idmx_frame = (
         b"\x0d\xb0\xf0\x50\x37\x03\xb5\xea\xee\x55\x66\x77\x88"
@@ -2455,6 +2518,37 @@ def test_summarize_idmx_h264_local_packets_reports_sanitized_frame_shapes() -> N
         ],
         "truncated": False,
     }
+
+
+def test_summarize_idmx_h264_local_packets_labels_direct_hevc_frames() -> None:
+    sequence_base = 0xB712
+    rtp_timestamp = 0x165477EB
+
+    def frame(body: bytes, *, sequence: int) -> bytes:
+        inner_header = (
+            b"\x80\x60"
+            + sequence.to_bytes(2, "big")
+            + rtp_timestamp.to_bytes(4, "big")
+            + b"\x55\x66\x77\x88"
+        )
+        idmx_frame = inner_header + body
+        return len(idmx_frame).to_bytes(4, "little") + idmx_frame
+
+    summary = summarize_idmx_h264_local_packets(
+        [
+            frame(b"\x40\x01vps", sequence=sequence_base),
+            frame(b"\x62\x01\x93slice", sequence=sequence_base + 1),
+        ],
+        max_frames=2,
+    )
+
+    assert [sample["kind"] for sample in summary["samples"]] == [
+        "hevc_media",
+        "hevc_media",
+    ]
+    assert summary["samples"][0]["hevc_nal_type"] == 32
+    assert summary["samples"][1]["hevc_nal_type"] == 49
+    assert summary["hevc"] == {"parameter": 0, "media": 2}
 
 
 def test_summarize_h264_annexb_units_reports_sanitized_nal_shapes() -> None:

--- a/tests/test_local_stream.py
+++ b/tests/test_local_stream.py
@@ -1886,6 +1886,7 @@ def test_copy_local_stream_to_mpegts_prefers_hevc_idr_over_h264_sei_shape(
         output,
         ffmpeg_path=str(fake_ffmpeg),
         max_packets=1,
+        h264_skip_initial_idr_windows=1,
     )
 
     assert output.getvalue() == (

--- a/tests/test_local_stream.py
+++ b/tests/test_local_stream.py
@@ -1814,6 +1814,51 @@ def test_copy_local_stream_to_mpegts_remuxes_clear_h264_idmx_payload(tmp_path) -
     )
 
 
+def test_copy_local_stream_to_mpegts_preserves_default_h264_idmx_codec(
+    tmp_path,
+) -> None:
+    fake_ffmpeg = tmp_path / "fake-ffmpeg"
+    fake_ffmpeg.write_text(
+        "#!/usr/bin/env python3\n"
+        "import sys\n"
+        "codec = sys.argv[sys.argv.index('-f') + 1]\n"
+        "sys.stdout.buffer.write(codec.encode() + b':' + sys.stdin.buffer.read())\n",
+        encoding="utf-8",
+    )
+    fake_ffmpeg.chmod(0o755)
+    idmx_header = b"\x80\x60\x02\x03\x04\x05\x06\x07\x55\x66\x77\x88"
+    sps = b"\x67\x4d\x00"
+    h264_p_slice_with_hevc_shape = b"\x41\x89p"
+
+    def idmx_frame(body: bytes) -> bytes:
+        frame = idmx_header + body
+        return len(frame).to_bytes(4, "little") + frame
+
+    class FakeStream:
+        def iter_packets(self, *, max_packets: int | None = None) -> list[Any]:
+            assert max_packets == 2
+            return [
+                SimpleNamespace(body=idmx_frame(sps)),
+                SimpleNamespace(body=idmx_frame(h264_p_slice_with_hevc_shape)),
+            ]
+
+    output = io.BytesIO()
+
+    copy_local_stream_to_mpegts(
+        FakeStream(),
+        output,
+        ffmpeg_path=str(fake_ffmpeg),
+        max_packets=2,
+    )
+
+    assert output.getvalue() == (
+        b"h264:\x00\x00\x00\x01"
+        + sps
+        + b"\x00\x00\x00\x01"
+        + h264_p_slice_with_hevc_shape
+    )
+
+
 def test_copy_local_stream_to_mpegts_ignores_h264_shaped_non_h264_idmx_payload(
     tmp_path,
 ) -> None:

--- a/tests/test_local_stream.py
+++ b/tests/test_local_stream.py
@@ -2093,7 +2093,7 @@ def test_copy_local_stream_to_mpegts_preserves_default_h264_idmx_codec(
     fake_ffmpeg.chmod(0o755)
     idmx_header = b"\x80\x60\x02\x03\x04\x05\x06\x07\x55\x66\x77\x88"
     sps = b"\x67\x4d\x00"
-    h264_p_slice_with_hevc_shape = b"\x41\x89p"
+    h264_p_slice_with_hevc_shape = b"\x41\x01p"
 
     def idmx_frame(body: bytes) -> bytes:
         frame = idmx_header + body

--- a/tests/test_local_stream.py
+++ b/tests/test_local_stream.py
@@ -1620,7 +1620,7 @@ def test_copy_local_stream_to_decrypted_mpegts_wait_for_clean_idr_bounds_output(
         for body in (sps, pps, clean_idr, within_duration, second_idr, after_duration)
     ]
     seen: dict[str, Any] = {}
-    times = iter([0.0, 0.1, 0.2, 0.3, 0.8, 1.5])
+    times = iter([0.0, 0.0, 0.1, 0.2, 0.3, 0.8, 1.5])
 
     def monotonic() -> float:
         return next(times, 1.5)
@@ -1644,7 +1644,7 @@ def test_copy_local_stream_to_decrypted_mpegts_wait_for_clean_idr_bounds_output(
 
     output = io.BytesIO()
     stream = object()
-    requested_duration = 0.0
+    requested_duration = 0.25
     wait_seconds = 10.0
 
     copy_local_stream_to_decrypted_mpegts(
@@ -1670,8 +1670,6 @@ def test_copy_local_stream_to_decrypted_mpegts_wait_for_clean_idr_bounds_output(
         + clean_idr
         + b"\x00\x00\x00\x01"
         + within_duration
-        + b"\x00\x00\x00\x01"
-        + second_idr
     )
 
 
@@ -1854,6 +1852,44 @@ def test_copy_local_stream_to_mpegts_prefers_direct_hevc_over_partial_h264(
         + pps
         + b"\x00\x00\x00\x01"
         + idr
+    )
+
+
+def test_copy_local_stream_to_mpegts_prefers_hevc_idr_over_h264_sei_shape(
+    tmp_path,
+) -> None:
+    fake_ffmpeg = tmp_path / "fake-ffmpeg"
+    fake_ffmpeg.write_text(
+        "#!/usr/bin/env python3\n"
+        "import sys\n"
+        "codec = sys.argv[sys.argv.index('-f') + 1]\n"
+        "sys.stdout.buffer.write(codec.encode() + b':' + sys.stdin.buffer.read())\n",
+        encoding="utf-8",
+    )
+    fake_ffmpeg.chmod(0o755)
+    idmx_header = b"\x80\x60\x02\x03\x04\x05\x06\x07\x55\x66\x77\x88"
+    hevc_idr_with_h264_sei_shape = b"\x26\x01idr"
+
+    def idmx_frame(body: bytes) -> bytes:
+        frame = idmx_header + body
+        return len(frame).to_bytes(4, "little") + frame
+
+    class FakeStream:
+        def iter_packets(self, *, max_packets: int | None = None) -> list[Any]:
+            assert max_packets == 1
+            return [SimpleNamespace(body=idmx_frame(hevc_idr_with_h264_sei_shape))]
+
+    output = io.BytesIO()
+
+    copy_local_stream_to_mpegts(
+        FakeStream(),
+        output,
+        ffmpeg_path=str(fake_ffmpeg),
+        max_packets=1,
+    )
+
+    assert output.getvalue() == (
+        b"hevc:\x00\x00\x00\x01" + hevc_idr_with_h264_sei_shape
     )
 
 

--- a/tests/test_local_stream.py
+++ b/tests/test_local_stream.py
@@ -1585,6 +1585,96 @@ def test_copy_local_stream_to_decrypted_mpegts_applies_h264_startup_trim(
     assert output.getvalue() == b"ts:\x00\x00\x00\x01" + second_idr
 
 
+def test_copy_local_stream_to_decrypted_mpegts_wait_for_clean_idr_bounds_output(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    fake_ffmpeg = tmp_path / "fake-ffmpeg"
+    fake_ffmpeg.write_text(
+        "#!/usr/bin/env python3\n"
+        "import sys\n"
+        "data = sys.stdin.buffer.read()\n"
+        "if b'bad' in data:\n"
+        "    sys.stderr.write('decode failed\\n')\n"
+        "elif '-f' in sys.argv and sys.argv[sys.argv.index('-f') + 1] == 'null':\n"
+        "    pass\n"
+        "else:\n"
+        "    sys.stdout.buffer.write(b'ts:' + data)\n",
+        encoding="utf-8",
+    )
+    fake_ffmpeg.chmod(0o755)
+    idmx_header = b"\x80\x60\x02\x03\x04\x05\x06\x07\x55\x66\x77\x88"
+    sps = b"\x67\x4d\x00"
+    pps = b"\x68\xee\x38"
+    clean_idr = b"\x65clean"
+    within_duration = b"\x41keep"
+    second_idr = b"\x65second"
+    after_duration = b"\x41drop"
+
+    def idmx_frame(body: bytes) -> bytes:
+        frame = idmx_header + body
+        return len(frame).to_bytes(4, "little") + frame
+
+    packets = [
+        idmx_frame(body)
+        for body in (sps, pps, clean_idr, within_duration, second_idr, after_duration)
+    ]
+    seen: dict[str, Any] = {}
+    times = iter([0.0, 0.1, 0.2, 0.3, 0.8, 1.5])
+
+    def monotonic() -> float:
+        return next(times, 1.5)
+
+    def fake_iter_payloads(
+        stream: Any,
+        *,
+        max_packets: int | None,
+        duration_seconds: float | None,
+        monotonic: Any,
+    ) -> Iterator[bytes]:
+        seen["stream"] = stream
+        seen["max_packets"] = max_packets
+        seen["duration_seconds"] = duration_seconds
+        yield from packets
+
+    monkeypatch.setattr(
+        "pyezvizapi.local_stream._iter_local_stream_payloads",
+        fake_iter_payloads,
+    )
+
+    output = io.BytesIO()
+    stream = object()
+    requested_duration = 0.0
+    wait_seconds = 10.0
+
+    copy_local_stream_to_decrypted_mpegts(
+        stream,
+        output,
+        IDMX_MEDIA_KEY,
+        ffmpeg_path=str(fake_ffmpeg),
+        duration_seconds=requested_duration,
+        monotonic=monotonic,
+        h264_wait_for_clean_idr_window=True,
+        h264_clean_idr_wait_seconds=wait_seconds,
+    )
+
+    assert seen["stream"] is stream
+    assert seen["max_packets"] is None
+    assert seen["duration_seconds"] == requested_duration + wait_seconds
+    assert output.getvalue() == (
+        b"ts:\x00\x00\x00\x01"
+        + sps
+        + b"\x00\x00\x00\x01"
+        + pps
+        + b"\x00\x00\x00\x01"
+        + clean_idr
+        + b"\x00\x00\x00\x01"
+        + within_duration
+        + b"\x00\x00\x00\x01"
+        + second_idr
+    )
+
+
 def test_copy_local_stream_to_mpegts_remuxes_direct_idmx_hevc_payload(
     tmp_path,
 ) -> None:

--- a/tools/apk-re/bin/hcnetsdk-command-live-check
+++ b/tools/apk-re/bin/hcnetsdk-command-live-check
@@ -174,7 +174,7 @@ def _default_python() -> str:
 
 def _artifact_dir(value: str | None) -> Path:
     if value:
-        path = Path(value)
+        path = Path(value).resolve()
     else:
         path = Path(tempfile.gettempdir()) / f"pyezvizapi-hcnetsdk-command-check-{int(time.time())}"
     path.mkdir(parents=True, exist_ok=True)

--- a/tools/apk-re/bin/hcnetsdk-command-live-check
+++ b/tools/apk-re/bin/hcnetsdk-command-live-check
@@ -511,6 +511,22 @@ def _check_item(
         "battery": item.battery,
         "in_use": item.in_use,
     }
+    if args.decrypt_video and not item.enc_key:
+        result.update(
+            {
+                "ok": False,
+                "stage": "credential-validation",
+                "diagnosis": "missing_encryption_key",
+                "credential_attempts": [],
+                "artifacts": {
+                    "capture": str(_artifact_path(base, ".ts")),
+                    "metadata": str(_artifact_path(base, ".metadata.json")),
+                    "save_stdout": str(_artifact_path(base, ".save.stdout.json")),
+                    "save_stderr": str(_artifact_path(base, ".save.stderr.txt")),
+                },
+            }
+        )
+        return result
     if args.dry_run:
         commands = []
         for credential_source, command_password in credential_attempts:

--- a/tools/apk-re/bin/hcnetsdk-command-live-check
+++ b/tools/apk-re/bin/hcnetsdk-command-live-check
@@ -1,0 +1,768 @@
+#!/usr/bin/env python3
+"""Run a bounded HCNetSDK command-port live-view compatibility matrix.
+
+This operator tool wraps ``pyezvizapi save clip --source hcnetsdk-command-port``
+with the built-in native LAN live-view plan, then validates the MPEG-TS output
+with FFprobe. It is intended for owner-run compatibility checks against real
+cameras on the local network; it does not print camera passwords, serials, or
+encryption keys.
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+import json
+import os
+from pathlib import Path
+import re
+import shlex
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+DEFAULT_INVENTORY_ENV = "EZVIZ_CAMERA_INVENTORY_JSON"
+DEFAULT_NATIVE_PLAN = "app-lan-live-view"
+REDACTED = "<redacted>"
+
+
+@dataclass(frozen=True)
+class CameraInventoryItem:
+    """One sanitized camera inventory entry."""
+
+    name: str
+    serial: str
+    password: str
+    enc_key: str = ""
+    battery: bool = False
+    in_use: bool = True
+    host: str | None = None
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(prog="hcnetsdk-command-live-check")
+    parser.add_argument(
+        "--python",
+        default=_default_python(),
+        help="Python executable used for `python -m pyezvizapi` (default: repo .venv if present)",
+    )
+    parser.add_argument(
+        "--inventory-file",
+        help=(
+            "Optional .env file containing EZVIZ_CAMERA_INVENTORY_JSON. "
+            "If omitted, the process environment is used."
+        ),
+    )
+    parser.add_argument(
+        "--inventory-env",
+        default=DEFAULT_INVENTORY_ENV,
+        help=f"Environment variable containing inventory JSON (default: {DEFAULT_INVENTORY_ENV})",
+    )
+    parser.add_argument(
+        "--output-dir",
+        default=None,
+        help="Directory for per-camera clips, metadata, logs, and matrix report",
+    )
+    parser.add_argument(
+        "--duration",
+        default="8s",
+        help="Capture duration passed to save clip (default: 8s)",
+    )
+    parser.add_argument(
+        "--timeout",
+        default="12",
+        help="Command-port socket timeout passed to save clip (default: 12)",
+    )
+    parser.add_argument(
+        "--command-port",
+        default="8000",
+        help="HCNetSDK command port passed to save clip (default: 8000)",
+    )
+    parser.add_argument(
+        "--channel",
+        default="1",
+        help="Camera channel passed to save clip (default: 1)",
+    )
+    parser.add_argument(
+        "--native-plan",
+        default=DEFAULT_NATIVE_PLAN,
+        help=f"Built-in native command-port plan (default: {DEFAULT_NATIVE_PLAN})",
+    )
+    parser.add_argument(
+        "--ffmpeg-path",
+        default="ffmpeg",
+        help="FFmpeg executable passed to save clip (default: ffmpeg)",
+    )
+    parser.add_argument(
+        "--ffprobe-path",
+        default="ffprobe",
+        help="FFprobe executable for stream inspection (default: ffprobe)",
+    )
+    parser.add_argument(
+        "--local-ip",
+        help="Optional client LAN IPv4 to patch into generated command-port frames",
+    )
+    parser.add_argument(
+        "--host",
+        action="append",
+        default=[],
+        metavar="SERIAL=HOST",
+        help="Camera host override. May be passed more than once.",
+    )
+    parser.add_argument(
+        "--serial",
+        action="append",
+        default=[],
+        help="Limit the matrix to this camera serial/mDNS id. May be repeated.",
+    )
+    parser.add_argument(
+        "--include-unused",
+        action="store_true",
+        help="Include inventory entries marked not in use",
+    )
+    parser.add_argument(
+        "--include-battery",
+        action="store_true",
+        help="Include battery cameras. Default skips them to avoid waking devices unnecessarily.",
+    )
+    parser.add_argument(
+        "--max-cameras",
+        type=int,
+        help="Optional cap after filters are applied",
+    )
+    parser.add_argument(
+        "--no-skip-initial-idr",
+        action="store_true",
+        help="Do not pass --hcnetsdk-h264-skip-initial-idr-windows 1",
+    )
+    parser.add_argument(
+        "--decrypt-video",
+        action="store_true",
+        help="Pass the inventory encryption key to decrypt encrypted IDMX video payloads",
+    )
+    parser.add_argument(
+        "--no-try-enc-key-password",
+        action="store_true",
+        help=(
+            "Do not retry command-port login with the inventory encryption key as "
+            "the command password after a pre-bootstrap password failure"
+        ),
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Resolve/filter cameras and print the sanitized plan without contacting devices",
+    )
+    parser.add_argument(
+        "--include-metadata-in-stdout",
+        action="store_true",
+        help="Include full packet metadata in stdout. The report file always keeps full metadata.",
+    )
+    return parser.parse_args()
+
+
+def _default_python() -> str:
+    venv_python = REPO_ROOT / ".venv" / "bin" / "python"
+    if venv_python.exists():
+        return str(venv_python)
+    return sys.executable
+
+
+def _artifact_dir(value: str | None) -> Path:
+    if value:
+        path = Path(value)
+    else:
+        path = Path(tempfile.gettempdir()) / f"pyezvizapi-hcnetsdk-command-check-{int(time.time())}"
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def _inventory_json_from_env_file(path: str, env_name: str) -> str:
+    for raw_line in Path(path).read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        try:
+            parsed = shlex.split(line, comments=True, posix=True)
+        except ValueError:
+            parsed = [line]
+        for token in parsed:
+            key, _, value = token.partition("=")
+            if key == env_name:
+                return value
+    raise ValueError(f"{env_name} was not found in {path}")
+
+
+def _load_inventory(args: argparse.Namespace) -> list[CameraInventoryItem]:
+    text = (
+        _inventory_json_from_env_file(args.inventory_file, args.inventory_env)
+        if args.inventory_file
+        else os.environ.get(args.inventory_env, "")
+    )
+    if not text:
+        raise ValueError(
+            f"provide --inventory-file or set {args.inventory_env} with camera inventory JSON"
+        )
+    try:
+        raw_items = json.loads(text)
+    except json.JSONDecodeError as err:
+        raise ValueError("camera inventory JSON is invalid") from err
+    if not isinstance(raw_items, list):
+        raise ValueError("camera inventory JSON must be a list")
+
+    items: list[CameraInventoryItem] = []
+    for index, raw_item in enumerate(raw_items):
+        if not isinstance(raw_item, dict):
+            raise ValueError(f"camera inventory entry {index} must be an object")
+        serial = str(raw_item.get("mdns") or raw_item.get("serial") or "").strip()
+        password = str(raw_item.get("password") or "").strip()
+        if not serial or not password:
+            raise ValueError(f"camera inventory entry {index} requires serial/mdns and password")
+        items.append(
+            CameraInventoryItem(
+                name=str(raw_item.get("name") or f"camera-{index + 1}"),
+                serial=serial,
+                password=password,
+                enc_key=str(raw_item.get("enc_key") or ""),
+                battery=bool(raw_item.get("battery")),
+                in_use=bool(raw_item.get("in_use", True)),
+                host=(str(raw_item["host"]).strip() if raw_item.get("host") else None),
+            )
+        )
+    return items
+
+
+def _host_overrides(values: list[str]) -> dict[str, str]:
+    overrides: dict[str, str] = {}
+    for value in values:
+        serial, sep, host = value.partition("=")
+        if not sep or not serial.strip() or not host.strip():
+            raise ValueError("--host values must use SERIAL=HOST")
+        overrides[serial.strip()] = host.strip()
+    return overrides
+
+
+def _filtered_items(
+    items: list[CameraInventoryItem],
+    *,
+    serials: list[str],
+    include_unused: bool,
+    include_battery: bool,
+    max_cameras: int | None,
+) -> list[CameraInventoryItem]:
+    selected = items
+    if serials:
+        wanted = set(serials)
+        selected = [item for item in selected if item.serial in wanted]
+    if not include_unused:
+        selected = [item for item in selected if item.in_use]
+    if not include_battery:
+        selected = [item for item in selected if not item.battery]
+    if max_cameras is not None:
+        if max_cameras < 1:
+            raise ValueError("--max-cameras must be positive")
+        selected = selected[:max_cameras]
+    return selected
+
+
+def _safe_name(value: str) -> str:
+    text = re.sub(r"[^A-Za-z0-9_.-]+", "-", value.strip()).strip("-")
+    return text or "camera"
+
+
+def _public_serial() -> str:
+    return REDACTED
+
+
+def _resolve_host(item: CameraInventoryItem, overrides: dict[str, str]) -> tuple[str | None, str]:
+    host = overrides.get(item.serial) or item.host
+    if host:
+        return host, "override"
+    for candidate, source in ((f"{item.serial}.local", "mdns"), (item.serial, "serial-host")):
+        try:
+            return socket.gethostbyname(candidate), source
+        except OSError:
+            continue
+    return None, "unresolved"
+
+
+def _run(command: list[str], *, cwd: Path) -> subprocess.CompletedProcess[bytes]:
+    return subprocess.run(command, cwd=cwd, capture_output=True, check=False)
+
+
+def _tail_text(data: bytes, *, max_chars: int = 4000) -> str:
+    text = data.decode("utf-8", errors="replace")
+    if len(text) <= max_chars:
+        return text
+    return text[-max_chars:]
+
+
+def _ffprobe(ffprobe_path: str, capture_path: Path) -> subprocess.CompletedProcess[bytes]:
+    return _run(
+        [
+            ffprobe_path,
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-print_format",
+            "json",
+            "-show_format",
+            "-show_streams",
+            str(capture_path),
+        ],
+        cwd=REPO_ROOT,
+    )
+
+
+def _stream_summary(ffprobe_stdout: bytes) -> dict[str, Any]:
+    try:
+        payload = json.loads(ffprobe_stdout.decode("utf-8"))
+    except json.JSONDecodeError:
+        return {"streams": []}
+    streams: list[dict[str, Any]] = []
+    for stream in payload.get("streams", []):
+        if not isinstance(stream, dict):
+            continue
+        streams.append(
+            {
+                "index": stream.get("index"),
+                "codec_type": stream.get("codec_type"),
+                "codec_name": stream.get("codec_name"),
+                "width": stream.get("width"),
+                "height": stream.get("height"),
+                "duration": stream.get("duration"),
+            }
+        )
+    return {
+        "streams": streams,
+        "format_duration": (payload.get("format") or {}).get("duration"),
+    }
+
+
+def _diagnose_save_failure(stderr_tail: str, metadata_path: Path) -> str:
+    metadata = _read_metadata(metadata_path)
+    lower_tail = stderr_tail.lower()
+    if "modulenotfounderror" in lower_tail or "importerror" in lower_tail:
+        return "environment_error"
+    if "connection refused" in lower_tail:
+        return "connection_refused"
+    if "did not contain enough idr windows" in lower_tail:
+        return "insufficient_idr_windows"
+    if not metadata.get("bootstrap_complete"):
+        diagnosis = "bootstrap_failed"
+        if "login" in lower_tail:
+            diagnosis = "login_failed"
+        elif "timed out" in lower_tail or "timeout" in lower_tail:
+            diagnosis = "bootstrap_timeout"
+        return diagnosis
+
+    diagnosis = "save_clip_failed"
+    packets = metadata.get("packets")
+    if isinstance(packets, dict):
+        if packets.get("packet_count", 0) == 0:
+            diagnosis = "no_media_packets"
+        elif packets.get("h264_idr_windows"):
+            diagnosis = "remux_failed_after_media"
+    elif "clean h.264 idr" in stderr_tail.lower():
+        diagnosis = "no_clean_idr_window"
+    return diagnosis
+
+
+def _read_metadata(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {}
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _save_command(
+    *,
+    args: argparse.Namespace,
+    item: CameraInventoryItem,
+    command_password: str,
+    host: str,
+    capture_path: Path,
+    metadata_path: Path,
+) -> list[str]:
+    command = [
+        args.python,
+        "-m",
+        "pyezvizapi",
+        "--json",
+        "save",
+        "clip",
+        "--serial",
+        item.serial,
+        "--source",
+        "hcnetsdk-command-port",
+        "--host",
+        host,
+        "--command-port",
+        args.command_port,
+        "--channel",
+        args.channel,
+        "--hcnetsdk-command-native-plan",
+        args.native_plan,
+        "--hcnetsdk-command-password",
+        command_password,
+        "--duration",
+        args.duration,
+        "--timeout",
+        args.timeout,
+        "--format",
+        "mpegts",
+        "--ffmpeg-path",
+        args.ffmpeg_path,
+        "--output",
+        str(capture_path),
+        "--hcnetsdk-command-metadata-output",
+        str(metadata_path),
+    ]
+    if args.local_ip:
+        command.extend(["--hcnetsdk-local-ip", args.local_ip])
+    if args.decrypt_video and item.enc_key:
+        command.append("--decrypt-video")
+        command.extend(["--media-key", item.enc_key])
+    if not args.no_skip_initial_idr:
+        command.extend(["--hcnetsdk-h264-skip-initial-idr-windows", "1"])
+    return command
+
+
+def _credential_attempts(
+    args: argparse.Namespace, item: CameraInventoryItem
+) -> list[tuple[str, str]]:
+    attempts = [("inventory_password", item.password)]
+    if (
+        not args.no_try_enc_key_password
+        and item.enc_key
+        and item.enc_key != item.password
+    ):
+        attempts.append(("encryption_key_password", item.enc_key))
+    return attempts
+
+
+def _attempt_base(base: Path, credential_source: str, *, include_suffix: bool) -> Path:
+    if not include_suffix:
+        return base
+    return base.with_name(f"{base.name}-{credential_source}")
+
+
+def _sanitized_command(command: list[str]) -> list[str]:
+    sanitized = list(command)
+    for index, value in enumerate(sanitized[:-1]):
+        if value in {"--hcnetsdk-command-password", "--media-key", "--serial"}:
+            sanitized[index + 1] = REDACTED
+    return sanitized
+
+
+def _redact_text(value: str, item: CameraInventoryItem) -> str:
+    redacted = value
+    for sensitive in (item.serial, item.password, item.enc_key):
+        if sensitive:
+            redacted = redacted.replace(sensitive, REDACTED)
+    return redacted
+
+
+def _redact_sensitive(value: Any, item: CameraInventoryItem) -> Any:
+    if isinstance(value, str):
+        return _redact_text(value, item)
+    if isinstance(value, list):
+        return [_redact_sensitive(entry, item) for entry in value]
+    if isinstance(value, dict):
+        return {key: _redact_sensitive(entry, item) for key, entry in value.items()}
+    return value
+
+
+def _check_item(
+    *,
+    args: argparse.Namespace,
+    item: CameraInventoryItem,
+    output_dir: Path,
+    host: str,
+    host_source: str,
+    camera_index: int,
+) -> dict[str, Any]:
+    base = output_dir / f"camera-{camera_index:02d}-{_safe_name(item.name)}"
+    credential_attempts = _credential_attempts(args, item)
+    include_attempt_suffix = len(credential_attempts) > 1
+    result: dict[str, Any] = {
+        "name": item.name,
+        "serial": _public_serial(),
+        "host": host,
+        "host_source": host_source,
+        "battery": item.battery,
+        "in_use": item.in_use,
+    }
+    if args.dry_run:
+        commands = []
+        for credential_source, command_password in credential_attempts:
+            attempt_base = _attempt_base(
+                base, credential_source, include_suffix=include_attempt_suffix
+            )
+            commands.append(
+                {
+                    "credential_source": credential_source,
+                    "command": _sanitized_command(
+                        _save_command(
+                            args=args,
+                            item=item,
+                            command_password=command_password,
+                            host=host,
+                            capture_path=attempt_base.with_suffix(".ts"),
+                            metadata_path=attempt_base.with_suffix(".metadata.json"),
+                        )
+                    ),
+                }
+            )
+        result.update(
+            {
+                "ok": None,
+                "stage": "dry-run",
+                "credential_attempts": commands,
+                "command": commands[0]["command"],
+                "artifacts": {
+                    "capture": str(base.with_suffix(".ts")),
+                    "metadata": str(base.with_suffix(".metadata.json")),
+                    "save_stdout": str(base.with_suffix(".save.stdout.json")),
+                    "save_stderr": str(base.with_suffix(".save.stderr.txt")),
+                },
+            }
+        )
+        return result
+
+    failed_attempts: list[dict[str, Any]] = []
+    for attempt_index, (credential_source, command_password) in enumerate(
+        credential_attempts, 1
+    ):
+        attempt_base = _attempt_base(base, credential_source, include_suffix=include_attempt_suffix)
+        capture_path = attempt_base.with_suffix(".ts")
+        metadata_path = attempt_base.with_suffix(".metadata.json")
+        stderr_path = attempt_base.with_suffix(".save.stderr.txt")
+        stdout_path = attempt_base.with_suffix(".save.stdout.json")
+        command = _save_command(
+            args=args,
+            item=item,
+            command_password=command_password,
+            host=host,
+            capture_path=capture_path,
+            metadata_path=metadata_path,
+        )
+        artifacts = {
+            "capture": str(capture_path),
+            "metadata": str(metadata_path),
+            "save_stdout": str(stdout_path),
+            "save_stderr": str(stderr_path),
+        }
+        save = _run(command, cwd=REPO_ROOT)
+        stdout_path.write_bytes(save.stdout)
+        stderr_path.write_bytes(save.stderr)
+        if save.returncode == 0:
+            break
+        stderr_tail = _tail_text(save.stderr)
+        diagnosis = _diagnose_save_failure(stderr_tail, metadata_path)
+        failed_attempts.append(
+            {
+                "credential_source": credential_source,
+                "stage": "save-clip",
+                "returncode": save.returncode,
+                "diagnosis": diagnosis,
+                "stderr_tail": _redact_text(stderr_tail, item),
+                "artifacts": artifacts,
+            }
+        )
+        if attempt_index == len(credential_attempts) or diagnosis not in {
+            "login_failed",
+            "bootstrap_failed",
+            "bootstrap_timeout",
+        }:
+            result.update(
+                {
+                    "ok": False,
+                    "stage": "save-clip",
+                    "credential_source": credential_source,
+                    "credential_attempts": failed_attempts,
+                    "returncode": save.returncode,
+                    "diagnosis": diagnosis,
+                    "stderr_tail": _redact_text(stderr_tail, item),
+                    "artifacts": artifacts,
+                }
+            )
+            return result
+
+    probe = _ffprobe(args.ffprobe_path, capture_path)
+    ffprobe_stdout_path = attempt_base.with_suffix(".ffprobe.stdout.json")
+    ffprobe_stderr_path = attempt_base.with_suffix(".ffprobe.stderr.txt")
+    ffprobe_stdout_path.write_bytes(probe.stdout)
+    ffprobe_stderr_path.write_bytes(probe.stderr)
+    artifacts.update(
+        {
+            "ffprobe_stdout": str(ffprobe_stdout_path),
+            "ffprobe_stderr": str(ffprobe_stderr_path),
+        }
+    )
+    if probe.returncode != 0:
+        result.update(
+            {
+                "ok": False,
+                "stage": "ffprobe",
+                "credential_source": credential_source,
+                "credential_attempts": failed_attempts,
+                "returncode": probe.returncode,
+                "diagnosis": "unreadable_media",
+                "stderr_tail": _redact_text(_tail_text(probe.stderr), item),
+                "capture_size": capture_path.stat().st_size if capture_path.exists() else 0,
+                "metadata": _redact_sensitive(_read_metadata(metadata_path), item),
+                "artifacts": artifacts,
+            }
+        )
+        return result
+
+    result.update(
+        {
+            "ok": True,
+            "stage": "complete",
+            "credential_source": credential_source,
+            "credential_attempts": failed_attempts,
+            "diagnosis": "playable_mpegts",
+            "capture_size": capture_path.stat().st_size,
+            "metadata": _redact_sensitive(_read_metadata(metadata_path), item),
+            "artifacts": artifacts,
+            **_stream_summary(probe.stdout),
+        }
+    )
+    return result
+
+
+def _stdout_result(result: dict[str, Any], *, include_metadata: bool) -> dict[str, Any]:
+    if include_metadata or "metadata" not in result:
+        return result
+    compact = dict(result)
+    metadata = result.get("metadata")
+    if isinstance(metadata, dict):
+        packets = metadata.get("packets")
+        compact_metadata: dict[str, Any] = {
+            "bootstrap_complete": metadata.get("bootstrap_complete"),
+            "command_port_exchange_count": len(metadata.get("command_port_exchanges", [])),
+        }
+        if isinstance(packets, dict):
+            compact_metadata["packets"] = {
+                "packet_count": packets.get("packet_count"),
+                "last_packet_elapsed_seconds": packets.get("last_packet_elapsed_seconds"),
+                "idmx_h264": _compact_idmx_h264_summary(packets.get("idmx_h264")),
+            }
+        compact["metadata"] = compact_metadata
+    return compact
+
+
+def _compact_idmx_h264_summary(value: Any) -> dict[str, Any] | None:
+    if not isinstance(value, dict):
+        return None
+    return {
+        "packet_count": value.get("packet_count"),
+        "nal_type_counts": value.get("nal_type_counts"),
+        "rtp_payload_type_counts": value.get("rtp_payload_type_counts"),
+        "sequence_gap_count": value.get("sequence_gap_count"),
+        "invalid_media_marker_count": value.get("invalid_media_marker_count"),
+    }
+
+
+def _stdout_summary(summary: dict[str, Any], *, include_metadata: bool) -> dict[str, Any]:
+    compact = dict(summary)
+    results = summary.get("results", [])
+    if isinstance(results, list):
+        compact["results"] = [
+            _stdout_result(result, include_metadata=include_metadata)
+            if isinstance(result, dict)
+            else result
+            for result in results
+        ]
+    return compact
+
+
+def main() -> int:
+    args = _parse_args()
+    try:
+        inventory = _load_inventory(args)
+        overrides = _host_overrides(args.host)
+        selected = _filtered_items(
+            inventory,
+            serials=args.serial,
+            include_unused=args.include_unused,
+            include_battery=args.include_battery,
+            max_cameras=args.max_cameras,
+        )
+        output_dir = _artifact_dir(args.output_dir)
+        results: list[dict[str, Any]] = []
+        for camera_index, item in enumerate(selected, 1):
+            host, host_source = _resolve_host(item, overrides)
+            if host is None:
+                results.append(
+                    {
+                        "name": item.name,
+                        "serial": _public_serial(),
+                        "ok": None if args.dry_run else False,
+                        "stage": "resolve-host",
+                        "diagnosis": "host_unresolved",
+                        "battery": item.battery,
+                        "in_use": item.in_use,
+                    }
+                )
+                continue
+            results.append(
+                _check_item(
+                    args=args,
+                    item=item,
+                    output_dir=output_dir,
+                    host=host,
+                    host_source=host_source,
+                    camera_index=camera_index,
+                )
+            )
+
+        summary = {
+            "ok": all(result.get("ok") in (True, None) for result in results),
+            "dry_run": args.dry_run,
+            "output_dir": str(output_dir),
+            "selected": len(selected),
+            "results": results,
+        }
+        report_path = output_dir / "hcnetsdk-command-live-check.report.json"
+        report_path.write_text(json.dumps(summary, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        summary["report"] = str(report_path)
+        print(
+            json.dumps(
+                _stdout_summary(
+                    summary,
+                    include_metadata=args.include_metadata_in_stdout,
+                ),
+                indent=2,
+                sort_keys=True,
+            )
+        )
+        return 0 if summary["ok"] else 1
+    except Exception as err:
+        print(
+            json.dumps(
+                {
+                    "ok": False,
+                    "stage": "argument-validation",
+                    "error_type": type(err).__name__,
+                    "error": str(err),
+                },
+                indent=2,
+                sort_keys=True,
+            ),
+            file=sys.stderr,
+        )
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/apk-re/bin/hcnetsdk-command-live-check
+++ b/tools/apk-re/bin/hcnetsdk-command-live-check
@@ -480,6 +480,13 @@ def _redact_sensitive(value: Any, item: CameraInventoryItem) -> Any:
     return value
 
 
+def _write_redacted_artifact(path: Path, data: bytes, item: CameraInventoryItem) -> None:
+    path.write_text(
+        _redact_text(data.decode("utf-8", errors="replace"), item),
+        encoding="utf-8",
+    )
+
+
 def _check_item(
     *,
     args: argparse.Namespace,
@@ -561,8 +568,8 @@ def _check_item(
             "save_stderr": str(stderr_path),
         }
         save = _run(command, cwd=REPO_ROOT)
-        stdout_path.write_bytes(save.stdout)
-        stderr_path.write_bytes(save.stderr)
+        _write_redacted_artifact(stdout_path, save.stdout, item)
+        _write_redacted_artifact(stderr_path, save.stderr, item)
         if save.returncode == 0:
             break
         stderr_tail = _tail_text(save.stderr)

--- a/tools/apk-re/bin/hcnetsdk-command-live-check
+++ b/tools/apk-re/bin/hcnetsdk-command-live-check
@@ -491,6 +491,12 @@ def _write_redacted_artifact(path: Path, data: bytes, item: CameraInventoryItem)
     )
 
 
+def _redact_existing_artifact(path: Path, item: CameraInventoryItem) -> None:
+    if not path.exists():
+        return
+    _write_redacted_artifact(path, path.read_bytes(), item)
+
+
 def _check_item(
     *,
     args: argparse.Namespace,
@@ -590,6 +596,7 @@ def _check_item(
         save = _run(command, cwd=REPO_ROOT)
         _write_redacted_artifact(stdout_path, save.stdout, item)
         _write_redacted_artifact(stderr_path, save.stderr, item)
+        _redact_existing_artifact(metadata_path, item)
         if save.returncode == 0:
             break
         stderr_tail = _tail_text(save.stderr)

--- a/tools/apk-re/bin/hcnetsdk-command-live-check
+++ b/tools/apk-re/bin/hcnetsdk-command-live-check
@@ -454,6 +454,10 @@ def _attempt_base(base: Path, credential_source: str, *, include_suffix: bool) -
     return base.with_name(f"{base.name}-{credential_source}")
 
 
+def _artifact_path(base: Path, extension: str) -> Path:
+    return base.with_name(f"{base.name}{extension}")
+
+
 def _sanitized_command(command: list[str]) -> list[str]:
     sanitized = list(command)
     for index, value in enumerate(sanitized[:-1]):
@@ -522,8 +526,8 @@ def _check_item(
                             item=item,
                             command_password=command_password,
                             host=host,
-                            capture_path=attempt_base.with_suffix(".ts"),
-                            metadata_path=attempt_base.with_suffix(".metadata.json"),
+                            capture_path=_artifact_path(attempt_base, ".ts"),
+                            metadata_path=_artifact_path(attempt_base, ".metadata.json"),
                         )
                     ),
                 }
@@ -535,10 +539,10 @@ def _check_item(
                 "credential_attempts": commands,
                 "command": commands[0]["command"],
                 "artifacts": {
-                    "capture": str(base.with_suffix(".ts")),
-                    "metadata": str(base.with_suffix(".metadata.json")),
-                    "save_stdout": str(base.with_suffix(".save.stdout.json")),
-                    "save_stderr": str(base.with_suffix(".save.stderr.txt")),
+                    "capture": str(_artifact_path(base, ".ts")),
+                    "metadata": str(_artifact_path(base, ".metadata.json")),
+                    "save_stdout": str(_artifact_path(base, ".save.stdout.json")),
+                    "save_stderr": str(_artifact_path(base, ".save.stderr.txt")),
                 },
             }
         )
@@ -549,10 +553,10 @@ def _check_item(
         credential_attempts, 1
     ):
         attempt_base = _attempt_base(base, credential_source, include_suffix=include_attempt_suffix)
-        capture_path = attempt_base.with_suffix(".ts")
-        metadata_path = attempt_base.with_suffix(".metadata.json")
-        stderr_path = attempt_base.with_suffix(".save.stderr.txt")
-        stdout_path = attempt_base.with_suffix(".save.stdout.json")
+        capture_path = _artifact_path(attempt_base, ".ts")
+        metadata_path = _artifact_path(attempt_base, ".metadata.json")
+        stderr_path = _artifact_path(attempt_base, ".save.stderr.txt")
+        stdout_path = _artifact_path(attempt_base, ".save.stdout.json")
         command = _save_command(
             args=args,
             item=item,
@@ -604,8 +608,8 @@ def _check_item(
             return result
 
     probe = _ffprobe(args.ffprobe_path, capture_path)
-    ffprobe_stdout_path = attempt_base.with_suffix(".ffprobe.stdout.json")
-    ffprobe_stderr_path = attempt_base.with_suffix(".ffprobe.stderr.txt")
+    ffprobe_stdout_path = _artifact_path(attempt_base, ".ffprobe.stdout.json")
+    ffprobe_stderr_path = _artifact_path(attempt_base, ".ffprobe.stderr.txt")
     ffprobe_stdout_path.write_bytes(probe.stdout)
     ffprobe_stderr_path.write_bytes(probe.stderr)
     artifacts.update(

--- a/tools/apk-re/bin/hcnetsdk-command-live-check
+++ b/tools/apk-re/bin/hcnetsdk-command-live-check
@@ -464,9 +464,9 @@ def _sanitized_command(command: list[str]) -> list[str]:
 
 def _redact_text(value: str, item: CameraInventoryItem) -> str:
     redacted = value
-    for sensitive in (item.serial, item.password, item.enc_key):
-        if sensitive:
-            redacted = redacted.replace(sensitive, REDACTED)
+    sensitive_values = {item.serial, item.password, item.enc_key}
+    for sensitive in sorted(filter(None, sensitive_values), key=len, reverse=True):
+        redacted = redacted.replace(sensitive, REDACTED)
     return redacted
 
 


### PR DESCRIPTION
## Summary
- add a sanitized owner-run HCNetSDK command-port live compatibility matrix runner
- allow command-port captures to use static media keys for encrypted IDMX payloads
- support clear direct HEVC IDMX remuxing and retry live-check login with the encryption key as command password after login/bootstrap failures

## Validation
- Full pytest: `.venv/bin/python -m pytest -q`
- Focused pytest: `.venv/bin/python -m pytest tests/test_local_stream.py tests/test_hcnetsdk_command_live_check.py tests/test_cli.py -q`
- Ruff on touched files
- mypy: `pyezvizapi/local_stream.py pyezvizapi/__main__.py pyezvizapi/client.py`
- Pyright on touched source/tests
- `python -m py_compile tools/apk-re/bin/hcnetsdk-command-live-check`
- `git diff --check`
- Exact diff scan against local camera inventory passwords, serials/mDNS IDs, verification codes, and encryption keys: `0` hits

## Notes
This replaces the closed/deleted matrix PRs with a clean branch. The live matrix findings remain intentionally summarized without real camera identifiers or credentials.