### PR TITLE
Improve HCNetSDK command stream reliability

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,6 +352,22 @@ pyezvizapi stream hcnetsdk-command-dump-summary \
   --decode-idr-windows
 ```
 
+Native stream-transform hook labels that already contain Annex-B chunks can be
+summarized through the same helper. For example, Gadget traces that include
+`PlayCtrl.IDMXAESDecryptFrame` before/after dumps can check the post-decrypt
+buffers without concatenating or printing media bytes:
+
+```bash
+pyezvizapi stream hcnetsdk-command-dump-summary \
+  --native-annexb-dir native-dumps/ezviz-hook \
+  --native-annexb-label playctrl-idmx-aes-frame-after \
+  --decode-idr-windows
+```
+
+The helper auto-detects H.264 vs HEVC for these native Annex-B chunks. It reports
+both aggregate IRAP/IDR windows and per-chunk decode samples, because some native
+Frida labels are snapshot buffers rather than one linear elementary stream.
+
 Command payload templates still vary by native call, so callers remain
 responsible for supplying the correct generated template plan.
 

--- a/README.md
+++ b/README.md
@@ -249,6 +249,21 @@ The tool skips battery and out-of-use cameras by default, keeps passwords,
 camera serials, and encryption keys out of dry-run/report output and artifact
 filenames, and classifies common failure stages such as host resolution,
 bootstrap/login, missing media packets, unreadable media, or playable MPEG-TS.
+After FFprobe accepts a capture, the live-check wrapper also runs FFmpeg with
+error-level logging to catch decoder-visible corruption. A clean decode reports
+`playable_mpegts`; a nonzero decode exit reports `decode_failed`; zero-exit
+stderr on non-H.264 streams reports `decode_warnings`. Zero-exit H.264 stderr is
+kept as `playable_mpegts_with_h264_decode_warnings` because some H.264 command-
+port sessions can still produce nonfatal decoder chatter around otherwise
+playable output. Clean-window recovery should normally drive current H.264
+captures back to plain `playable_mpegts`.
+Add `--save-sampled-packets` when a matrix run should retain a bounded
+raw-dump-compatible `.sampled-packets.bin` sidecar next to each capture attempt.
+The sidecar is diagnostic context from packets observed by the metadata
+recorder, not a byte-for-byte source map for the final MPEG-TS. Clean-IDR/IRAP
+recovery, warning recovery, duration cutoffs, and trim/preroll options can make
+the sidecar include packets that are not present in the final remuxed clip, or
+omit packets after the configured sample byte/frame limits are reached.
 For offline Frida artifacts, the `hcnetsdk-command-dump-summary` stream helper
 can summarize dumped
 `ezviz-hcnetsdk-command-frame-*.bin` files and raw
@@ -491,6 +506,16 @@ a complete `0x63` control frame for callers that already know the command body
 tail. `hcnetsdk_command_port_control_template_from_frame()` extracts reusable
 control templates from captured/generated frames while dropping session-bound
 client IP and session-id fields.
+
+Native PlayCtrl traces can also show `IDMXAESDecryptFrame` decrypting complete
+assembled H.264 frames inside the app. That native AES boundary is currently a
+reverse-engineering parity target, not a requirement for the generated
+command-port capture path above: the cameras validated so far expose clear
+H.264 or HEVC IDMX payloads on the Python command-port path, and forcing AES
+there corrupts clear H.264. Keep PlayCtrl AES-boundary work scoped to future app
+parity or encrypted command-port evidence, with fresh Frida before/after dumps
+and packet sidecars as inputs, rather than mixing it into the clear remux
+recovery path.
 
 ### cloud_videos
 

--- a/pyezvizapi/__main__.py
+++ b/pyezvizapi/__main__.py
@@ -1398,6 +1398,27 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help="Directory containing *-playm4-input-*.bin dumps from the transform hook",
     )
     parser_stream_command_dump_summary.add_argument(
+        "--native-annexb-dir",
+        help=(
+            "Directory containing native Frida Annex-B dumps, such as "
+            "*-playctrl-idmx-aes-frame-after-*.bin"
+        ),
+    )
+    parser_stream_command_dump_summary.add_argument(
+        "--native-annexb-label",
+        default="playctrl-idmx-aes-frame-after",
+        help=(
+            "Native Annex-B dump label to summarize with --native-annexb-dir "
+            "(default: playctrl-idmx-aes-frame-after)"
+        ),
+    )
+    parser_stream_command_dump_summary.add_argument(
+        "--native-annexb-codec",
+        choices=("auto", "h264", "hevc"),
+        default="auto",
+        help="Codec for --native-annexb-dir decode-window checks (default: auto)",
+    )
+    parser_stream_command_dump_summary.add_argument(
         "--max-frames",
         type=int,
         default=64,
@@ -3977,10 +3998,15 @@ def _handle_h264_annexb_summary(args: argparse.Namespace) -> int:
 def _handle_hcnetsdk_command_dump_summary(args: argparse.Namespace) -> int:
     """Summarize offline HCNetSDK command-port dump artifacts."""
 
-    if not args.command_frame_dir and not args.inbound_media_file and not args.playm4_input_dir:
+    if (
+        not args.command_frame_dir
+        and not args.inbound_media_file
+        and not args.playm4_input_dir
+        and not args.native_annexb_dir
+    ):
         raise PyEzvizError(
             "hcnetsdk-command-dump-summary requires --command-frame-dir "
-            "or --inbound-media-file or --playm4-input-dir"
+            "or --inbound-media-file or --playm4-input-dir or --native-annexb-dir"
         )
     summary: dict[str, Any] = {}
     if args.command_frame_dir:
@@ -3998,6 +4024,15 @@ def _handle_hcnetsdk_command_dump_summary(args: argparse.Namespace) -> int:
     if args.playm4_input_dir:
         summary["playm4_input"] = _hcnetsdk_playm4_input_dump_summary(
             Path(args.playm4_input_dir),
+            max_frames=args.max_frames,
+            decode_idr_windows=args.decode_idr_windows,
+            ffmpeg_path=args.ffmpeg_path,
+        )
+    if args.native_annexb_dir:
+        summary["native_annexb"] = _hcnetsdk_native_annexb_dump_summary(
+            Path(args.native_annexb_dir),
+            label=args.native_annexb_label,
+            codec=args.native_annexb_codec,
             max_frames=args.max_frames,
             decode_idr_windows=args.decode_idr_windows,
             ffmpeg_path=args.ffmpeg_path,
@@ -4146,6 +4181,177 @@ def _hcnetsdk_playm4_input_dump_summary(
         ffmpeg_path=ffmpeg_path,
     )
     return summary
+
+
+def _hcnetsdk_native_annexb_dump_summary(
+    directory: Path,
+    *,
+    label: str,
+    codec: str,
+    max_frames: int,
+    decode_idr_windows: bool,
+    ffmpeg_path: str,
+) -> dict[str, Any]:
+    """Return sanitized metadata for native Annex-B Frida dump chunks."""
+
+    if max_frames <= 0:
+        raise PyEzvizError("--max-frames must be positive")
+    if not directory.is_dir():
+        raise PyEzvizError(f"Native Annex-B dump directory not found: {directory}")
+
+    paths = sorted(directory.rglob(f"*-{label}-*.bin"))
+    chunks = [path.read_bytes() for path in paths]
+    data = b"".join(chunks)
+    detected_codec = _detect_native_annexb_codec(data, requested=codec)
+    samples = [
+        {
+            "path": str(path),
+            "size": len(chunk),
+            "sha256": hashlib.sha256(chunk).hexdigest(),
+        }
+        for path, chunk in zip(paths[:max_frames], chunks[:max_frames], strict=False)
+    ]
+    summary: dict[str, Any] = {
+        "input": str(directory),
+        "label": label,
+        "codec": detected_codec,
+        "requested_codec": codec,
+        "file_count": len(paths),
+        "byte_count": len(data),
+        "sample_limit": max_frames,
+        "samples": samples,
+        "truncated": len(paths) > len(samples),
+    }
+    if detected_codec == "hevc":
+        irap_windows = summarize_hevc_annexb_irap_windows(
+            data,
+            max_windows=max_frames,
+        )
+        summary["annexb_irap_windows"] = irap_windows
+        if decode_idr_windows:
+            summary["decode_irap_windows"] = _decode_annexb_windows(
+                data,
+                irap_windows,
+                ffmpeg_path=ffmpeg_path,
+                input_format="hevc",
+            )
+            summary["decode_chunk_windows"] = _decode_native_annexb_chunk_windows(
+                paths,
+                codec="hevc",
+                max_windows=max_frames,
+                ffmpeg_path=ffmpeg_path,
+            )
+        return summary
+
+    idr_windows = summarize_h264_annexb_idr_windows(
+        data,
+        max_windows=max_frames,
+    )
+    summary["annexb_units"] = summarize_h264_annexb_units(
+        data,
+        max_units=max_frames,
+    )
+    summary["annexb_idr_windows"] = idr_windows
+    if decode_idr_windows:
+        summary["decode_idr_windows"] = _decode_annexb_windows(
+            data,
+            idr_windows,
+            ffmpeg_path=ffmpeg_path,
+            input_format="h264",
+        )
+        summary["decode_chunk_windows"] = _decode_native_annexb_chunk_windows(
+            paths,
+            codec="h264",
+            max_windows=max_frames,
+            ffmpeg_path=ffmpeg_path,
+        )
+    return summary
+
+
+def _decode_native_annexb_chunk_windows(
+    paths: list[Path],
+    *,
+    codec: str,
+    max_windows: int,
+    ffmpeg_path: str,
+) -> list[dict[str, Any]]:
+    """Decode sampled IDR/IRAP-bearing native dump chunks independently."""
+
+    results: list[dict[str, Any]] = []
+    for path in paths:
+        data = path.read_bytes()
+        if codec == "hevc":
+            windows = summarize_hevc_annexb_irap_windows(data, max_windows=1)
+            decoded = _decode_annexb_windows(
+                data,
+                windows,
+                ffmpeg_path=ffmpeg_path,
+                input_format="hevc",
+            )
+        else:
+            windows = summarize_h264_annexb_idr_windows(data, max_windows=1)
+            decoded = _decode_annexb_windows(
+                data,
+                windows,
+                ffmpeg_path=ffmpeg_path,
+                input_format="h264",
+            )
+        if not decoded:
+            continue
+        result = {
+            "path": str(path),
+            "size": len(data),
+            **decoded[0],
+        }
+        results.append(result)
+        if len(results) >= max_windows:
+            break
+    return results
+
+
+def _detect_native_annexb_codec(data: bytes, *, requested: str) -> str:
+    """Return the requested or likely codec for Annex-B dump bytes."""
+
+    if requested != "auto":
+        return requested
+
+    h264_score = 0
+    hevc_score = 0
+    for index, prefix in enumerate(_iter_annexb_nal_prefixes(data)):
+        if index >= 256:
+            break
+        h264_type = prefix[0] & 0x1F
+        hevc_type = (prefix[0] >> 1) & 0x3F
+        if h264_type in {1, 5, 6, 7, 8, 9}:
+            h264_score += 2 if h264_type in {5, 7, 8} else 1
+        if hevc_type in {32, 33, 34}:
+            hevc_score += 3
+        elif 16 <= hevc_type <= 23:
+            hevc_score += 2
+        elif 0 <= hevc_type <= 31:
+            hevc_score += 1
+    return "hevc" if hevc_score > h264_score else "h264"
+
+
+def _iter_annexb_nal_prefixes(data: bytes) -> Iterator[bytes]:
+    """Yield the first bytes after Annex-B start codes."""
+
+    offset = 0
+    while offset < len(data):
+        three = data.find(b"\x00\x00\x01", offset)
+        four = data.find(b"\x00\x00\x00\x01", offset)
+        if three < 0 and four < 0:
+            return
+        if four >= 0 and (three < 0 or four <= three):
+            start_code_offset = four
+            start_code_size = 4
+        else:
+            start_code_offset = three
+            start_code_size = 3
+        nal_offset = start_code_offset + start_code_size
+        if nal_offset < len(data):
+            yield data[nal_offset : nal_offset + 2]
+        offset = nal_offset + 1
 
 
 def _add_hcnetsdk_annexb_dump_summary(

--- a/pyezvizapi/__main__.py
+++ b/pyezvizapi/__main__.py
@@ -51,7 +51,7 @@ from .local_stream import (
     HcNetSdkCommandPortGeneratedSocketStep,
     HcNetSdkCommandPortMultiSocketPlan,
     HcNetSdkCommandPortSocketStep,
-    _idmx_local_packets_to_h264_annexb,
+    _idmx_local_packets_to_annexb_with_codec,
     copy_local_stream_to_decrypted_mpegps,
     copy_local_stream_to_decrypted_mpegts,
     copy_local_stream_to_mpegps,
@@ -62,6 +62,7 @@ from .local_stream import (
     open_local_sdk_stream,
     summarize_h264_annexb_idr_windows,
     summarize_h264_annexb_units,
+    summarize_hevc_annexb_irap_windows,
     summarize_idmx_h264_local_packets,
 )
 from .stream import (
@@ -792,6 +793,17 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         ),
     )
     parser_save_clip.add_argument(
+        "--hcnetsdk-command-sampled-packets-output",
+        help=(
+            "Optional binary file for the bounded HCNetSDK command-port media "
+            "packet sample used by metadata summaries. The file uses the same "
+            "little-endian $ framing as raw command-port dump artifacts. This "
+            "diagnostic sidecar records sampled packets observed before final "
+            "clean-window trimming/recovery, so it is not an exact byte source "
+            "map for the remuxed clip."
+        ),
+    )
+    parser_save_clip.add_argument(
         "--hcnetsdk-h264-skip-initial-idr-windows",
         type=int,
         default=0,
@@ -1395,8 +1407,8 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "--decode-idr-windows",
         action="store_true",
         help=(
-            "Run ffmpeg decode checks for reconstructed H.264 IDR windows from "
-            "inbound media and PlayM4 input dumps"
+            "Run ffmpeg decode checks for reconstructed H.264 IDR or HEVC IRAP "
+            "windows from inbound media and PlayM4 input dumps"
         ),
     )
     parser_stream_command_dump_summary.add_argument(
@@ -2173,11 +2185,15 @@ def _handle_save_clip(args: argparse.Namespace, client: EzvizClient) -> int:
             lambda stream: _write_local_sdk_metadata_output(
                 args.hcnetsdk_command_metadata_output,
                 stream,
+                packet_output_path=args.hcnetsdk_command_sampled_packets_output,
             )
         )
         if (
             args.source == "hcnetsdk-command-port"
-            and args.hcnetsdk_command_metadata_output
+            and (
+                args.hcnetsdk_command_metadata_output
+                or args.hcnetsdk_command_sampled_packets_output
+            )
         )
         else None
     )
@@ -3191,7 +3207,7 @@ def _codec_nalu_header_size(codec: str) -> int | None:
         return 2
     if codec in {"h264", "h264-clear-header"}:
         return 1
-    if codec in {"hevc-encrypted-header", "encrypted-header"}:
+    if codec in {"hevc-encrypted-header", "h264-encrypted-header", "encrypted-header"}:
         return 0
     return 0
 
@@ -4143,10 +4159,26 @@ def _add_hcnetsdk_annexb_dump_summary(
     """Attach sanitized reconstructed Annex-B metadata to a dump summary."""
 
     try:
-        annexb = _idmx_local_packets_to_h264_annexb(packets)
+        annexb, codec = _idmx_local_packets_to_annexb_with_codec(packets)
     except PyEzvizError as err:
         summary["annexb_error"] = str(err)
         return
+    summary["annexb_codec"] = codec
+    if codec == "hevc":
+        irap_windows = summarize_hevc_annexb_irap_windows(
+            annexb,
+            max_windows=max_frames,
+        )
+        summary["annexb_irap_windows"] = irap_windows
+        if decode_idr_windows:
+            summary["decode_irap_windows"] = _decode_annexb_windows(
+                annexb,
+                irap_windows,
+                ffmpeg_path=ffmpeg_path,
+                input_format="hevc",
+            )
+        return
+
     idr_windows = summarize_h264_annexb_idr_windows(
         annexb,
         max_windows=max_frames,
@@ -4157,10 +4189,11 @@ def _add_hcnetsdk_annexb_dump_summary(
     )
     summary["annexb_idr_windows"] = idr_windows
     if decode_idr_windows:
-        summary["decode_idr_windows"] = _decode_h264_annexb_idr_windows(
+        summary["decode_idr_windows"] = _decode_annexb_windows(
             annexb,
             idr_windows,
             ffmpeg_path=ffmpeg_path,
+            input_format="h264",
         )
 
 
@@ -4332,16 +4365,17 @@ def _hcnetsdk_command_template_to_json(
     return value
 
 
-def _decode_h264_annexb_idr_windows(
+def _decode_annexb_windows(
     data: bytes,
-    idr_summary: Mapping[str, Any],
+    window_summary: Mapping[str, Any],
     *,
     ffmpeg_path: str,
+    input_format: str,
 ) -> list[dict[str, Any]]:
-    """Return bounded ffmpeg decode results for sampled IDR windows."""
+    """Return bounded ffmpeg decode results for sampled Annex-B windows."""
 
     results: list[dict[str, Any]] = []
-    samples = idr_summary.get("samples")
+    samples = window_summary.get("samples")
     if not isinstance(samples, list):
         return results
     for sample in samples:
@@ -4363,7 +4397,7 @@ def _decode_h264_annexb_idr_windows(
                     "-v",
                     "error",
                     "-f",
-                    "h264",
+                    input_format,
                     "-i",
                     "pipe:0",
                     "-f",
@@ -4393,15 +4427,57 @@ def _decode_h264_annexb_idr_windows(
     return results
 
 
-def _write_local_sdk_metadata_output(path: str | None, stream: Any) -> None:
-    """Write a safe JSON summary for a completed direct-local SDK stream."""
+def _decode_h264_annexb_idr_windows(
+    data: bytes,
+    idr_summary: Mapping[str, Any],
+    *,
+    ffmpeg_path: str,
+) -> list[dict[str, Any]]:
+    """Return bounded ffmpeg decode results for sampled H.264 IDR windows."""
 
-    if not path:
-        return
+    return _decode_annexb_windows(
+        data,
+        idr_summary,
+        ffmpeg_path=ffmpeg_path,
+        input_format="h264",
+    )
+
+
+def _write_local_sdk_metadata_output(
+    path: str | None,
+    stream: Any,
+    *,
+    packet_output_path: str | None = None,
+) -> None:
+    """Write safe stream metadata and optional bounded packet samples."""
+
     metadata = _local_sdk_stream_metadata(stream)
+    if packet_output_path:
+        _write_hcnetsdk_sampled_packet_output(packet_output_path, stream)
+    if path:
+        output_path = Path(path)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(
+            json.dumps(metadata, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+
+
+def _write_hcnetsdk_sampled_packet_output(path: str, stream: Any) -> None:
+    """Write bounded sampled command-port packets as raw dump-compatible frames."""
+
+    packets = getattr(stream, "_idmx_summary_packets", None)
+    if not isinstance(packets, list):
+        return
     output_path = Path(path)
     output_path.parent.mkdir(parents=True, exist_ok=True)
-    output_path.write_text(json.dumps(metadata, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    with output_path.open("wb") as output:
+        for packet in packets:
+            if not isinstance(packet, bytes):
+                continue
+            output.write(b"$\0")
+            output.write((len(packet) + 4).to_bytes(2, "little"))
+            output.write(packet)
 
 
 def _local_sdk_stream_metadata(stream: Any) -> dict[str, Any]:

--- a/pyezvizapi/client.py
+++ b/pyezvizapi/client.py
@@ -3004,6 +3004,7 @@ class EzvizClient:
                 ffmpeg_path=ffmpeg_path,
                 decrypt_video=decrypt_video,
                 media_key=media_key,
+                nalu_header_size=nalu_header_size,
                 timeout=timeout,
                 host=host,
                 command_port=command_port,
@@ -3140,6 +3141,7 @@ class EzvizClient:
         ffmpeg_path: str,
         decrypt_video: bool,
         media_key: str | bytes | None,
+        nalu_header_size: int | None,
         timeout: float | None,
         host: str | None,
         command_port: int | None,
@@ -3221,6 +3223,7 @@ class EzvizClient:
                             output_file,
                             media_key,
                             ffmpeg_path=ffmpeg_path,
+                            nalu_header_size=nalu_header_size,
                             max_packets=max_packets,
                             duration_seconds=duration_seconds,
                             h264_skip_initial_idr_windows=(
@@ -3289,6 +3292,7 @@ class EzvizClient:
                             output,
                             media_key,
                             ffmpeg_path=ffmpeg_path,
+                            nalu_header_size=nalu_header_size,
                             max_packets=max_packets,
                             duration_seconds=duration_seconds,
                             h264_skip_initial_idr_windows=(

--- a/pyezvizapi/local_stream.py
+++ b/pyezvizapi/local_stream.py
@@ -4122,7 +4122,7 @@ def _looks_like_idmx_hevc_direct_frame(body: bytes) -> bool:
     if len(body) < HEVC_NAL_HEADER_SIZE or body[0] & 0x80 or body[1] & 0x07 == 0:
         return False
     nal_type = _hevc_nal_type(body)
-    return 0 < nal_type <= 40 or nal_type == 49
+    return 0 <= nal_type <= 40 or nal_type == 49
 
 
 def _looks_like_idmx_hevc_evidence_frame(body: bytes) -> bool:
@@ -4381,7 +4381,7 @@ def _is_plausible_hevc_nal(nal: bytes) -> bool:
         len(nal) >= HEVC_NAL_HEADER_SIZE
         and not nal[0] & 0x80
         and nal[1] & 0x07 != 0
-        and 0 < nal_type <= 40
+        and 0 <= nal_type <= 40
     )
 
 
@@ -4483,7 +4483,9 @@ def _decrypt_hevc_nal_prefix(nal: bytes, aes_key: bytes) -> bytes:
     )
     decrypt_length -= decrypt_length % AES.block_size
     if decrypt_length > 0:
-        cipher = _hikvision_aes_ecb_cipher(aes_key)
+        cipher = _hikvision_aes_ecb_cipher(  # codeql[py/weak-cryptographic-algorithm]
+            aes_key
+        )
         decrypt_end = HEVC_NAL_HEADER_SIZE + decrypt_length
         frame[HEVC_NAL_HEADER_SIZE:decrypt_end] = cipher.decrypt(
             bytes(frame[HEVC_NAL_HEADER_SIZE:decrypt_end])
@@ -4507,7 +4509,9 @@ def _decrypt_h264_nal_prefix(
     )
     decrypt_length -= decrypt_length % AES.block_size
     if decrypt_length > 0:
-        cipher = _hikvision_aes_ecb_cipher(aes_key)
+        cipher = _hikvision_aes_ecb_cipher(  # codeql[py/weak-cryptographic-algorithm]
+            aes_key
+        )
         decrypt_end = nalu_header_size + decrypt_length
         frame[nalu_header_size:decrypt_end] = cipher.decrypt(
             bytes(frame[nalu_header_size:decrypt_end])
@@ -4545,6 +4549,7 @@ def _copy_mpegps_payloads_to_mpegts(
         raise PyEzvizError("Could not open FFmpeg pipes")
 
     writer_errors: list[Exception] = []
+    stderr_chunks, stderr_reader = _start_ffmpeg_stderr_drain(process)
 
     def _write_input() -> None:
         try:
@@ -4578,30 +4583,53 @@ def _copy_mpegps_payloads_to_mpegts(
         except subprocess.TimeoutExpired:
             process.kill()
             return_code = process.wait()
+        if stderr_reader is not None:
+            stderr_reader.join(timeout=2)
 
     if writer_errors:
         raise writer_errors[0]
     if return_code not in (0, -15):
-        stderr_tail = _ffmpeg_process_stderr_tail(process)
+        stderr_tail = _ffmpeg_stderr_tail(stderr_chunks)
         message = f"FFmpeg exited with status {return_code}"
         if stderr_tail:
             message = f"{message}: {stderr_tail}"
         raise PyEzvizError(message)
 
 
-def _ffmpeg_process_stderr_tail(
+def _start_ffmpeg_stderr_drain(
     process: subprocess.Popen[bytes],
+    *,
+    max_bytes: int = 65536,
+) -> tuple[list[bytes], Thread | None]:
+    stderr = process.stderr
+    if stderr is None:
+        return [], None
+
+    chunks: list[bytes] = []
+
+    def _drain_stderr() -> None:
+        with suppress(OSError):
+            while True:
+                chunk = stderr.read(4096)
+                if not chunk:
+                    return
+                if max_bytes <= 0:
+                    continue
+                data = b"".join(chunks) + chunk
+                chunks[:] = [data[-max_bytes:]]
+
+    reader = Thread(target=_drain_stderr, daemon=True)
+    reader.start()
+    return chunks, reader
+
+
+def _ffmpeg_stderr_tail(
+    chunks: list[bytes],
     *,
     max_chars: int = 1200,
 ) -> str:
-    stderr = process.stderr
-    if stderr is None:
-        return ""
-    with suppress(OSError):
-        data = stderr.read()
-        text = data.decode("utf-8", errors="replace").strip()
-        return text[-max_chars:]
-    return ""
+    text = b"".join(chunks).decode("utf-8", errors="replace").strip()
+    return text[-max_chars:]
 
 
 def _write_local_stream_payloads(

--- a/pyezvizapi/local_stream.py
+++ b/pyezvizapi/local_stream.py
@@ -98,6 +98,17 @@ class _H264CleanIdrProbeResult:
     sampled_window_count: int = 0
     complete_window_count: int = 0
     nal_count: int = 0
+    codec_name: str = "H.264"
+    window_name: str = "IDR"
+
+
+@dataclass
+class _RtpFragmentedNal:
+    """In-progress fragmented NAL with RTP continuity state."""
+
+    data: bytearray
+    last_sequence: int | None
+    rtp_timestamp: int | None
 
 
 @dataclass(frozen=True)
@@ -1644,6 +1655,7 @@ def copy_local_stream_to_decrypted_mpegts(  # noqa: PLR0913
         annexb = collect_decrypted_h264_idmx_annexb_after_first_clean_idr_window(
             payloads,
             media_key,
+            nalu_header_size=nalu_header_size,
             duration_seconds=duration_seconds,
             monotonic=monotonic,
             ffmpeg_path=ffmpeg_path,
@@ -1674,7 +1686,11 @@ def copy_local_stream_to_decrypted_mpegts(  # noqa: PLR0913
         monotonic=monotonic,
     )
     if _local_stream_packets_are_idmx(packets):
-        annexb = _decrypt_idmx_local_packets_to_annexb(packets, media_key)
+        annexb = _decrypt_idmx_local_packets_to_annexb(
+            packets,
+            media_key,
+            nalu_header_size=nalu_header_size,
+        )
         if _annexb_has_h264_vcl(annexb):
             annexb = skip_h264_annexb_initial_idr_windows(
                 annexb,
@@ -1688,6 +1704,16 @@ def copy_local_stream_to_decrypted_mpegts(  # noqa: PLR0913
                 )
             process = _open_local_h264_mpegts_remux_process(ffmpeg_path)
         elif _annexb_looks_like_hevc(annexb):
+            annexb = skip_hevc_annexb_initial_irap_windows(
+                annexb,
+                h264_skip_initial_idr_windows,
+            )
+            if h264_trim_to_clean_idr_window:
+                annexb = trim_hevc_annexb_to_first_clean_irap_window(
+                    annexb,
+                    ffmpeg_path=ffmpeg_path,
+                    max_windows=h264_clean_idr_max_windows,
+                )
             process = _open_local_hevc_mpegts_remux_process(ffmpeg_path)
         elif _annexb_looks_like_h264(annexb):
             process = _open_local_h264_mpegts_remux_process(ffmpeg_path)
@@ -1790,9 +1816,10 @@ def copy_local_stream_to_mpegts(  # noqa: PLR0912, PLR0913
         is_h264_startup_options = bool(
             h264_skip_initial_idr_windows or h264_trim_to_clean_idr_window
         )
+        annexb_codec: str | None = None
         annexb_is_h264 = False
         if h264_wait_for_clean_idr_window:
-            annexb = collect_h264_idmx_annexb_after_first_clean_idr_window(
+            annexb, annexb_codec = collect_idmx_annexb_after_first_clean_video_window(
                 chain((first_payload,), payloads),
                 duration_seconds=duration_seconds,
                 monotonic=monotonic,
@@ -1800,6 +1827,7 @@ def copy_local_stream_to_mpegts(  # noqa: PLR0912, PLR0913
                 max_windows=h264_clean_idr_max_windows,
                 wait_seconds=h264_clean_idr_wait_seconds,
             )
+            annexb_is_h264 = annexb_codec == "h264"
         else:
             packets = list(chain((first_payload,), payloads))
             if is_h264_startup_options:
@@ -1814,9 +1842,19 @@ def copy_local_stream_to_mpegts(  # noqa: PLR0912, PLR0913
                 annexb_is_h264 = annexb_codec == "h264"
         if (
             not annexb_is_h264
-            and not h264_wait_for_clean_idr_window
             and _annexb_looks_like_hevc(annexb)
         ):
+            if not h264_wait_for_clean_idr_window:
+                annexb = skip_hevc_annexb_initial_irap_windows(
+                    annexb,
+                    h264_skip_initial_idr_windows,
+                )
+                if h264_trim_to_clean_idr_window:
+                    annexb = trim_hevc_annexb_to_first_clean_irap_window(
+                        annexb,
+                        ffmpeg_path=ffmpeg_path,
+                        max_windows=h264_clean_idr_max_windows,
+                    )
             process = _open_local_hevc_mpegts_remux_process(ffmpeg_path)
         else:
             annexb = skip_h264_annexb_initial_idr_windows(
@@ -2019,7 +2057,7 @@ def _open_local_mpegts_remux_process(ffmpeg_path: str) -> subprocess.Popen[bytes
             ],
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
-            stderr=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
         )
     except OSError as err:
         raise PyEzvizError(f"Could not launch FFmpeg at {ffmpeg_path!r}: {err}") from err
@@ -2047,7 +2085,7 @@ def _open_local_hevc_mpegts_remux_process(
             ],
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
-            stderr=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
         )
     except OSError as err:
         raise PyEzvizError(f"Could not launch FFmpeg at {ffmpeg_path!r}: {err}") from err
@@ -2075,7 +2113,7 @@ def _open_local_h264_mpegts_remux_process(
             ],
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
-            stderr=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
         )
     except OSError as err:
         raise PyEzvizError(f"Could not launch FFmpeg at {ffmpeg_path!r}: {err}") from err
@@ -2084,6 +2122,7 @@ def _open_local_h264_mpegts_remux_process(
 IDMX_LOCAL_FRAME_SENTINEL = b"\x55\x66\x77\x88"
 IDMX_LOCAL_FRAME_HEADER_SIZE = 13
 IDMX_LOCAL_FRAME_SENTINEL_OFFSETS = (8, 9)
+H264_NAL_HEADER_SIZE = 1
 HEVC_NAL_HEADER_SIZE = 2
 IDMX_H264_RTP_PAYLOAD_TYPE = 96
 H264_FU_A_NAL_TYPE = 28
@@ -2146,6 +2185,11 @@ def summarize_idmx_h264_local_packets(
             "sample_limit": max_frames,
             "samples": [],
             "truncated": False,
+            "incomplete_fu_a": 0,
+            "discarded_fu_a_fragments": 0,
+            "sequence_gap_count": 0,
+            "timestamp_change_count": 0,
+            "restart_count": 0,
         },
     }
     samples = summary["samples"]
@@ -2164,6 +2208,7 @@ def summarize_idmx_h264_local_packets(
         if len(samples) < max_frames:
             samples.append(frame_summary)
     if active_h264_fu is not None:
+        _increment_idmx_h264_nal_unit_counter(summary, "incomplete_fu_a")
         _append_idmx_h264_nal_unit_sample(
             summary,
             active_h264_fu,
@@ -2283,6 +2328,73 @@ def summarize_h264_annexb_idr_windows(
     return summary
 
 
+def summarize_hevc_annexb_irap_windows(
+    data: bytes,
+    *,
+    max_windows: int = 16,
+) -> dict[str, Any]:
+    """Return sanitized IRAP-started HEVC Annex-B window metadata."""
+
+    spans = _h264_annexb_nal_spans(data)
+    nal_types = [_hevc_nal_type(data[nal_start:end]) for _, nal_start, end in spans]
+    irap_indexes = [
+        index for index, nal_type in enumerate(nal_types) if 16 <= nal_type <= 21
+    ]
+    summary: dict[str, Any] = {
+        "byte_count": len(data),
+        "nal_count": len(spans),
+        "irap_count": len(irap_indexes),
+        "sample_limit": max_windows,
+        "samples": [],
+        "truncated": False,
+    }
+    samples = summary["samples"]
+    assert isinstance(samples, list)
+
+    for sample_index, irap_nal_index in enumerate(irap_indexes):
+        if len(samples) >= max_windows:
+            summary["truncated"] = True
+            break
+        start_nal_index = _hevc_annexb_irap_window_start_index(
+            nal_types,
+            irap_nal_index,
+        )
+        next_irap_nal_index = (
+            irap_indexes[sample_index + 1]
+            if sample_index + 1 < len(irap_indexes)
+            else None
+        )
+        end_nal_index = (
+            next_irap_nal_index if next_irap_nal_index is not None else len(spans)
+        )
+        start_offset = spans[start_nal_index][0]
+        end_offset = (
+            spans[next_irap_nal_index][0]
+            if next_irap_nal_index is not None
+            else len(data)
+        )
+        irap_start_code_offset, irap_nal_offset, irap_end_offset = spans[irap_nal_index]
+        samples.append(
+            {
+                "index": sample_index,
+                "start_nal_index": start_nal_index,
+                "irap_nal_index": irap_nal_index,
+                "end_nal_index": end_nal_index,
+                "start_code_offset": start_offset,
+                "irap_start_code_offset": irap_start_code_offset,
+                "end_offset": end_offset,
+                "window_bytes": max(end_offset - start_offset, 0),
+                "leading_nal_types": nal_types[start_nal_index:irap_nal_index],
+                "irap_payload_bytes": max(irap_end_offset - irap_nal_offset, 0),
+                "irap_sha256": hashlib.sha256(
+                    data[irap_nal_offset:irap_end_offset]
+                ).hexdigest(),
+                "window_sha256": hashlib.sha256(data[start_offset:end_offset]).hexdigest(),
+            }
+        )
+    return summary
+
+
 def skip_h264_annexb_initial_idr_windows(data: bytes, count: int) -> bytes:
     """Return Annex-B bytes starting at the requested IDR window."""
 
@@ -2302,7 +2414,25 @@ def skip_h264_annexb_initial_idr_windows(data: bytes, count: int) -> bytes:
     return data[spans[start_index][0] :]
 
 
-def collect_h264_idmx_annexb_after_first_clean_idr_window(
+def skip_hevc_annexb_initial_irap_windows(data: bytes, count: int) -> bytes:
+    """Return HEVC Annex-B bytes starting at the requested IRAP window."""
+
+    if count < 0:
+        raise PyEzvizError("HEVC IRAP-window skip count cannot be negative")
+    if count == 0:
+        return data
+    spans = _h264_annexb_nal_spans(data)
+    nal_types = [_hevc_nal_type(data[nal_start:end]) for _, nal_start, end in spans]
+    irap_indexes = [
+        index for index, nal_type in enumerate(nal_types) if 16 <= nal_type <= 21
+    ]
+    if count >= len(irap_indexes):
+        return data
+    start_index = _hevc_annexb_irap_window_start_index(nal_types, irap_indexes[count])
+    return data[spans[start_index][0] :]
+
+
+def collect_h264_idmx_annexb_after_first_clean_idr_window(  # noqa: PLR0912, PLR0915
     packets: Iterable[bytes],
     *,
     duration_seconds: float | None,
@@ -2331,6 +2461,8 @@ def collect_h264_idmx_annexb_after_first_clean_idr_window(
     collected: list[bytes] = []
     clean_start_offset: int | None = None
     first_decode_error: str | None = None
+    final_decode_error: str | None = None
+    last_suffix_probe_packet_count = 0
     last_probe = _H264CleanIdrProbeResult(start_offset=None)
 
     for packet in packets:
@@ -2343,8 +2475,22 @@ def collect_h264_idmx_annexb_after_first_clean_idr_window(
             raise PyEzvizError(
                 "Timed out waiting for a clean H.264 IDR window" + suffix
             )
-        if capture_deadline is not None and now >= capture_deadline:
-            break
+        if (
+            clean_start_offset is not None
+            and capture_deadline is not None
+            and now >= capture_deadline
+            and last_suffix_probe_packet_count == 0
+        ):
+            annexb = _idmx_local_packets_to_h264_annexb(collected)
+            try:
+                return trim_h264_annexb_to_first_error_free_suffix(
+                    annexb[clean_start_offset:],
+                    ffmpeg_path=ffmpeg_path,
+                    max_windows=max_windows,
+                )
+            except PyEzvizError as err:
+                final_decode_error = final_decode_error or str(err)
+                last_suffix_probe_packet_count = len(collected)
         collected.append(packet)
         if clean_start_offset is None:
             probe = _try_first_clean_h264_annexb_idr_window_offset(
@@ -2359,6 +2505,26 @@ def collect_h264_idmx_annexb_after_first_clean_idr_window(
             if clean_start_offset is not None:
                 capture_deadline = now + duration_seconds
             continue
+        if (
+            capture_deadline is not None
+            and now >= capture_deadline
+            and len(collected) - last_suffix_probe_packet_count >= 32
+        ):
+            annexb = _idmx_local_packets_to_h264_annexb(collected)
+            try:
+                return trim_h264_annexb_to_first_error_free_suffix(
+                    annexb[clean_start_offset:],
+                    ffmpeg_path=ffmpeg_path,
+                    max_windows=max_windows,
+                )
+            except PyEzvizError as err:
+                final_decode_error = final_decode_error or str(err)
+                last_suffix_probe_packet_count = len(collected)
+                if now >= capture_deadline + wait_seconds:
+                    raise PyEzvizError(
+                        "Timed out waiting for a clean final H.264 suffix: "
+                        + str(err)
+                    ) from err
 
     if clean_start_offset is None:
         suffix = _h264_clean_idr_timeout_suffix(
@@ -2369,13 +2535,196 @@ def collect_h264_idmx_annexb_after_first_clean_idr_window(
             "H.264 stream ended before a clean IDR window was found" + suffix
         )
     annexb = _idmx_local_packets_to_h264_annexb(collected)
-    return annexb[clean_start_offset:]
+    try:
+        return trim_h264_annexb_to_first_error_free_suffix(
+            annexb[clean_start_offset:],
+            ffmpeg_path=ffmpeg_path,
+            max_windows=max_windows,
+        )
+    except PyEzvizError as err:
+        if final_decode_error:
+            raise PyEzvizError(final_decode_error) from err
+        raise
 
 
-def collect_decrypted_h264_idmx_annexb_after_first_clean_idr_window(
+def collect_idmx_annexb_after_first_clean_video_window(  # noqa: PLR0912, PLR0915
+    packets: Iterable[bytes],
+    *,
+    duration_seconds: float | None,
+    monotonic: Callable[[], float] = time.monotonic,
+    ffmpeg_path: str = "ffmpeg",
+    max_windows: int = 32,
+    wait_seconds: float = 60.0,
+) -> tuple[bytes, str]:
+    """Collect clear IDMX video from the first clean H.264 IDR or HEVC IRAP."""
+
+    if duration_seconds is None:
+        raise PyEzvizError("duration_seconds is required when waiting for clean video")
+    if wait_seconds < 0:
+        raise PyEzvizError("wait_seconds cannot be negative")
+    if max_windows <= 0:
+        raise PyEzvizError("max_windows must be positive")
+
+    wait_deadline = monotonic() + wait_seconds
+    capture_deadline: float | None = None
+    collected: list[bytes] = []
+    clean_start_offset: int | None = None
+    clean_codec: str | None = None
+    first_decode_error: str | None = None
+    final_decode_error: str | None = None
+    last_suffix_probe_packet_count = 0
+    last_probe = _H264CleanIdrProbeResult(start_offset=None)
+
+    for packet in packets:
+        now = monotonic()
+        if clean_start_offset is None and now >= wait_deadline:
+            suffix = _h264_clean_idr_timeout_suffix(
+                first_decode_error=first_decode_error,
+                probe=last_probe,
+            )
+            raise PyEzvizError("Timed out waiting for a clean video window" + suffix)
+        if (
+            clean_start_offset is not None
+            and clean_codec is not None
+            and capture_deadline is not None
+            and now >= capture_deadline
+            and last_suffix_probe_packet_count == 0
+        ):
+            if clean_codec == "h264":
+                annexb = _idmx_local_packets_to_h264_annexb(collected)
+                trim = trim_h264_annexb_to_first_error_free_suffix
+            else:
+                annexb = _idmx_local_packets_to_hevc_annexb(collected)
+                trim = trim_hevc_annexb_to_first_error_free_suffix
+            try:
+                return (
+                    trim(
+                        annexb[clean_start_offset:],
+                        ffmpeg_path=ffmpeg_path,
+                        max_windows=max_windows,
+                    ),
+                    clean_codec,
+                )
+            except PyEzvizError as err:
+                final_decode_error = final_decode_error or str(err)
+                last_suffix_probe_packet_count = len(collected)
+        collected.append(packet)
+        if clean_start_offset is None:
+            (
+                probe_start_offset,
+                probe_codec,
+                probe_decode_error,
+                last_probe,
+            ) = _probe_first_clean_idmx_video_window(
+                collected,
+                ffmpeg_path=ffmpeg_path,
+                max_windows=max_windows,
+            )
+            if first_decode_error is None and probe_decode_error is not None:
+                first_decode_error = probe_decode_error
+            if probe_start_offset is not None and probe_codec is not None:
+                clean_start_offset = probe_start_offset
+                clean_codec = probe_codec
+                capture_deadline = now + duration_seconds
+            continue
+
+        if (
+            capture_deadline is not None
+            and now >= capture_deadline
+            and len(collected) - last_suffix_probe_packet_count >= 32
+        ):
+            assert clean_codec is not None
+            if clean_codec == "h264":
+                annexb = _idmx_local_packets_to_h264_annexb(collected)
+                trim = trim_h264_annexb_to_first_error_free_suffix
+            else:
+                annexb = _idmx_local_packets_to_hevc_annexb(collected)
+                trim = trim_hevc_annexb_to_first_error_free_suffix
+            try:
+                return (
+                    trim(
+                        annexb[clean_start_offset:],
+                        ffmpeg_path=ffmpeg_path,
+                        max_windows=max_windows,
+                    ),
+                    clean_codec,
+                )
+            except PyEzvizError as err:
+                final_decode_error = final_decode_error or str(err)
+                last_suffix_probe_packet_count = len(collected)
+                if now >= capture_deadline + wait_seconds:
+                    raise PyEzvizError(
+                        f"Timed out waiting for a clean final {clean_codec.upper()} suffix: "
+                        + str(err)
+                    ) from err
+
+    if clean_start_offset is None or clean_codec is None:
+        suffix = _h264_clean_idr_timeout_suffix(
+            first_decode_error=first_decode_error,
+            probe=last_probe,
+        )
+        raise PyEzvizError("IDMX stream ended before a clean video window was found" + suffix)
+
+    if clean_codec == "h264":
+        annexb = _idmx_local_packets_to_h264_annexb(collected)
+        annexb = trim_h264_annexb_to_first_error_free_suffix(
+            annexb[clean_start_offset:],
+            ffmpeg_path=ffmpeg_path,
+            max_windows=max_windows,
+        )
+        return annexb, clean_codec
+    else:
+        annexb = _idmx_local_packets_to_hevc_annexb(collected)
+        try:
+            annexb = trim_hevc_annexb_to_first_error_free_suffix(
+                annexb[clean_start_offset:],
+                ffmpeg_path=ffmpeg_path,
+                max_windows=max_windows,
+            )
+        except PyEzvizError as err:
+            if final_decode_error:
+                raise PyEzvizError(final_decode_error) from err
+            raise
+    return annexb, clean_codec
+
+
+def _probe_first_clean_idmx_video_window(
+    packets: list[bytes],
+    *,
+    ffmpeg_path: str,
+    max_windows: int,
+) -> tuple[int | None, str | None, str | None, _H264CleanIdrProbeResult]:
+    h264_probe = _try_first_clean_h264_annexb_idr_window_offset(
+        packets,
+        ffmpeg_path=ffmpeg_path,
+        max_windows=max_windows,
+    )
+    if h264_probe.start_offset is not None:
+        return (
+            h264_probe.start_offset,
+            "h264",
+            h264_probe.first_decode_error,
+            h264_probe,
+        )
+
+    hevc_probe = _try_first_clean_hevc_annexb_irap_window_offset(
+        packets,
+        ffmpeg_path=ffmpeg_path,
+        max_windows=max_windows,
+    )
+    return (
+        hevc_probe.start_offset,
+        "hevc" if hevc_probe.start_offset is not None else None,
+        h264_probe.first_decode_error or hevc_probe.first_decode_error,
+        hevc_probe if hevc_probe.nal_count or hevc_probe.idr_count else h264_probe,
+    )
+
+
+def collect_decrypted_h264_idmx_annexb_after_first_clean_idr_window(  # noqa: PLR0912, PLR0915
     packets: Iterable[bytes],
     media_key: str | bytes,
     *,
+    nalu_header_size: int | None = None,
     duration_seconds: float | None,
     monotonic: Callable[[], float] = time.monotonic,
     ffmpeg_path: str = "ffmpeg",
@@ -2397,7 +2746,10 @@ def collect_decrypted_h264_idmx_annexb_after_first_clean_idr_window(
     packet_times: list[float] = []
     clean_start_offset: int | None = None
     clean_idr_time: float | None = None
+    clean_stream_is_clear = False
     first_decode_error: str | None = None
+    final_decode_error: str | None = None
+    last_suffix_probe_packet_count = 0
     last_probe = _H264CleanIdrProbeResult(start_offset=None)
 
     for packet in packets:
@@ -2410,30 +2762,110 @@ def collect_decrypted_h264_idmx_annexb_after_first_clean_idr_window(
             raise PyEzvizError(
                 "Timed out waiting for a clean H.264 IDR window" + suffix
             )
-        if capture_deadline is not None and now >= capture_deadline:
-            break
+        if (
+            clean_start_offset is not None
+            and capture_deadline is not None
+            and clean_idr_time is not None
+            and now >= capture_deadline
+            and last_suffix_probe_packet_count == 0
+        ):
+            deadline_packets = [
+                packet
+                for packet, packet_time in zip(collected, packet_times, strict=True)
+                if packet_time < capture_deadline or packet_time == clean_idr_time
+            ]
+            if clean_stream_is_clear:
+                annexb = _idmx_local_packets_to_h264_annexb(deadline_packets)
+            else:
+                annexb = _decrypt_idmx_local_packets_to_annexb(
+                    deadline_packets,
+                    media_key,
+                    nalu_header_size=nalu_header_size,
+                )
+            try:
+                return trim_h264_annexb_to_first_error_free_suffix(
+                    annexb[clean_start_offset:],
+                    ffmpeg_path=ffmpeg_path,
+                    max_windows=max_windows,
+                )
+            except PyEzvizError as err:
+                final_decode_error = final_decode_error or str(err)
+                last_suffix_probe_packet_count = len(collected)
         collected.append(packet)
         packet_times.append(now)
         if clean_start_offset is None:
-            probe = _try_first_clean_decrypted_h264_annexb_idr_window_offset(
+            clear_probe = _try_first_clean_h264_annexb_idr_window_offset(
                 collected,
-                media_key,
                 ffmpeg_path=ffmpeg_path,
                 max_windows=max_windows,
             )
-            last_probe = probe
-            clean_start_offset = probe.start_offset
-            if first_decode_error is None and probe.first_decode_error is not None:
-                first_decode_error = probe.first_decode_error
-            if clean_start_offset is not None:
-                clean_idr_packet_index = _decrypted_h264_annexb_packet_index_for_offset(
+            if clear_probe.start_offset is not None:
+                probe = clear_probe
+                clean_stream_is_clear = True
+            else:
+                probe = _try_first_clean_decrypted_h264_annexb_idr_window_offset(
                     collected,
                     media_key,
-                    probe.idr_start_offset or clean_start_offset,
+                    nalu_header_size=nalu_header_size,
+                    ffmpeg_path=ffmpeg_path,
+                    max_windows=max_windows,
+                )
+            if (
+                first_decode_error is None
+                and clear_probe.first_decode_error is not None
+            ):
+                first_decode_error = clear_probe.first_decode_error
+            if (
+                first_decode_error is None
+                and probe.first_decode_error is not None
+            ):
+                first_decode_error = probe.first_decode_error
+            last_probe = probe
+            clean_start_offset = probe.start_offset
+            if clean_start_offset is not None:
+                clean_idr_packet_index = (
+                    _h264_annexb_packet_index_for_offset(
+                        collected,
+                        offset=probe.idr_start_offset or clean_start_offset,
+                    )
+                    if clean_stream_is_clear
+                    else _decrypted_h264_annexb_packet_index_for_offset(
+                        collected,
+                        media_key,
+                        nalu_header_size=nalu_header_size,
+                        offset=probe.idr_start_offset or clean_start_offset,
+                    )
                 )
                 clean_idr_time = packet_times[clean_idr_packet_index]
                 capture_deadline = clean_idr_time + duration_seconds
             continue
+        if (
+            capture_deadline is not None
+            and now >= capture_deadline
+            and len(collected) - last_suffix_probe_packet_count >= 32
+        ):
+            if clean_stream_is_clear:
+                annexb = _idmx_local_packets_to_h264_annexb(collected)
+            else:
+                annexb = _decrypt_idmx_local_packets_to_annexb(
+                    collected,
+                    media_key,
+                    nalu_header_size=nalu_header_size,
+                )
+            try:
+                return trim_h264_annexb_to_first_error_free_suffix(
+                    annexb[clean_start_offset:],
+                    ffmpeg_path=ffmpeg_path,
+                    max_windows=max_windows,
+                )
+            except PyEzvizError as err:
+                final_decode_error = final_decode_error or str(err)
+                last_suffix_probe_packet_count = len(collected)
+                if now >= capture_deadline + wait_seconds:
+                    raise PyEzvizError(
+                        "Timed out waiting for a clean final H.264 suffix: "
+                        + str(err)
+                    ) from err
 
     if clean_start_offset is None:
         suffix = _h264_clean_idr_timeout_suffix(
@@ -2443,14 +2875,24 @@ def collect_decrypted_h264_idmx_annexb_after_first_clean_idr_window(
         raise PyEzvizError(
             "H.264 stream ended before a clean IDR window was found" + suffix
         )
-    if capture_deadline is not None and clean_idr_time is not None:
-        collected = [
-            packet
-            for packet, packet_time in zip(collected, packet_times, strict=True)
-            if packet_time < capture_deadline or packet_time == clean_idr_time
-        ]
-    annexb = _decrypt_idmx_local_packets_to_annexb(collected, media_key)
-    return annexb[clean_start_offset:]
+    if clean_stream_is_clear:
+        annexb = _idmx_local_packets_to_h264_annexb(collected)
+    else:
+        annexb = _decrypt_idmx_local_packets_to_annexb(
+            collected,
+            media_key,
+            nalu_header_size=nalu_header_size,
+        )
+    try:
+        return trim_h264_annexb_to_first_error_free_suffix(
+            annexb[clean_start_offset:],
+            ffmpeg_path=ffmpeg_path,
+            max_windows=max_windows,
+        )
+    except PyEzvizError as err:
+        if final_decode_error:
+            raise PyEzvizError(final_decode_error) from err
+        raise
 
 
 def _h264_clean_idr_timeout_suffix(
@@ -2461,8 +2903,9 @@ def _h264_clean_idr_timeout_suffix(
     """Return concise diagnostic context for a failed clean-IDR wait."""
 
     details = (
-        f"checked {probe.complete_window_count} complete sampled IDR windows "
-        f"from {probe.idr_count} IDRs/{probe.nal_count} NALs"
+        f"checked {probe.complete_window_count} complete sampled "
+        f"{probe.window_name} windows from {probe.idr_count} "
+        f"{probe.window_name}s/{probe.nal_count} {probe.codec_name} NALs"
     )
     if first_decode_error:
         return f": {details}; first decode error: {first_decode_error}"
@@ -2494,7 +2937,11 @@ def trim_h264_annexb_to_first_clean_idr_window(
         if not isinstance(end_offset, int) or end_offset <= start_offset:
             continue
         window = data[start_offset:end_offset]
-        stderr_lines = _ffmpeg_h264_decode_errors(window, ffmpeg_path=ffmpeg_path)
+        stderr_lines = _ffmpeg_h264_decode_errors(
+            window,
+            ffmpeg_path=ffmpeg_path,
+            accept_success_with_stderr=False,
+        )
         if not stderr_lines:
             return data[start_offset:]
         if first_error is None and stderr_lines:
@@ -2502,6 +2949,134 @@ def trim_h264_annexb_to_first_clean_idr_window(
     suffix = f": {first_error}" if first_error else ""
     raise PyEzvizError(
         "H.264 stream did not contain a clean sampled IDR window" + suffix
+    )
+
+
+def trim_h264_annexb_to_first_error_free_suffix(
+    data: bytes,
+    *,
+    ffmpeg_path: str = "ffmpeg",
+    max_windows: int = 32,
+) -> bytes:
+    """Return the earliest IDR-started suffix that decodes without errors."""
+
+    if not data:
+        return data
+    initial_errors = _ffmpeg_h264_decode_errors(
+        data,
+        ffmpeg_path=ffmpeg_path,
+        accept_success_with_stderr=False,
+    )
+    if not initial_errors:
+        return data
+
+    idr_summary = summarize_h264_annexb_idr_windows(data, max_windows=max_windows)
+    samples = idr_summary.get("samples")
+    if not isinstance(samples, list) or not samples:
+        raise PyEzvizError(
+            "H.264 stream did not contain a clean decodable suffix: "
+            + initial_errors[0]
+        )
+    first_error = initial_errors[0]
+    for sample in samples[1:]:
+        if not isinstance(sample, dict):
+            continue
+        start_offset = sample.get("start_code_offset")
+        if not isinstance(start_offset, int):
+            continue
+        suffix = data[start_offset:]
+        decode_errors = _ffmpeg_h264_decode_errors(
+            suffix,
+            ffmpeg_path=ffmpeg_path,
+            accept_success_with_stderr=False,
+        )
+        if not decode_errors:
+            return suffix
+        if not first_error and decode_errors:
+            first_error = decode_errors[0]
+    raise PyEzvizError(
+        "H.264 stream did not contain a clean decodable suffix: " + first_error
+    )
+
+
+def trim_hevc_annexb_to_first_clean_irap_window(
+    data: bytes,
+    *,
+    ffmpeg_path: str = "ffmpeg",
+    max_windows: int = 32,
+) -> bytes:
+    """Return Annex-B bytes from the first IRAP window that decodes cleanly."""
+
+    irap_summary = summarize_hevc_annexb_irap_windows(data, max_windows=max_windows)
+    samples = irap_summary.get("samples")
+    if not isinstance(samples, list) or not samples:
+        raise PyEzvizError("HEVC stream did not contain IRAP windows")
+    first_error: str | None = None
+    for sample in samples:
+        if not isinstance(sample, dict):
+            continue
+        start_offset = sample.get("start_code_offset")
+        if not isinstance(start_offset, int):
+            continue
+        end_offset = sample.get("end_offset")
+        if not isinstance(end_offset, int) or end_offset <= start_offset:
+            continue
+        window = data[start_offset:end_offset]
+        stderr_lines = _ffmpeg_hevc_decode_errors(window, ffmpeg_path=ffmpeg_path)
+        if not stderr_lines:
+            return data[start_offset:]
+        if first_error is None and stderr_lines:
+            first_error = stderr_lines[0]
+    suffix = f": {first_error}" if first_error else ""
+    raise PyEzvizError(
+        "HEVC stream did not contain a clean sampled IRAP window" + suffix
+    )
+
+
+def trim_hevc_annexb_to_first_error_free_suffix(
+    data: bytes,
+    *,
+    ffmpeg_path: str = "ffmpeg",
+    max_windows: int = 32,
+) -> bytes:
+    """Return the earliest IRAP-started suffix that decodes without errors."""
+
+    if not data:
+        return data
+    initial_errors = _ffmpeg_hevc_decode_errors(
+        data,
+        ffmpeg_path=ffmpeg_path,
+        accept_success_with_stderr=False,
+    )
+    if not initial_errors:
+        return data
+
+    irap_summary = summarize_hevc_annexb_irap_windows(data, max_windows=max_windows)
+    samples = irap_summary.get("samples")
+    if not isinstance(samples, list) or not samples:
+        raise PyEzvizError(
+            "HEVC stream did not contain a clean decodable suffix: "
+            + initial_errors[0]
+        )
+    first_error = initial_errors[0]
+    for sample in samples[1:]:
+        if not isinstance(sample, dict):
+            continue
+        start_offset = sample.get("start_code_offset")
+        if not isinstance(start_offset, int):
+            continue
+        suffix = data[start_offset:]
+        decode_errors = _ffmpeg_hevc_decode_errors(
+            suffix,
+            ffmpeg_path=ffmpeg_path,
+            accept_success_with_stderr=False,
+        )
+        if not decode_errors:
+            return suffix
+        if not first_error and decode_errors:
+            first_error = decode_errors[0]
+    raise PyEzvizError(
+        "HEVC stream did not contain a clean decodable suffix: " + first_error
     )
 
 
@@ -2528,13 +3103,18 @@ def _try_first_clean_decrypted_h264_annexb_idr_window_offset(
     packets: list[bytes],
     media_key: str | bytes,
     *,
+    nalu_header_size: int | None,
     ffmpeg_path: str,
     max_windows: int,
 ) -> _H264CleanIdrProbeResult:
     """Return the first clean IDR offset for partial encrypted IDMX packets."""
 
     try:
-        annexb = _decrypt_idmx_local_packets_to_annexb(packets, media_key)
+        annexb = _decrypt_idmx_local_packets_to_annexb(
+            packets,
+            media_key,
+            nalu_header_size=nalu_header_size,
+        )
     except PyEzvizError:
         return _H264CleanIdrProbeResult(start_offset=None)
     return _try_first_clean_h264_annexb_idr_window_offset_from_annexb(
@@ -2544,9 +3124,88 @@ def _try_first_clean_decrypted_h264_annexb_idr_window_offset(
     )
 
 
+def _try_first_clean_hevc_annexb_irap_window_offset(
+    packets: list[bytes],
+    *,
+    ffmpeg_path: str,
+    max_windows: int,
+) -> _H264CleanIdrProbeResult:
+    """Return the first clean HEVC IRAP window offset for partial IDMX packets."""
+
+    try:
+        annexb = _idmx_local_packets_to_hevc_annexb(packets)
+    except PyEzvizError:
+        return _H264CleanIdrProbeResult(
+            start_offset=None,
+            codec_name="HEVC",
+            window_name="IRAP",
+        )
+
+    irap_summary = summarize_hevc_annexb_irap_windows(annexb, max_windows=max_windows)
+    samples = irap_summary.get("samples")
+    if not isinstance(samples, list):
+        return _H264CleanIdrProbeResult(
+            start_offset=None,
+            idr_count=int(irap_summary.get("irap_count", 0)),
+            nal_count=int(irap_summary.get("nal_count", 0)),
+            codec_name="HEVC",
+            window_name="IRAP",
+        )
+    first_decode_error: str | None = None
+    complete_window_count = 0
+    for sample in samples:
+        if not isinstance(sample, dict):
+            continue
+        end_nal_index = sample.get("end_nal_index")
+        if (
+            not isinstance(end_nal_index, int)
+            or end_nal_index >= int(irap_summary["nal_count"])
+        ):
+            continue
+        start_offset = sample.get("start_code_offset")
+        end_offset = sample.get("end_offset")
+        if (
+            not isinstance(start_offset, int)
+            or not isinstance(end_offset, int)
+            or end_offset <= start_offset
+        ):
+            continue
+        complete_window_count += 1
+        decode_errors = _ffmpeg_hevc_decode_errors(
+            annexb[start_offset:end_offset],
+            ffmpeg_path=ffmpeg_path,
+        )
+        if not decode_errors:
+            return _H264CleanIdrProbeResult(
+                start_offset=start_offset,
+                idr_start_offset=int(sample["irap_start_code_offset"]),
+                first_decode_error=first_decode_error,
+                idr_count=int(irap_summary.get("irap_count", 0)),
+                sampled_window_count=len(samples),
+                complete_window_count=complete_window_count,
+                nal_count=int(irap_summary.get("nal_count", 0)),
+                codec_name="HEVC",
+                window_name="IRAP",
+            )
+        if first_decode_error is None:
+            first_decode_error = decode_errors[0]
+    return _H264CleanIdrProbeResult(
+        start_offset=None,
+        first_decode_error=first_decode_error,
+        idr_count=int(irap_summary.get("irap_count", 0)),
+        sampled_window_count=len(samples),
+        complete_window_count=complete_window_count,
+        nal_count=int(irap_summary.get("nal_count", 0)),
+        codec_name="HEVC",
+        window_name="IRAP",
+    )
+
+
 def _decrypted_h264_annexb_packet_index_for_offset(
     packets: list[bytes],
     media_key: str | bytes,
+    *,
+    nalu_header_size: int | None,
     offset: int,
 ) -> int:
     """Return the packet index that first contributes the given Annex-B offset."""
@@ -2556,7 +3215,25 @@ def _decrypted_h264_annexb_packet_index_for_offset(
             annexb = _decrypt_idmx_local_packets_to_annexb(
                 packets[: index + 1],
                 media_key,
+                nalu_header_size=nalu_header_size,
             )
+        except PyEzvizError:
+            continue
+        if len(annexb) > offset:
+            return index
+    return max(len(packets) - 1, 0)
+
+
+def _h264_annexb_packet_index_for_offset(
+    packets: list[bytes],
+    *,
+    offset: int,
+) -> int:
+    """Return the packet index that first contributes the clear Annex-B offset."""
+
+    for index in range(len(packets)):
+        try:
+            annexb = _idmx_local_packets_to_h264_annexb(packets[: index + 1])
         except PyEzvizError:
             continue
         if len(annexb) > offset:
@@ -2603,6 +3280,7 @@ def _try_first_clean_h264_annexb_idr_window_offset_from_annexb(
         decode_errors = _ffmpeg_h264_decode_errors(
             annexb[start_offset:end_offset],
             ffmpeg_path=ffmpeg_path,
+            accept_success_with_stderr=False,
         )
         if not decode_errors:
             return _H264CleanIdrProbeResult(
@@ -2630,6 +3308,52 @@ def _ffmpeg_h264_decode_errors(
     data: bytes,
     *,
     ffmpeg_path: str,
+    accept_success_with_stderr: bool = True,
+) -> list[str]:
+    lines = _ffmpeg_video_decode_errors(
+        data,
+        ffmpeg_path=ffmpeg_path,
+        input_format="h264",
+        accept_success_with_stderr=accept_success_with_stderr,
+    )
+    if accept_success_with_stderr:
+        return lines
+    saw_missing_picture_probe = any(
+        "missing picture in access unit" in line or "no frame!" in line
+        for line in lines
+    )
+    return [
+        line
+        for line in lines
+        if "missing picture in access unit" not in line
+        and "no frame!" not in line
+        and not (
+            saw_missing_picture_probe
+            and "Decoding error: Invalid data found when processing input" in line
+        )
+    ]
+
+
+def _ffmpeg_hevc_decode_errors(
+    data: bytes,
+    *,
+    ffmpeg_path: str,
+    accept_success_with_stderr: bool = True,
+) -> list[str]:
+    return _ffmpeg_video_decode_errors(
+        data,
+        ffmpeg_path=ffmpeg_path,
+        input_format="hevc",
+        accept_success_with_stderr=accept_success_with_stderr,
+    )
+
+
+def _ffmpeg_video_decode_errors(
+    data: bytes,
+    *,
+    ffmpeg_path: str,
+    input_format: str,
+    accept_success_with_stderr: bool = False,
 ) -> list[str]:
     try:
         completed = subprocess.run(
@@ -2638,7 +3362,7 @@ def _ffmpeg_h264_decode_errors(
                 "-v",
                 "error",
                 "-f",
-                "h264",
+                input_format,
                 "-i",
                 "pipe:0",
                 "-f",
@@ -2654,9 +3378,11 @@ def _ffmpeg_h264_decode_errors(
     except OSError as err:
         raise PyEzvizError(f"Could not launch FFmpeg at {ffmpeg_path!r}: {err}") from err
     except subprocess.TimeoutExpired as err:
-        raise PyEzvizError("FFmpeg H.264 decode check timed out") from err
+        raise PyEzvizError("FFmpeg video decode check timed out") from err
     stderr_text = completed.stderr.decode("utf-8", errors="replace")
     lines = [line for line in stderr_text.splitlines() if line]
+    if completed.returncode == 0 and accept_success_with_stderr:
+        return []
     if completed.returncode != 0 and not lines:
         lines.append(f"ffmpeg exited with status {completed.returncode}")
     return lines[:8]
@@ -2668,6 +3394,16 @@ def _h264_annexb_idr_window_start_index(
 ) -> int:
     start = idr_nal_index
     while start > 0 and nal_types[start - 1] in {6, 7, 8, 9}:
+        start -= 1
+    return start
+
+
+def _hevc_annexb_irap_window_start_index(
+    nal_types: list[int],
+    irap_nal_index: int,
+) -> int:
+    start = irap_nal_index
+    while start > 0 and nal_types[start - 1] in {32, 33, 34, 35, 39, 40}:
         start -= 1
     return start
 
@@ -2745,6 +3481,45 @@ def _idmx_local_frame_is_h264_transport(frame: bytes, header_size: int) -> bool:
     return transport.get("rtp_payload_type") == IDMX_H264_RTP_PAYLOAD_TYPE
 
 
+def _idmx_local_frame_sequence_number(frame: bytes, header_size: int) -> int | None:
+    value = _idmx_local_frame_transport_fields(frame, header_size).get(
+        "sequence_number"
+    )
+    return value if isinstance(value, int) else None
+
+
+def _idmx_local_frame_rtp_timestamp(frame: bytes, header_size: int) -> int | None:
+    value = _idmx_local_frame_transport_fields(frame, header_size).get(
+        "rtp_timestamp"
+    )
+    return value if isinstance(value, int) else None
+
+
+def _idmx_local_frame_rtp_marker(frame: bytes, header_size: int) -> bool:
+    return bool(_idmx_local_frame_transport_fields(frame, header_size).get("rtp_marker"))
+
+
+def _rtp_fragment_continues(
+    active_fu: _RtpFragmentedNal | None,
+    *,
+    sequence_number: int | None,
+    rtp_timestamp: int | None,
+) -> bool:
+    if active_fu is None:
+        return False
+    if (
+        active_fu.rtp_timestamp is not None
+        and rtp_timestamp is not None
+        and active_fu.rtp_timestamp != rtp_timestamp
+    ):
+        return False
+    return not (
+        active_fu.last_sequence is not None
+        and sequence_number is not None
+        and ((active_fu.last_sequence + 1) & 0xFFFF) != sequence_number
+    )
+
+
 def _merge_idmx_h264_frame_summary(
     summary: dict[str, Any],
     frame_summary: dict[str, Any],
@@ -2792,7 +3567,7 @@ def _increment_h264_nal_type_count(h264: dict[str, Any], nal_type: Any) -> None:
     h264[name] = int(h264[name]) + 1
 
 
-def _record_idmx_h264_nal_unit_summary(
+def _record_idmx_h264_nal_unit_summary(  # noqa: PLR0911, PLR0912
     summary: dict[str, Any],
     frame: bytes,
     frame_summary: dict[str, Any],
@@ -2830,27 +3605,77 @@ def _record_idmx_h264_nal_unit_summary(
     is_start = bool(fu_header & 0x80)
     is_end = bool(fu_header & 0x40)
     nal_type = fu_header & 0x1F
-    if is_start or active_fu is None:
+    sequence_number = frame_summary.get("sequence_number")
+    rtp_timestamp = frame_summary.get("rtp_timestamp")
+    if not is_start and active_fu is None:
+        _increment_idmx_h264_nal_unit_counter(summary, "discarded_fu_a_fragments")
+        return None
+    if is_start and active_fu is not None:
+        _increment_idmx_h264_nal_unit_counter(summary, "restart_count")
+        _increment_idmx_h264_nal_unit_counter(summary, "incomplete_fu_a")
+        _append_idmx_h264_nal_unit_sample(
+            summary,
+            active_fu,
+            complete=False,
+            end_frame_index=None,
+        )
+        active_fu = None
+    if active_fu is not None and not _rtp_fragment_continues(
+        _RtpFragmentedNal(
+            data=bytearray(),
+            last_sequence=(
+                active_fu.get("last_sequence")
+                if isinstance(active_fu.get("last_sequence"), int)
+                else None
+            ),
+            rtp_timestamp=(
+                active_fu.get("rtp_timestamp")
+                if isinstance(active_fu.get("rtp_timestamp"), int)
+                else None
+            ),
+        ),
+        sequence_number=sequence_number if isinstance(sequence_number, int) else None,
+        rtp_timestamp=rtp_timestamp if isinstance(rtp_timestamp, int) else None,
+    ):
+        if (
+            isinstance(active_fu.get("last_sequence"), int)
+            and isinstance(sequence_number, int)
+            and ((int(active_fu["last_sequence"]) + 1) & 0xFFFF) != sequence_number
+        ):
+            active_fu["sequence_gap_count"] = int(active_fu["sequence_gap_count"]) + 1
+            _increment_idmx_h264_nal_unit_counter(summary, "sequence_gap_count")
+        if (
+            isinstance(active_fu.get("rtp_timestamp"), int)
+            and isinstance(rtp_timestamp, int)
+            and int(active_fu["rtp_timestamp"]) != rtp_timestamp
+        ):
+            _increment_idmx_h264_nal_unit_counter(summary, "timestamp_change_count")
+        _increment_idmx_h264_nal_unit_counter(summary, "incomplete_fu_a")
+        _append_idmx_h264_nal_unit_sample(
+            summary,
+            active_fu,
+            complete=False,
+            end_frame_index=None,
+        )
+        _increment_idmx_h264_nal_unit_counter(summary, "discarded_fu_a_fragments")
+        return None
+    if is_start:
         reconstructed_header = bytes([(body[0] & 0xE0) | nal_type])
         active_fu = {
             "nal_type": nal_type,
             "start_frame_index": frame_summary["index"],
-            "start_sequence": frame_summary.get("sequence_number"),
-            "end_sequence": frame_summary.get("sequence_number"),
-            "rtp_timestamp": frame_summary.get("rtp_timestamp"),
+            "start_sequence": sequence_number,
+            "end_sequence": sequence_number,
+            "rtp_timestamp": rtp_timestamp,
             "last_sequence": None,
             "sequence_gap_count": 0,
             "fragment_count": 0,
             "payload_bytes": len(reconstructed_header),
             "sha256": hashlib.sha256(reconstructed_header),
         }
-    sequence_number = frame_summary.get("sequence_number")
-    last_sequence = active_fu.get("last_sequence")
+    if active_fu is None:
+        return None
     if isinstance(sequence_number, int):
-        if isinstance(last_sequence, int) and (
-            (last_sequence + 1) & 0xFFFF
-        ) != sequence_number:
-            active_fu["sequence_gap_count"] = int(active_fu["sequence_gap_count"]) + 1
         active_fu["last_sequence"] = sequence_number
         active_fu["end_sequence"] = sequence_number
     hasher = active_fu["sha256"]
@@ -2870,6 +3695,15 @@ def _record_idmx_h264_nal_unit_summary(
         )
         return None
     return active_fu
+
+
+def _increment_idmx_h264_nal_unit_counter(
+    summary: dict[str, Any],
+    name: str,
+) -> None:
+    nal_units = summary["h264_nal_units"]
+    assert isinstance(nal_units, dict)
+    nal_units[name] = int(nal_units.get(name, 0)) + 1
 
 
 def _append_idmx_h264_nal_unit_sample(
@@ -3078,11 +3912,16 @@ def _unsupported_idmx_local_payload_error() -> PyEzvizError:
 def _decrypt_idmx_local_packets_to_annexb(
     packets: list[bytes],
     media_key: str | bytes,
+    *,
+    nalu_header_size: int | None = None,
 ) -> bytes:
     aes_key = _local_media_aes_key(media_key)
+    h264_nalu_header_size = (
+        H264_NAL_HEADER_SIZE if nalu_header_size is None else nalu_header_size
+    )
     output = bytearray()
-    active_fu: bytearray | None = None
-    active_h264_fu: bytearray | None = None
+    active_fu: _RtpFragmentedNal | None = None
+    active_h264_fu: _RtpFragmentedNal | None = None
     for frame in _iter_idmx_local_frames(b"".join(packets)):
         header_size = _idmx_local_frame_header_size(frame)
         if header_size is None:
@@ -3099,6 +3938,9 @@ def _decrypt_idmx_local_packets_to_annexb(
                 body[IDMX_HEVC_MEDIA_FRAME_NAL_OFFSET:],
                 aes_key,
                 active_fu=active_fu,
+                sequence_number=_idmx_local_frame_sequence_number(frame, header_size),
+                rtp_timestamp=_idmx_local_frame_rtp_timestamp(frame, header_size),
+                rtp_marker=_idmx_local_frame_rtp_marker(frame, header_size),
             )
             continue
         if h264_transport and _looks_like_idmx_h264_fu_a_frame(body):
@@ -3106,13 +3948,43 @@ def _decrypt_idmx_local_packets_to_annexb(
                 output,
                 body,
                 active_fu=active_h264_fu,
+                sequence_number=_idmx_local_frame_sequence_number(frame, header_size),
+                rtp_timestamp=_idmx_local_frame_rtp_timestamp(frame, header_size),
+                aes_key=aes_key,
+                nalu_header_size=h264_nalu_header_size,
             )
             continue
         if h264_transport and _looks_like_idmx_h264_clear_nal(body):
             active_h264_fu = None
-            _append_h264_nal(output, body)
+            _append_decrypted_h264_nal(
+                output,
+                body,
+                aes_key,
+                nalu_header_size=h264_nalu_header_size,
+            )
+            continue
+        if h264_transport and h264_nalu_header_size == 0 and body:
+            active_h264_fu = None
+            _append_decrypted_h264_nal(
+                output,
+                body,
+                aes_key,
+                nalu_header_size=h264_nalu_header_size,
+            )
+            continue
+        if h264_transport and _looks_like_idmx_hevc_direct_frame(body):
+            active_fu = _append_idmx_hevc_media_payload(
+                output,
+                body,
+                aes_key,
+                active_fu=active_fu,
+                sequence_number=_idmx_local_frame_sequence_number(frame, header_size),
+                rtp_timestamp=_idmx_local_frame_rtp_timestamp(frame, header_size),
+                rtp_marker=_idmx_local_frame_rtp_marker(frame, header_size),
+                decrypt_parameter_sets=False,
+            )
     if active_fu is not None:
-        _append_decrypted_hevc_nal(output, bytes(active_fu), aes_key)
+        _append_decrypted_hevc_nal(output, bytes(active_fu.data), aes_key)
     if not output:
         raise PyEzvizError("EZVIZ local IDMX stream did not include media frames")
     return bytes(output)
@@ -3120,7 +3992,7 @@ def _decrypt_idmx_local_packets_to_annexb(
 
 def _idmx_local_packets_to_h264_annexb(packets: list[bytes]) -> bytes:
     output = bytearray()
-    active_h264_fu: bytearray | None = None
+    active_h264_fu: _RtpFragmentedNal | None = None
     for frame in _iter_idmx_local_frames(b"".join(packets)):
         header_size = _idmx_local_frame_header_size(frame)
         if header_size is None:
@@ -3133,6 +4005,8 @@ def _idmx_local_packets_to_h264_annexb(packets: list[bytes]) -> bytes:
                 output,
                 body,
                 active_fu=active_h264_fu,
+                sequence_number=_idmx_local_frame_sequence_number(frame, header_size),
+                rtp_timestamp=_idmx_local_frame_rtp_timestamp(frame, header_size),
             )
             continue
         if _looks_like_idmx_h264_clear_nal(body):
@@ -3145,7 +4019,7 @@ def _idmx_local_packets_to_h264_annexb(packets: list[bytes]) -> bytes:
 
 def _idmx_local_packets_to_hevc_annexb(packets: list[bytes]) -> bytes:
     output = bytearray()
-    active_fu: bytearray | None = None
+    active_fu: _RtpFragmentedNal | None = None
     for frame in _iter_idmx_local_frames(b"".join(packets)):
         header_size = _idmx_local_frame_header_size(frame)
         if header_size is None:
@@ -3159,6 +4033,9 @@ def _idmx_local_packets_to_hevc_annexb(packets: list[bytes]) -> bytes:
             output,
             body,
             active_fu=active_fu,
+            sequence_number=_idmx_local_frame_sequence_number(frame, header_size),
+            rtp_timestamp=_idmx_local_frame_rtp_timestamp(frame, header_size),
+            rtp_marker=_idmx_local_frame_rtp_marker(frame, header_size),
         )
     if not output:
         raise PyEzvizError("EZVIZ local IDMX stream did not include clear HEVC media frames")
@@ -3245,7 +4122,7 @@ def _looks_like_idmx_hevc_direct_frame(body: bytes) -> bool:
     if len(body) < HEVC_NAL_HEADER_SIZE or body[0] & 0x80 or body[1] & 0x07 == 0:
         return False
     nal_type = _hevc_nal_type(body)
-    return nal_type <= 40 or nal_type == 49
+    return 0 < nal_type <= 40 or nal_type == 49
 
 
 def _looks_like_idmx_hevc_evidence_frame(body: bytes) -> bool:
@@ -3287,23 +4164,33 @@ def _append_idmx_hevc_media_payload(
     payload: bytes,
     aes_key: bytes,
     *,
-    active_fu: bytearray | None,
-) -> bytearray | None:
+    active_fu: _RtpFragmentedNal | None,
+    sequence_number: int | None = None,
+    rtp_timestamp: int | None = None,
+    rtp_marker: bool = False,
+    decrypt_parameter_sets: bool = True,
+) -> _RtpFragmentedNal | None:
     if len(payload) < HEVC_NAL_HEADER_SIZE:
         return active_fu
     nal_type = (payload[0] >> 1) & 0x3F
     if nal_type != 49:
         if _is_plausible_hevc_nal(payload):
-            _append_decrypted_hevc_nal(output, payload, aes_key)
+            if not decrypt_parameter_sets and nal_type in {32, 33, 34, 39, 40}:
+                _append_hevc_nal(output, payload)
+            else:
+                _append_decrypted_hevc_nal(output, payload, aes_key)
         return active_fu
     if len(payload) < 3:
         return active_fu
 
     fu_header = payload[2]
     is_start = bool(fu_header & 0x80)
-    is_end = bool(fu_header & 0x40)
     original_type = fu_header & 0x3F
-    if active_fu is None and not is_start:
+    if not is_start and not _rtp_fragment_continues(
+        active_fu,
+        sequence_number=sequence_number,
+        rtp_timestamp=rtp_timestamp,
+    ):
         return None
     reconstructed_header = bytes(
         [
@@ -3312,11 +4199,28 @@ def _append_idmx_hevc_media_payload(
         ]
     )
     if is_start:
-        active_fu = bytearray(reconstructed_header)
+        active_fu = _RtpFragmentedNal(
+            data=bytearray(reconstructed_header),
+            last_sequence=sequence_number,
+            rtp_timestamp=rtp_timestamp,
+        )
     assert active_fu is not None
-    active_fu.extend(payload[3:])
-    if is_end:
-        _append_decrypted_hevc_nal(output, bytes(active_fu), aes_key)
+    active_original_type = _hevc_nal_type(bytes(active_fu.data[:HEVC_NAL_HEADER_SIZE]))
+    # EZVIZ RTP HEVC continuations sometimes use the reconstructed NAL header's
+    # first byte, optionally ORed with the FU end bit, where a standard FU
+    # header would normally repeat the original NAL type.
+    active_header0 = active_fu.data[0] if active_fu.data else 0
+    has_ezviz_pseudo_header = fu_header in {active_header0, active_header0 | 0x40}
+    has_fu_header = (
+        is_start or original_type == active_original_type or has_ezviz_pseudo_header
+    )
+    active_fu.data.extend(payload[3:] if has_fu_header else payload[2:])
+    active_fu.last_sequence = sequence_number
+    active_fu.rtp_timestamp = rtp_timestamp
+    if (has_fu_header and bool(fu_header & 0x40)) or (
+        not has_fu_header and rtp_marker
+    ):
+        _append_decrypted_hevc_nal(output, bytes(active_fu.data), aes_key)
         return None
     return active_fu
 
@@ -3325,8 +4229,11 @@ def _append_idmx_hevc_clear_payload(
     output: bytearray,
     payload: bytes,
     *,
-    active_fu: bytearray | None,
-) -> bytearray | None:
+    active_fu: _RtpFragmentedNal | None,
+    sequence_number: int | None = None,
+    rtp_timestamp: int | None = None,
+    rtp_marker: bool = False,
+) -> _RtpFragmentedNal | None:
     if len(payload) < HEVC_NAL_HEADER_SIZE:
         return active_fu
     nal_type = _hevc_nal_type(payload)
@@ -3338,9 +4245,12 @@ def _append_idmx_hevc_clear_payload(
 
     fu_header = payload[2]
     is_start = bool(fu_header & 0x80)
-    is_end = bool(fu_header & 0x40)
     original_type = fu_header & 0x3F
-    if active_fu is None and not is_start:
+    if not is_start and not _rtp_fragment_continues(
+        active_fu,
+        sequence_number=sequence_number,
+        rtp_timestamp=rtp_timestamp,
+    ):
         return None
     reconstructed_header = bytes(
         [
@@ -3349,11 +4259,25 @@ def _append_idmx_hevc_clear_payload(
         ]
     )
     if is_start:
-        active_fu = bytearray(reconstructed_header)
+        active_fu = _RtpFragmentedNal(
+            data=bytearray(reconstructed_header),
+            last_sequence=sequence_number,
+            rtp_timestamp=rtp_timestamp,
+        )
     assert active_fu is not None
-    active_fu.extend(payload[3:])
-    if is_end:
-        _append_hevc_nal(output, bytes(active_fu))
+    active_original_type = _hevc_nal_type(bytes(active_fu.data[:HEVC_NAL_HEADER_SIZE]))
+    active_header0 = active_fu.data[0] if active_fu.data else 0
+    has_ezviz_pseudo_header = fu_header in {active_header0, active_header0 | 0x40}
+    has_fu_header = (
+        is_start or original_type == active_original_type or has_ezviz_pseudo_header
+    )
+    active_fu.data.extend(payload[3:] if has_fu_header else payload[2:])
+    active_fu.last_sequence = sequence_number
+    active_fu.rtp_timestamp = rtp_timestamp
+    if (has_fu_header and bool(fu_header & 0x40)) or (
+        not has_fu_header and rtp_marker
+    ):
+        _append_hevc_nal(output, bytes(active_fu.data))
         return None
     return active_fu
 
@@ -3362,20 +4286,42 @@ def _append_idmx_h264_fu_a_payload(
     output: bytearray,
     payload: bytes,
     *,
-    active_fu: bytearray | None,
-) -> bytearray | None:
+    active_fu: _RtpFragmentedNal | None,
+    sequence_number: int | None = None,
+    rtp_timestamp: int | None = None,
+    aes_key: bytes | None = None,
+    nalu_header_size: int = H264_NAL_HEADER_SIZE,
+) -> _RtpFragmentedNal | None:
     fu_header = payload[1]
     is_start = bool(fu_header & 0x80)
     is_end = bool(fu_header & 0x40)
-    if active_fu is None and not is_start:
+    if not is_start and not _rtp_fragment_continues(
+        active_fu,
+        sequence_number=sequence_number,
+        rtp_timestamp=rtp_timestamp,
+    ):
         return None
     reconstructed_header = bytes([(payload[0] & 0xE0) | (fu_header & 0x1F)])
     if is_start:
-        active_fu = bytearray(reconstructed_header)
+        active_fu = _RtpFragmentedNal(
+            data=bytearray(reconstructed_header),
+            last_sequence=sequence_number,
+            rtp_timestamp=rtp_timestamp,
+        )
     assert active_fu is not None
-    active_fu.extend(payload[2:])
+    active_fu.data.extend(payload[2:])
+    active_fu.last_sequence = sequence_number
+    active_fu.rtp_timestamp = rtp_timestamp
     if is_end:
-        _append_h264_nal(output, bytes(active_fu))
+        if aes_key is None:
+            _append_h264_nal(output, bytes(active_fu.data))
+        else:
+            _append_decrypted_h264_nal(
+                output,
+                bytes(active_fu.data),
+                aes_key,
+                nalu_header_size=max(nalu_header_size, H264_NAL_HEADER_SIZE),
+            )
         return None
     return active_fu
 
@@ -3398,6 +4344,30 @@ def _append_h264_nal(output: bytearray, nal: bytes) -> None:
     output.extend(nal)
 
 
+def _append_decrypted_h264_nal(
+    output: bytearray,
+    nal: bytes,
+    aes_key: bytes,
+    *,
+    nalu_header_size: int = H264_NAL_HEADER_SIZE,
+) -> None:
+    if nalu_header_size != 0 and not _is_plausible_h264_nal(nal):
+        return
+    if _is_plausible_h264_nal(nal) and _h264_nal_type(nal) not in {1, 5}:
+        output.extend(ANNEX_B_LONG_START_CODE)
+        output.extend(nal)
+        return
+    decrypted = _decrypt_h264_nal_prefix(
+        nal,
+        aes_key,
+        nalu_header_size=nalu_header_size,
+    )
+    if not _is_plausible_h264_nal(decrypted):
+        return
+    output.extend(ANNEX_B_LONG_START_CODE)
+    output.extend(decrypted)
+
+
 def _append_hevc_nal(output: bytearray, nal: bytes) -> None:
     if not _is_plausible_hevc_nal(nal):
         return
@@ -3406,11 +4376,12 @@ def _append_hevc_nal(output: bytearray, nal: bytes) -> None:
 
 
 def _is_plausible_hevc_nal(nal: bytes) -> bool:
+    nal_type = _hevc_nal_type(nal)
     return (
         len(nal) >= HEVC_NAL_HEADER_SIZE
         and not nal[0] & 0x80
         and nal[1] & 0x07 != 0
-        and (nal[0] >> 1) & 0x3F <= 40
+        and 0 < nal_type <= 40
     )
 
 
@@ -3520,6 +4491,30 @@ def _decrypt_hevc_nal_prefix(nal: bytes, aes_key: bytes) -> bytes:
     return bytes(frame)
 
 
+def _decrypt_h264_nal_prefix(
+    nal: bytes,
+    aes_key: bytes,
+    *,
+    nalu_header_size: int = H264_NAL_HEADER_SIZE,
+) -> bytes:
+    # H.264 local IDMX uses the same fixed encrypted-prefix scheme as HEVC.
+    # Some streams keep the one-byte H.264 NAL header clear, while C6C command
+    # streams encrypt the NAL header too; the caller selects the preserved size.
+    frame = bytearray(nal)
+    decrypt_length = min(
+        HIKVISION_NAL_ENCRYPTED_PREFIX_LENGTH,
+        len(frame) - nalu_header_size,
+    )
+    decrypt_length -= decrypt_length % AES.block_size
+    if decrypt_length > 0:
+        cipher = _hikvision_aes_ecb_cipher(aes_key)
+        decrypt_end = nalu_header_size + decrypt_length
+        frame[nalu_header_size:decrypt_end] = cipher.decrypt(
+            bytes(frame[nalu_header_size:decrypt_end])
+        )
+    return bytes(frame)
+
+
 def _iter_local_stream_payloads(
     stream: Any,
     *,
@@ -3587,7 +4582,26 @@ def _copy_mpegps_payloads_to_mpegts(
     if writer_errors:
         raise writer_errors[0]
     if return_code not in (0, -15):
-        raise PyEzvizError(f"FFmpeg exited with status {return_code}")
+        stderr_tail = _ffmpeg_process_stderr_tail(process)
+        message = f"FFmpeg exited with status {return_code}"
+        if stderr_tail:
+            message = f"{message}: {stderr_tail}"
+        raise PyEzvizError(message)
+
+
+def _ffmpeg_process_stderr_tail(
+    process: subprocess.Popen[bytes],
+    *,
+    max_chars: int = 1200,
+) -> str:
+    stderr = process.stderr
+    if stderr is None:
+        return ""
+    with suppress(OSError):
+        data = stderr.read()
+        text = data.decode("utf-8", errors="replace").strip()
+        return text[-max_chars:]
+    return ""
 
 
 def _write_local_stream_payloads(

--- a/pyezvizapi/local_stream.py
+++ b/pyezvizapi/local_stream.py
@@ -2568,8 +2568,10 @@ def collect_idmx_annexb_after_first_clean_video_window(  # noqa: PLR0912, PLR091
     wait_deadline = monotonic() + wait_seconds
     capture_deadline: float | None = None
     collected: list[bytes] = []
+    packet_times: list[float] = []
     clean_start_offset: int | None = None
     clean_codec: str | None = None
+    clean_window_time: float | None = None
     first_decode_error: str | None = None
     final_decode_error: str | None = None
     last_suffix_probe_packet_count = 0
@@ -2587,14 +2589,20 @@ def collect_idmx_annexb_after_first_clean_video_window(  # noqa: PLR0912, PLR091
             clean_start_offset is not None
             and clean_codec is not None
             and capture_deadline is not None
+            and clean_window_time is not None
             and now >= capture_deadline
             and last_suffix_probe_packet_count == 0
         ):
+            deadline_packets = [
+                packet
+                for packet, packet_time in zip(collected, packet_times, strict=True)
+                if packet_time < capture_deadline or packet_time == clean_window_time
+            ]
             if clean_codec == "h264":
-                annexb = _idmx_local_packets_to_h264_annexb(collected)
+                annexb = _idmx_local_packets_to_h264_annexb(deadline_packets)
                 trim = trim_h264_annexb_to_first_error_free_suffix
             else:
-                annexb = _idmx_local_packets_to_hevc_annexb(collected)
+                annexb = _idmx_local_packets_to_hevc_annexb(deadline_packets)
                 trim = trim_hevc_annexb_to_first_error_free_suffix
             try:
                 return (
@@ -2609,6 +2617,7 @@ def collect_idmx_annexb_after_first_clean_video_window(  # noqa: PLR0912, PLR091
                 final_decode_error = final_decode_error or str(err)
                 last_suffix_probe_packet_count = len(collected)
         collected.append(packet)
+        packet_times.append(now)
         if clean_start_offset is None:
             (
                 probe_start_offset,
@@ -2625,7 +2634,14 @@ def collect_idmx_annexb_after_first_clean_video_window(  # noqa: PLR0912, PLR091
             if probe_start_offset is not None and probe_codec is not None:
                 clean_start_offset = probe_start_offset
                 clean_codec = probe_codec
-                capture_deadline = now + duration_seconds
+                clean_packet_index = _idmx_annexb_packet_index_for_offset(
+                    collected,
+                    codec=probe_codec,
+                    offset=getattr(last_probe, "idr_start_offset", None)
+                    or clean_start_offset,
+                )
+                clean_window_time = packet_times[clean_packet_index]
+                capture_deadline = clean_window_time + duration_seconds
             continue
 
         if (
@@ -3243,6 +3259,36 @@ def _h264_annexb_packet_index_for_offset(
             continue
         if len(annexb) > offset:
             return index
+    return max(len(packets) - 1, 0)
+
+
+def _hevc_annexb_packet_index_for_offset(
+    packets: list[bytes],
+    *,
+    offset: int,
+) -> int:
+    """Return the packet index that first contributes the clear HEVC Annex-B offset."""
+
+    for index in range(len(packets)):
+        try:
+            annexb = _idmx_local_packets_to_hevc_annexb(packets[: index + 1])
+        except PyEzvizError:
+            continue
+        if len(annexb) > offset:
+            return index
+    return max(len(packets) - 1, 0)
+
+
+def _idmx_annexb_packet_index_for_offset(
+    packets: list[bytes],
+    *,
+    codec: str,
+    offset: int,
+) -> int:
+    if codec == "h264":
+        return _h264_annexb_packet_index_for_offset(packets, offset=offset)
+    if codec == "hevc":
+        return _hevc_annexb_packet_index_for_offset(packets, offset=offset)
     return max(len(packets) - 1, 0)
 
 
@@ -3927,6 +3973,7 @@ def _decrypt_idmx_local_packets_to_annexb(
     output = bytearray()
     active_fu: _RtpFragmentedNal | None = None
     active_h264_fu: _RtpFragmentedNal | None = None
+    hevc_evidence_seen = False
     for frame in _iter_idmx_local_frames(b"".join(packets)):
         header_size = _idmx_local_frame_header_size(frame)
         if header_size is None:
@@ -3938,6 +3985,7 @@ def _decrypt_idmx_local_packets_to_annexb(
             # the short sidecar-looking 00 01/00 02 records are not fed to FFmpeg.
             continue
         if _looks_like_idmx_hevc_media_frame(body):
+            hevc_evidence_seen = True
             active_fu = _append_idmx_hevc_media_payload(
                 output,
                 body[IDMX_HEVC_MEDIA_FRAME_NAL_OFFSET:],
@@ -3948,7 +3996,11 @@ def _decrypt_idmx_local_packets_to_annexb(
                 rtp_marker=_idmx_local_frame_rtp_marker(frame, header_size),
             )
             continue
-        if h264_transport and _looks_like_idmx_h264_fu_a_frame(body):
+        if (
+            h264_transport
+            and not hevc_evidence_seen
+            and _looks_like_idmx_h264_fu_a_frame(body)
+        ):
             active_h264_fu = _append_idmx_h264_fu_a_payload(
                 output,
                 body,
@@ -3959,7 +4011,11 @@ def _decrypt_idmx_local_packets_to_annexb(
                 nalu_header_size=h264_nalu_header_size,
             )
             continue
-        if h264_transport and _looks_like_idmx_h264_clear_nal(body):
+        if (
+            h264_transport
+            and not hevc_evidence_seen
+            and _looks_like_idmx_h264_clear_nal(body)
+        ):
             active_h264_fu = None
             _append_decrypted_h264_nal(
                 output,
@@ -3968,7 +4024,11 @@ def _decrypt_idmx_local_packets_to_annexb(
                 nalu_header_size=h264_nalu_header_size,
             )
             continue
-        if h264_transport and _looks_like_idmx_hevc_direct_frame(body):
+        hevc_direct_evidence = _looks_like_idmx_hevc_evidence_frame(body)
+        if h264_transport and (
+            hevc_evidence_seen or hevc_direct_evidence
+        ) and _looks_like_idmx_hevc_direct_frame(body):
+            hevc_evidence_seen = True
             active_fu = _append_idmx_hevc_media_payload(
                 output,
                 body,

--- a/pyezvizapi/local_stream.py
+++ b/pyezvizapi/local_stream.py
@@ -2459,7 +2459,9 @@ def collect_h264_idmx_annexb_after_first_clean_idr_window(  # noqa: PLR0912, PLR
     wait_deadline = monotonic() + wait_seconds
     capture_deadline: float | None = None
     collected: list[bytes] = []
+    packet_times: list[float] = []
     clean_start_offset: int | None = None
+    clean_idr_time: float | None = None
     first_decode_error: str | None = None
     final_decode_error: str | None = None
     last_suffix_probe_packet_count = 0
@@ -2478,20 +2480,35 @@ def collect_h264_idmx_annexb_after_first_clean_idr_window(  # noqa: PLR0912, PLR
         if (
             clean_start_offset is not None
             and capture_deadline is not None
+            and clean_idr_time is not None
             and now >= capture_deadline
             and last_suffix_probe_packet_count == 0
         ):
-            annexb = _idmx_local_packets_to_h264_annexb(collected)
+            deadline_packets = [
+                packet
+                for packet, packet_time in zip(collected, packet_times, strict=True)
+                if packet_time < capture_deadline or packet_time == clean_idr_time
+            ]
+            deadline_packet_times = packet_times[: len(deadline_packets)]
+            annexb = _idmx_local_packets_to_h264_annexb(deadline_packets)
             try:
                 return trim_h264_annexb_to_first_error_free_suffix(
                     annexb[clean_start_offset:],
                     ffmpeg_path=ffmpeg_path,
                     max_windows=max_windows,
+                    accept_start_offset=_requested_duration_h264_suffix_predicate(
+                        packets=deadline_packets,
+                        packet_times=deadline_packet_times,
+                        base_offset=clean_start_offset,
+                        now=capture_deadline,
+                        duration_seconds=duration_seconds,
+                    ),
                 )
             except PyEzvizError as err:
                 final_decode_error = final_decode_error or str(err)
                 last_suffix_probe_packet_count = len(collected)
         collected.append(packet)
+        packet_times.append(now)
         if clean_start_offset is None:
             probe = _try_first_clean_h264_annexb_idr_window_offset(
                 collected,
@@ -2503,7 +2520,13 @@ def collect_h264_idmx_annexb_after_first_clean_idr_window(  # noqa: PLR0912, PLR
             if first_decode_error is None and probe.first_decode_error is not None:
                 first_decode_error = probe.first_decode_error
             if clean_start_offset is not None:
-                capture_deadline = now + duration_seconds
+                clean_idr_packet_index = _h264_annexb_packet_index_for_offset(
+                    collected,
+                    offset=getattr(probe, "idr_start_offset", None)
+                    or clean_start_offset,
+                )
+                clean_idr_time = packet_times[clean_idr_packet_index]
+                capture_deadline = clean_idr_time + duration_seconds
             continue
         if (
             capture_deadline is not None
@@ -2516,6 +2539,13 @@ def collect_h264_idmx_annexb_after_first_clean_idr_window(  # noqa: PLR0912, PLR
                     annexb[clean_start_offset:],
                     ffmpeg_path=ffmpeg_path,
                     max_windows=max_windows,
+                    accept_start_offset=_requested_duration_h264_suffix_predicate(
+                        packets=collected,
+                        packet_times=packet_times,
+                        base_offset=clean_start_offset,
+                        now=now,
+                        duration_seconds=duration_seconds,
+                    ),
                 )
             except PyEzvizError as err:
                 final_decode_error = final_decode_error or str(err)
@@ -2540,6 +2570,13 @@ def collect_h264_idmx_annexb_after_first_clean_idr_window(  # noqa: PLR0912, PLR
             annexb[clean_start_offset:],
             ffmpeg_path=ffmpeg_path,
             max_windows=max_windows,
+            accept_start_offset=_requested_duration_h264_suffix_predicate(
+                packets=collected,
+                packet_times=packet_times,
+                base_offset=clean_start_offset,
+                now=packet_times[-1] if packet_times else 0.0,
+                duration_seconds=duration_seconds,
+            ),
         )
     except PyEzvizError as err:
         if final_decode_error:
@@ -2610,6 +2647,14 @@ def collect_idmx_annexb_after_first_clean_video_window(  # noqa: PLR0912, PLR091
                         annexb[clean_start_offset:],
                         ffmpeg_path=ffmpeg_path,
                         max_windows=max_windows,
+                        accept_start_offset=_requested_duration_idmx_suffix_predicate(
+                            packets=deadline_packets,
+                            packet_times=packet_times[: len(deadline_packets)],
+                            codec=clean_codec,
+                            base_offset=clean_start_offset,
+                            now=capture_deadline,
+                            duration_seconds=duration_seconds,
+                        ),
                     ),
                     clean_codec,
                 )
@@ -2662,6 +2707,14 @@ def collect_idmx_annexb_after_first_clean_video_window(  # noqa: PLR0912, PLR091
                         annexb[clean_start_offset:],
                         ffmpeg_path=ffmpeg_path,
                         max_windows=max_windows,
+                        accept_start_offset=_requested_duration_idmx_suffix_predicate(
+                            packets=collected,
+                            packet_times=packet_times,
+                            codec=clean_codec,
+                            base_offset=clean_start_offset,
+                            now=now,
+                            duration_seconds=duration_seconds,
+                        ),
                     ),
                     clean_codec,
                 )
@@ -2687,6 +2740,14 @@ def collect_idmx_annexb_after_first_clean_video_window(  # noqa: PLR0912, PLR091
             annexb[clean_start_offset:],
             ffmpeg_path=ffmpeg_path,
             max_windows=max_windows,
+            accept_start_offset=_requested_duration_idmx_suffix_predicate(
+                packets=collected,
+                packet_times=packet_times,
+                codec="h264",
+                base_offset=clean_start_offset,
+                now=packet_times[-1] if packet_times else 0.0,
+                duration_seconds=duration_seconds,
+            ),
         )
         return annexb, clean_codec
     else:
@@ -2696,6 +2757,14 @@ def collect_idmx_annexb_after_first_clean_video_window(  # noqa: PLR0912, PLR091
                 annexb[clean_start_offset:],
                 ffmpeg_path=ffmpeg_path,
                 max_windows=max_windows,
+                accept_start_offset=_requested_duration_idmx_suffix_predicate(
+                    packets=collected,
+                    packet_times=packet_times,
+                    codec="hevc",
+                    base_offset=clean_start_offset,
+                    now=packet_times[-1] if packet_times else 0.0,
+                    duration_seconds=duration_seconds,
+                ),
             )
         except PyEzvizError as err:
             if final_decode_error:
@@ -2803,6 +2872,16 @@ def collect_decrypted_h264_idmx_annexb_after_first_clean_idr_window(  # noqa: PL
                     annexb[clean_start_offset:],
                     ffmpeg_path=ffmpeg_path,
                     max_windows=max_windows,
+                    accept_start_offset=_requested_duration_decrypted_h264_suffix_predicate(
+                        packets=deadline_packets,
+                        packet_times=packet_times[: len(deadline_packets)],
+                        media_key=media_key,
+                        nalu_header_size=nalu_header_size,
+                        stream_is_clear=clean_stream_is_clear,
+                        base_offset=clean_start_offset,
+                        now=capture_deadline,
+                        duration_seconds=duration_seconds,
+                    ),
                 )
             except PyEzvizError as err:
                 final_decode_error = final_decode_error or str(err)
@@ -2873,6 +2952,16 @@ def collect_decrypted_h264_idmx_annexb_after_first_clean_idr_window(  # noqa: PL
                     annexb[clean_start_offset:],
                     ffmpeg_path=ffmpeg_path,
                     max_windows=max_windows,
+                    accept_start_offset=_requested_duration_decrypted_h264_suffix_predicate(
+                        packets=collected,
+                        packet_times=packet_times,
+                        media_key=media_key,
+                        nalu_header_size=nalu_header_size,
+                        stream_is_clear=clean_stream_is_clear,
+                        base_offset=clean_start_offset,
+                        now=now,
+                        duration_seconds=duration_seconds,
+                    ),
                 )
             except PyEzvizError as err:
                 final_decode_error = final_decode_error or str(err)
@@ -2904,6 +2993,16 @@ def collect_decrypted_h264_idmx_annexb_after_first_clean_idr_window(  # noqa: PL
             annexb[clean_start_offset:],
             ffmpeg_path=ffmpeg_path,
             max_windows=max_windows,
+            accept_start_offset=_requested_duration_decrypted_h264_suffix_predicate(
+                packets=collected,
+                packet_times=packet_times,
+                media_key=media_key,
+                nalu_header_size=nalu_header_size,
+                stream_is_clear=clean_stream_is_clear,
+                base_offset=clean_start_offset,
+                now=packet_times[-1] if packet_times else 0.0,
+                duration_seconds=duration_seconds,
+            ),
         )
     except PyEzvizError as err:
         if final_decode_error:
@@ -2928,6 +3027,94 @@ def _h264_clean_idr_timeout_suffix(
     if probe.idr_count or probe.nal_count:
         return f": {details}"
     return ""
+
+
+def _requested_duration_h264_suffix_predicate(
+    *,
+    packets: list[bytes],
+    packet_times: list[float],
+    base_offset: int,
+    now: float,
+    duration_seconds: float,
+) -> Callable[[int], bool]:
+    """Return a suffix-start guard that preserves useful post-IDR duration."""
+
+    latest_start_time = now - duration_seconds
+
+    def accept_start_offset(start_offset: int) -> bool:
+        packet_index = _h264_annexb_packet_index_for_offset(
+            packets,
+            offset=base_offset + start_offset,
+        )
+        if not packet_times:
+            return False
+        packet_index = min(packet_index, len(packet_times) - 1)
+        return packet_times[packet_index] <= latest_start_time
+
+    return accept_start_offset
+
+
+def _requested_duration_idmx_suffix_predicate(
+    *,
+    packets: list[bytes],
+    packet_times: list[float],
+    codec: str,
+    base_offset: int,
+    now: float,
+    duration_seconds: float,
+) -> Callable[[int], bool]:
+    """Return a suffix-start guard for clear H.264/HEVC IDMX Annex-B."""
+
+    latest_start_time = now - duration_seconds
+
+    def accept_start_offset(start_offset: int) -> bool:
+        packet_index = _idmx_annexb_packet_index_for_offset(
+            packets,
+            codec=codec,
+            offset=base_offset + start_offset,
+        )
+        if not packet_times:
+            return False
+        packet_index = min(packet_index, len(packet_times) - 1)
+        return packet_times[packet_index] <= latest_start_time
+
+    return accept_start_offset
+
+
+def _requested_duration_decrypted_h264_suffix_predicate(
+    *,
+    packets: list[bytes],
+    packet_times: list[float],
+    media_key: str | bytes,
+    nalu_header_size: int | None,
+    stream_is_clear: bool,
+    base_offset: int,
+    now: float,
+    duration_seconds: float,
+) -> Callable[[int], bool]:
+    """Return a suffix-start guard for clear-first or encrypted H.264 IDMX."""
+
+    latest_start_time = now - duration_seconds
+
+    def accept_start_offset(start_offset: int) -> bool:
+        if stream_is_clear:
+            packet_index = _h264_annexb_packet_index_for_offset(
+                packets,
+                offset=base_offset + start_offset,
+            )
+        else:
+            packet_index = _decrypted_h264_annexb_packet_index_for_offset(
+                packets,
+                media_key,
+                nalu_header_size=nalu_header_size,
+                offset=base_offset + start_offset,
+            )
+        if not packet_times:
+            return False
+        packet_index = min(packet_index, len(packet_times) - 1)
+        return packet_times[packet_index] <= latest_start_time
+
+    return accept_start_offset
 
 
 def trim_h264_annexb_to_first_clean_idr_window(
@@ -2973,6 +3160,7 @@ def trim_h264_annexb_to_first_error_free_suffix(
     *,
     ffmpeg_path: str = "ffmpeg",
     max_windows: int = 32,
+    accept_start_offset: Callable[[int], bool] | None = None,
 ) -> bytes:
     """Return the earliest IDR-started suffix that decodes without errors."""
 
@@ -2983,7 +3171,9 @@ def trim_h264_annexb_to_first_error_free_suffix(
         ffmpeg_path=ffmpeg_path,
         accept_success_with_stderr=False,
     )
-    if not initial_errors:
+    if not initial_errors and (
+        accept_start_offset is None or accept_start_offset(0)
+    ):
         return data
 
     idr_summary = summarize_h264_annexb_idr_windows(data, max_windows=max_windows)
@@ -2991,14 +3181,24 @@ def trim_h264_annexb_to_first_error_free_suffix(
     if not isinstance(samples, list) or not samples:
         raise PyEzvizError(
             "H.264 stream did not contain a clean decodable suffix: "
-            + initial_errors[0]
+            + (
+                initial_errors[0]
+                if initial_errors
+                else "clean suffix starts too late for requested duration"
+            )
         )
-    first_error = initial_errors[0]
+    first_error = (
+        initial_errors[0]
+        if initial_errors
+        else "clean suffix starts too late for requested duration"
+    )
     for sample in samples[1:]:
         if not isinstance(sample, dict):
             continue
         start_offset = sample.get("start_code_offset")
         if not isinstance(start_offset, int):
+            continue
+        if accept_start_offset is not None and not accept_start_offset(start_offset):
             continue
         suffix = data[start_offset:]
         decode_errors = _ffmpeg_h264_decode_errors(
@@ -3058,6 +3258,7 @@ def trim_hevc_annexb_to_first_error_free_suffix(
     *,
     ffmpeg_path: str = "ffmpeg",
     max_windows: int = 32,
+    accept_start_offset: Callable[[int], bool] | None = None,
 ) -> bytes:
     """Return the earliest IRAP-started suffix that decodes without errors."""
 
@@ -3068,7 +3269,9 @@ def trim_hevc_annexb_to_first_error_free_suffix(
         ffmpeg_path=ffmpeg_path,
         accept_success_with_stderr=False,
     )
-    if not initial_errors:
+    if not initial_errors and (
+        accept_start_offset is None or accept_start_offset(0)
+    ):
         return data
 
     irap_summary = summarize_hevc_annexb_irap_windows(data, max_windows=max_windows)
@@ -3076,14 +3279,24 @@ def trim_hevc_annexb_to_first_error_free_suffix(
     if not isinstance(samples, list) or not samples:
         raise PyEzvizError(
             "HEVC stream did not contain a clean decodable suffix: "
-            + initial_errors[0]
+            + (
+                initial_errors[0]
+                if initial_errors
+                else "clean suffix starts too late for requested duration"
+            )
         )
-    first_error = initial_errors[0]
+    first_error = (
+        initial_errors[0]
+        if initial_errors
+        else "clean suffix starts too late for requested duration"
+    )
     for sample in samples[1:]:
         if not isinstance(sample, dict):
             continue
         start_offset = sample.get("start_code_offset")
         if not isinstance(start_offset, int):
+            continue
+        if accept_start_offset is not None and not accept_start_offset(start_offset):
             continue
         suffix = data[start_offset:]
         decode_errors = _ffmpeg_hevc_decode_errors(

--- a/pyezvizapi/local_stream.py
+++ b/pyezvizapi/local_stream.py
@@ -2427,7 +2427,10 @@ def skip_hevc_annexb_initial_irap_windows(data: bytes, count: int) -> bytes:
         index for index, nal_type in enumerate(nal_types) if 16 <= nal_type <= 21
     ]
     if count >= len(irap_indexes):
-        return data
+        raise PyEzvizError(
+            "HEVC stream did not contain enough IRAP windows to skip "
+            f"{count} startup window(s)"
+        )
     start_index = _hevc_annexb_irap_window_start_index(nal_types, irap_indexes[count])
     return data[spans[start_index][0] :]
 

--- a/pyezvizapi/local_stream.py
+++ b/pyezvizapi/local_stream.py
@@ -4489,7 +4489,7 @@ def _decrypt_hevc_nal_prefix(nal: bytes, aes_key: bytes) -> bytes:
         decrypt_end = HEVC_NAL_HEADER_SIZE + decrypt_length
         frame[HEVC_NAL_HEADER_SIZE:decrypt_end] = cipher.decrypt(  # codeql[py/weak-cryptographic-algorithm]
             bytes(frame[HEVC_NAL_HEADER_SIZE:decrypt_end])
-        )  # codeql[py/weak-cryptographic-algorithm]
+        )  # codeql[py/weak-cryptographic-algorithm] lgtm[py/weak-cryptographic-algorithm]
     return bytes(frame)
 
 
@@ -4515,7 +4515,7 @@ def _decrypt_h264_nal_prefix(
         decrypt_end = nalu_header_size + decrypt_length
         frame[nalu_header_size:decrypt_end] = cipher.decrypt(  # codeql[py/weak-cryptographic-algorithm]
             bytes(frame[nalu_header_size:decrypt_end])
-        )  # codeql[py/weak-cryptographic-algorithm]
+        )  # codeql[py/weak-cryptographic-algorithm] lgtm[py/weak-cryptographic-algorithm]
     return bytes(frame)
 
 

--- a/pyezvizapi/local_stream.py
+++ b/pyezvizapi/local_stream.py
@@ -4489,7 +4489,7 @@ def _decrypt_hevc_nal_prefix(nal: bytes, aes_key: bytes) -> bytes:
         decrypt_end = HEVC_NAL_HEADER_SIZE + decrypt_length
         frame[HEVC_NAL_HEADER_SIZE:decrypt_end] = cipher.decrypt(  # codeql[py/weak-cryptographic-algorithm]
             bytes(frame[HEVC_NAL_HEADER_SIZE:decrypt_end])
-        )
+        )  # codeql[py/weak-cryptographic-algorithm]
     return bytes(frame)
 
 
@@ -4515,7 +4515,7 @@ def _decrypt_h264_nal_prefix(
         decrypt_end = nalu_header_size + decrypt_length
         frame[nalu_header_size:decrypt_end] = cipher.decrypt(  # codeql[py/weak-cryptographic-algorithm]
             bytes(frame[nalu_header_size:decrypt_end])
-        )
+        )  # codeql[py/weak-cryptographic-algorithm]
     return bytes(frame)
 
 

--- a/pyezvizapi/local_stream.py
+++ b/pyezvizapi/local_stream.py
@@ -4487,7 +4487,7 @@ def _decrypt_hevc_nal_prefix(nal: bytes, aes_key: bytes) -> bytes:
             aes_key
         )
         decrypt_end = HEVC_NAL_HEADER_SIZE + decrypt_length
-        frame[HEVC_NAL_HEADER_SIZE:decrypt_end] = cipher.decrypt(
+        frame[HEVC_NAL_HEADER_SIZE:decrypt_end] = cipher.decrypt(  # codeql[py/weak-cryptographic-algorithm]
             bytes(frame[HEVC_NAL_HEADER_SIZE:decrypt_end])
         )
     return bytes(frame)
@@ -4513,7 +4513,7 @@ def _decrypt_h264_nal_prefix(
             aes_key
         )
         decrypt_end = nalu_header_size + decrypt_length
-        frame[nalu_header_size:decrypt_end] = cipher.decrypt(
+        frame[nalu_header_size:decrypt_end] = cipher.decrypt(  # codeql[py/weak-cryptographic-algorithm]
             bytes(frame[nalu_header_size:decrypt_end])
         )
     return bytes(frame)

--- a/pyezvizapi/local_stream.py
+++ b/pyezvizapi/local_stream.py
@@ -3963,15 +3963,6 @@ def _decrypt_idmx_local_packets_to_annexb(
                 nalu_header_size=h264_nalu_header_size,
             )
             continue
-        if h264_transport and h264_nalu_header_size == 0 and body:
-            active_h264_fu = None
-            _append_decrypted_h264_nal(
-                output,
-                body,
-                aes_key,
-                nalu_header_size=h264_nalu_header_size,
-            )
-            continue
         if h264_transport and _looks_like_idmx_hevc_direct_frame(body):
             active_fu = _append_idmx_hevc_media_payload(
                 output,
@@ -3983,6 +3974,16 @@ def _decrypt_idmx_local_packets_to_annexb(
                 rtp_marker=_idmx_local_frame_rtp_marker(frame, header_size),
                 decrypt_parameter_sets=False,
             )
+            continue
+        if h264_transport and h264_nalu_header_size == 0 and body:
+            active_h264_fu = None
+            _append_decrypted_h264_nal(
+                output,
+                body,
+                aes_key,
+                nalu_header_size=h264_nalu_header_size,
+            )
+            continue
     if active_fu is not None:
         _append_decrypted_hevc_nal(output, bytes(active_fu.data), aes_key)
     if not output:

--- a/pyezvizapi/local_stream.py
+++ b/pyezvizapi/local_stream.py
@@ -3022,7 +3022,11 @@ def trim_hevc_annexb_to_first_clean_irap_window(
         if not isinstance(end_offset, int) or end_offset <= start_offset:
             continue
         window = data[start_offset:end_offset]
-        stderr_lines = _ffmpeg_hevc_decode_errors(window, ffmpeg_path=ffmpeg_path)
+        stderr_lines = _ffmpeg_hevc_decode_errors(
+            window,
+            ffmpeg_path=ffmpeg_path,
+            accept_success_with_stderr=False,
+        )
         if not stderr_lines:
             return data[start_offset:]
         if first_error is None and stderr_lines:
@@ -3174,6 +3178,7 @@ def _try_first_clean_hevc_annexb_irap_window_offset(
         decode_errors = _ffmpeg_hevc_decode_errors(
             annexb[start_offset:end_offset],
             ffmpeg_path=ffmpeg_path,
+            accept_success_with_stderr=False,
         )
         if not decode_errors:
             return _H264CleanIdrProbeResult(

--- a/pyezvizapi/local_stream.py
+++ b/pyezvizapi/local_stream.py
@@ -49,6 +49,16 @@ from .stream import (
 
 HCNETSDK_COMMAND_PORT_NATIVE_PLAN_APP_LAN_LIVE_VIEW = "app-lan-live-view"
 
+_COMMAND_PORT_RTP_UNWRAP_FALLBACK_ERRORS = {
+    "Unsupported RTP version",
+    "RTP packet is too short",
+    "RTP CSRC header exceeds packet length",
+    "RTP extension header exceeds packet length",
+    "RTP extension payload exceeds packet length",
+    "RTP padding set without payload",
+    "Invalid RTP padding length",
+}
+
 _HCNETSDK_APP_LAN_AUDIO_VIDEO_COMPRESS_INFO_TAIL = bytes.fromhex(
     "000000083c417564696f566964656f436f6d7072657373496e666f3e"
     "3c566964656f4368616e6e656c4e756d6265723e313c2f566964656f"
@@ -1992,7 +2002,7 @@ def _hcnetsdk_command_port_media_payload(payload: bytes) -> bytes:
     try:
         unwrapped = rtp_payload(payload)
     except PyEzvizError as err:
-        if str(err) not in {"Unsupported RTP version", "RTP packet is too short"}:
+        if str(err) not in _COMMAND_PORT_RTP_UNWRAP_FALLBACK_ERRORS:
             raise
         return payload
     if _looks_like_hcnetsdk_wrapped_media_payload(unwrapped):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3688,6 +3688,100 @@ def test_hcnetsdk_command_dump_summary_reports_hevc_playm4_input(
     assert output["playm4_input"]["decode_irap_windows"][0]["decode_clean"] is True
 
 
+def test_hcnetsdk_command_dump_summary_reports_native_annexb_label(
+    tmp_path,
+    capsys,
+) -> None:
+    dump_dir = tmp_path / "dumps"
+    dump_dir.mkdir()
+    chunks = [
+        b"\x00\x00\x00\x01\x67\x4d\x00\x29"
+        b"\x00\x00\x00\x01\x68\xee\x38\x80"
+        b"\x00\x00\x00\x01\x65idr",
+        b"\x00\x00\x00\x01\x61p",
+    ]
+    for index, chunk in enumerate(chunks):
+        (dump_dir / f"20260613070000-{index:04d}-playctrl-idmx-aes-frame-after-8.bin").write_bytes(
+            chunk
+        )
+    fake_ffmpeg = tmp_path / "fake-ffmpeg"
+    fake_ffmpeg.write_text(
+        "#!/usr/bin/env python3\n"
+        "import sys\n"
+        "sys.stdin.buffer.read()\n",
+        encoding="utf-8",
+    )
+    fake_ffmpeg.chmod(0o755)
+
+    assert (
+        cli_module.main(
+            [
+                "--token-file",
+                str(tmp_path / "missing.json"),
+                "stream",
+                "hcnetsdk-command-dump-summary",
+                "--native-annexb-dir",
+                str(dump_dir),
+                "--max-frames",
+                "8",
+                "--decode-idr-windows",
+                "--ffmpeg-path",
+                str(fake_ffmpeg),
+            ]
+        )
+        == 0
+    )
+
+    output = json.loads(capsys.readouterr().out)
+    assert output["native_annexb"]["label"] == "playctrl-idmx-aes-frame-after"
+    assert output["native_annexb"]["codec"] == "h264"
+    assert output["native_annexb"]["requested_codec"] == "auto"
+    assert output["native_annexb"]["file_count"] == 2
+    assert output["native_annexb"]["annexb_units"]["h264"]["sps"] == 1
+    assert output["native_annexb"]["annexb_idr_windows"]["idr_count"] == 1
+    assert output["native_annexb"]["decode_idr_windows"][0]["decode_clean"] is True
+    assert output["native_annexb"]["decode_chunk_windows"][0]["decode_clean"] is True
+
+
+def test_hcnetsdk_command_dump_summary_auto_detects_native_hevc(
+    tmp_path,
+    capsys,
+) -> None:
+    dump_dir = tmp_path / "dumps"
+    dump_dir.mkdir()
+    chunks = [
+        b"\x00\x00\x00\x01\x40\x01vps"
+        b"\x00\x00\x00\x01\x42\x01sps"
+        b"\x00\x00\x00\x01\x44\x01pps",
+        b"\x00\x00\x00\x01\x26\x01irap",
+    ]
+    for index, chunk in enumerate(chunks):
+        (dump_dir / f"20260613070000-{index:04d}-playctrl-idmx-aes-frame-after-8.bin").write_bytes(
+            chunk
+        )
+
+    assert (
+        cli_module.main(
+            [
+                "--token-file",
+                str(tmp_path / "missing.json"),
+                "stream",
+                "hcnetsdk-command-dump-summary",
+                "--native-annexb-dir",
+                str(dump_dir),
+                "--max-frames",
+                "8",
+            ]
+        )
+        == 0
+    )
+
+    output = json.loads(capsys.readouterr().out)
+    assert output["native_annexb"]["codec"] == "hevc"
+    assert output["native_annexb"]["requested_codec"] == "auto"
+    assert output["native_annexb"]["annexb_irap_windows"]["irap_count"] == 1
+
+
 def test_local_sdk_dump_can_fetch_cas_tuple_with_auth(monkeypatch, tmp_path) -> None:
     fake_client = _install_fake_client(monkeypatch)
     output_path = tmp_path / "local.ps"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3695,9 +3695,11 @@ def test_hcnetsdk_command_dump_summary_reports_native_annexb_label(
     dump_dir = tmp_path / "dumps"
     dump_dir.mkdir()
     chunks = [
-        b"\x00\x00\x00\x01\x67\x4d\x00\x29"
-        b"\x00\x00\x00\x01\x68\xee\x38\x80"
-        b"\x00\x00\x00\x01\x65idr",
+        (
+            b"\x00\x00\x00\x01\x67\x4d\x00\x29"
+            + b"\x00\x00\x00\x01\x68\xee\x38\x80"
+            + b"\x00\x00\x00\x01\x65idr"
+        ),
         b"\x00\x00\x00\x01\x61p",
     ]
     for index, chunk in enumerate(chunks):
@@ -3750,9 +3752,11 @@ def test_hcnetsdk_command_dump_summary_auto_detects_native_hevc(
     dump_dir = tmp_path / "dumps"
     dump_dir.mkdir()
     chunks = [
-        b"\x00\x00\x00\x01\x40\x01vps"
-        b"\x00\x00\x00\x01\x42\x01sps"
-        b"\x00\x00\x00\x01\x44\x01pps",
+        (
+            b"\x00\x00\x00\x01\x40\x01vps"
+            + b"\x00\x00\x00\x01\x42\x01sps"
+            + b"\x00\x00\x00\x01\x44\x01pps"
+        ),
         b"\x00\x00\x00\x01\x26\x01irap",
     ]
     for index, chunk in enumerate(chunks):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3636,6 +3636,58 @@ def test_hcnetsdk_command_dump_summary_runs_without_credentials(tmp_path, capsys
     assert output["playm4_input"]["decode_idr_windows"][0]["decode_clean"] is True
 
 
+def test_hcnetsdk_command_dump_summary_reports_hevc_playm4_input(
+    tmp_path,
+    capsys,
+) -> None:
+    dump_dir = tmp_path / "dumps"
+    dump_dir.mkdir()
+    rtp_header = b"\x80\x60\x5d\x5c\x7d\x52\x2a\x3e\x55\x66\x77\x88"
+    hevc_frames = [
+        rtp_header + b"\x40\x01vps",
+        rtp_header + b"\x42\x01sps",
+        rtp_header + b"\x44\x01pps",
+        rtp_header + b"\x26\x01idr",
+    ]
+    for index, idmx_frame in enumerate(hevc_frames):
+        (dump_dir / f"20260613070000-{index:04d}-playm4-input-16.bin").write_bytes(
+            idmx_frame
+        )
+    fake_ffmpeg = tmp_path / "fake-ffmpeg"
+    fake_ffmpeg.write_text(
+        "#!/usr/bin/env python3\n"
+        "import sys\n"
+        "sys.stdin.buffer.read()\n",
+        encoding="utf-8",
+    )
+    fake_ffmpeg.chmod(0o755)
+
+    assert (
+        cli_module.main(
+            [
+                "--token-file",
+                str(tmp_path / "missing.json"),
+                "stream",
+                "hcnetsdk-command-dump-summary",
+                "--playm4-input-dir",
+                str(dump_dir),
+                "--max-frames",
+                "8",
+                "--decode-idr-windows",
+                "--ffmpeg-path",
+                str(fake_ffmpeg),
+            ]
+        )
+        == 0
+    )
+
+    output = json.loads(capsys.readouterr().out)
+    assert output["playm4_input"]["annexb_codec"] == "hevc"
+    assert output["playm4_input"]["idmx_h264"]["hevc"]["media"] == 3
+    assert output["playm4_input"]["annexb_irap_windows"]["irap_count"] == 1
+    assert output["playm4_input"]["decode_irap_windows"][0]["decode_clean"] is True
+
+
 def test_local_sdk_dump_can_fetch_cas_tuple_with_auth(monkeypatch, tmp_path) -> None:
     fake_client = _install_fake_client(monkeypatch)
     output_path = tmp_path / "local.ps"

--- a/tests/test_hcnetsdk_command_live_check.py
+++ b/tests/test_hcnetsdk_command_live_check.py
@@ -276,7 +276,7 @@ def test_save_command_can_wait_for_clean_idr_window(tmp_path: Path) -> None:
         local_ip=None,
         decrypt_video=False,
         no_try_enc_key_password=True,
-        no_skip_initial_idr=True,
+        no_skip_initial_idr=False,
         wait_for_clean_idr_window=True,
         clean_idr_wait_seconds="20",
         clean_idr_max_windows="8",

--- a/tests/test_hcnetsdk_command_live_check.py
+++ b/tests/test_hcnetsdk_command_live_check.py
@@ -86,6 +86,26 @@ def test_filtered_items_skip_unused_and_battery_by_default() -> None:
     assert [item.serial for item in selected] == ["A"]
 
 
+def test_ffmpeg_decode_uses_error_log_level(
+    tmp_path: Path,
+    monkeypatch: Any,
+) -> None:
+    tool = _load_tool()
+    seen: dict[str, Any] = {}
+
+    def fake_run(command: list[str], *, cwd: Path) -> subprocess.CompletedProcess[bytes]:
+        seen["command"] = command
+        seen["cwd"] = cwd
+        return subprocess.CompletedProcess(command, 0, stdout=b"", stderr=b"")
+
+    monkeypatch.setattr(tool, "_run", fake_run)
+
+    result = tool._ffmpeg_decode("ffmpeg", tmp_path / "capture.ts")  # noqa: SLF001
+
+    assert result.returncode == 0
+    assert seen["command"][:3] == ["ffmpeg", "-v", "error"]
+
+
 def test_dry_run_redacts_sensitive_camera_fields(tmp_path: Path) -> None:
     tool = _load_tool()
     args = argparse.Namespace(
@@ -100,11 +120,14 @@ def test_dry_run_redacts_sensitive_camera_fields(tmp_path: Path) -> None:
         decrypt_video=False,
         no_try_enc_key_password=False,
         no_skip_initial_idr=False,
+        wait_for_clean_idr_window=False,
+        clean_idr_wait_seconds="60",
+        clean_idr_max_windows="32",
         dry_run=True,
     )
     item = tool.CameraInventoryItem(
-        name="Garage",
-        serial="SERIAL-GARAGE-01",
+        name="Camera",
+        serial="SERIAL-CAMERA-01",
         password="dummy-camera-password-01",
         enc_key="dummy-enc-key-03",
     )
@@ -122,7 +145,7 @@ def test_dry_run_redacts_sensitive_camera_fields(tmp_path: Path) -> None:
     assert result["ok"] is None
     assert "<redacted>" in rendered
     assert "dummy-camera-password-01" not in rendered
-    assert "SERIAL-GARAGE-01" not in rendered
+    assert "SERIAL-CAMERA-01" not in rendered
     assert "dummy-enc-key-03" not in rendered
     assert result["serial"] == "<redacted>"
     assert result["command"][result["command"].index("--serial") + 1] == "<redacted>"
@@ -134,10 +157,68 @@ def test_dry_run_redacts_sensitive_camera_fields(tmp_path: Path) -> None:
         command = attempt["command"]
         assert command[command.index("--hcnetsdk-command-password") + 1] == "<redacted>"
     assert any(
-        value.endswith("camera-01-Garage-encryption_key_password.ts")
+        value.endswith("camera-01-Camera-encryption_key_password.ts")
         for value in result["credential_attempts"][1]["command"]
     )
-    assert "camera-01-Garage" in result["artifacts"]["capture"]
+    assert "camera-01-Camera" in result["artifacts"]["capture"]
+
+
+def test_dry_run_includes_sampled_packet_sidecars_when_requested(
+    tmp_path: Path,
+) -> None:
+    tool = _load_tool()
+    args = argparse.Namespace(
+        python="python",
+        command_port="8000",
+        channel="1",
+        native_plan="app-lan-live-view",
+        duration="5s",
+        timeout="12",
+        ffmpeg_path="ffmpeg",
+        local_ip=None,
+        decrypt_video=False,
+        no_try_enc_key_password=False,
+        no_skip_initial_idr=False,
+        wait_for_clean_idr_window=True,
+        clean_idr_wait_seconds="60",
+        clean_idr_max_windows="32",
+        dry_run=True,
+        save_sampled_packets=True,
+    )
+    item = tool.CameraInventoryItem(
+        name="Camera",
+        serial="SERIAL-CAMERA-01",
+        password="dummy-camera-password-01",
+        enc_key="dummy-enc-key-03",
+    )
+
+    result = tool._check_item(  # noqa: SLF001
+        args=args,
+        item=item,
+        output_dir=tmp_path,
+        host="192.0.2.10",
+        host_source="override",
+        camera_index=1,
+    )
+
+    attempts = result["credential_attempts"]
+    assert len(attempts) == 2
+    first_command = attempts[0]["command"]
+    second_command = attempts[1]["command"]
+    assert (
+        first_command[
+            first_command.index("--hcnetsdk-command-sampled-packets-output") + 1
+        ]
+        == str(tmp_path / "camera-01-Camera-inventory_password.sampled-packets.bin")
+    )
+    assert (
+        second_command[
+            second_command.index("--hcnetsdk-command-sampled-packets-output") + 1
+        ]
+        == str(
+            tmp_path / "camera-01-Camera-encryption_key_password.sampled-packets.bin"
+        )
+    )
 
 
 def test_dry_run_redacts_media_key_when_decrypting(tmp_path: Path) -> None:
@@ -154,11 +235,14 @@ def test_dry_run_redacts_media_key_when_decrypting(tmp_path: Path) -> None:
         decrypt_video=True,
         no_try_enc_key_password=False,
         no_skip_initial_idr=False,
+        wait_for_clean_idr_window=False,
+        clean_idr_wait_seconds="60",
+        clean_idr_max_windows="32",
         dry_run=True,
     )
     item = tool.CameraInventoryItem(
-        name="Garage",
-        serial="SERIAL-GARAGE-01",
+        name="Camera",
+        serial="SERIAL-CAMERA-01",
         password="dummy-camera-password-01",
         enc_key="dummy-enc-key-03",
     )
@@ -179,6 +263,49 @@ def test_dry_run_redacts_media_key_when_decrypting(tmp_path: Path) -> None:
     assert "dummy-enc-key-03" not in rendered
 
 
+def test_save_command_can_wait_for_clean_idr_window(tmp_path: Path) -> None:
+    tool = _load_tool()
+    args = argparse.Namespace(
+        python="python",
+        command_port="8000",
+        channel="1",
+        native_plan="app-lan-live-view",
+        duration="5s",
+        timeout="12",
+        ffmpeg_path="ffmpeg",
+        local_ip=None,
+        decrypt_video=False,
+        no_try_enc_key_password=True,
+        no_skip_initial_idr=True,
+        wait_for_clean_idr_window=True,
+        clean_idr_wait_seconds="20",
+        clean_idr_max_windows="8",
+    )
+    item = tool.CameraInventoryItem(
+        name="Camera",
+        serial="SERIAL-CAMERA-01",
+        password="dummy-camera-password-01",
+    )
+
+    command = tool._save_command(  # noqa: SLF001
+        args=args,
+        item=item,
+        command_password=item.password,
+        host="192.0.2.10",
+        capture_path=tmp_path / "capture.ts",
+        metadata_path=tmp_path / "metadata.json",
+    )
+
+    assert "--hcnetsdk-h264-skip-initial-idr-windows" not in command
+    assert "--hcnetsdk-h264-wait-for-clean-idr-window" in command
+    assert command[
+        command.index("--hcnetsdk-h264-clean-idr-wait-seconds") + 1
+    ] == "20"
+    assert command[
+        command.index("--hcnetsdk-h264-clean-idr-max-windows") + 1
+    ] == "8"
+
+
 def test_decrypt_video_without_encryption_key_is_untestable(tmp_path: Path) -> None:
     tool = _load_tool()
     args = argparse.Namespace(
@@ -193,11 +320,14 @@ def test_decrypt_video_without_encryption_key_is_untestable(tmp_path: Path) -> N
         decrypt_video=True,
         no_try_enc_key_password=False,
         no_skip_initial_idr=False,
+        wait_for_clean_idr_window=False,
+        clean_idr_wait_seconds="60",
+        clean_idr_max_windows="32",
         dry_run=True,
     )
     item = tool.CameraInventoryItem(
-        name="Garage",
-        serial="SERIAL-GARAGE-01",
+        name="Camera",
+        serial="SERIAL-CAMERA-01",
         password="dummy-camera-password-01",
     )
 
@@ -216,7 +346,7 @@ def test_decrypt_video_without_encryption_key_is_untestable(tmp_path: Path) -> N
     assert result["diagnosis"] == "missing_encryption_key"
     assert result["credential_attempts"] == []
     assert "command" not in result
-    assert "SERIAL-GARAGE-01" not in rendered
+    assert "SERIAL-CAMERA-01" not in rendered
     assert "dummy-camera-password-01" not in rendered
 
 
@@ -234,6 +364,9 @@ def test_dotted_camera_name_preserves_retry_suffix_artifact_paths(tmp_path: Path
         decrypt_video=False,
         no_try_enc_key_password=False,
         no_skip_initial_idr=False,
+        wait_for_clean_idr_window=False,
+        clean_idr_wait_seconds="60",
+        clean_idr_max_windows="32",
         dry_run=True,
     )
     item = tool.CameraInventoryItem(
@@ -291,11 +424,14 @@ def test_relative_output_dir_resolves_before_child_commands(
         decrypt_video=False,
         no_try_enc_key_password=True,
         no_skip_initial_idr=False,
+        wait_for_clean_idr_window=False,
+        clean_idr_wait_seconds="60",
+        clean_idr_max_windows="32",
         dry_run=True,
     )
     item = tool.CameraInventoryItem(
-        name="Garage",
-        serial="SERIAL-GARAGE-01",
+        name="Camera",
+        serial="SERIAL-CAMERA-01",
         password="dummy-camera-password-01",
     )
 
@@ -313,8 +449,8 @@ def test_relative_output_dir_resolves_before_child_commands(
     capture = result["artifacts"]["capture"]
     metadata = result["artifacts"]["metadata"]
     command = result["command"]
-    assert capture == str(caller_cwd / "matrix-out" / "camera-01-Garage.ts")
-    assert metadata == str(caller_cwd / "matrix-out" / "camera-01-Garage.metadata.json")
+    assert capture == str(caller_cwd / "matrix-out" / "camera-01-Camera.ts")
+    assert metadata == str(caller_cwd / "matrix-out" / "camera-01-Camera.metadata.json")
     assert command[command.index("--output") + 1] == capture
     assert command[command.index("--hcnetsdk-command-metadata-output") + 1] == metadata
 
@@ -336,11 +472,14 @@ def test_success_artifacts_redact_child_save_artifacts(
         decrypt_video=True,
         no_try_enc_key_password=True,
         no_skip_initial_idr=False,
+        wait_for_clean_idr_window=False,
+        clean_idr_wait_seconds="60",
+        clean_idr_max_windows="32",
         dry_run=False,
     )
     item = tool.CameraInventoryItem(
-        name="Garage",
-        serial="SERIAL-GARAGE-01",
+        name="Camera",
+        serial="SERIAL-CAMERA-01",
         password="dummy-camera-password-01",
         enc_key="dummy-enc-key-03",
     )
@@ -357,6 +496,8 @@ def test_success_artifacts_redact_child_save_artifacts(
                 ),
                 stderr=b"",
             )
+        if command[0] == "ffmpeg":
+            return subprocess.CompletedProcess(command, 0, stdout=b"", stderr=b"")
         capture_path = Path(command[command.index("--output") + 1])
         metadata_path = Path(
             command[command.index("--hcnetsdk-command-metadata-output") + 1]
@@ -366,7 +507,7 @@ def test_success_artifacts_redact_child_save_artifacts(
             json.dumps(
                 {
                     "bootstrap_complete": True,
-                    "serial": "SERIAL-GARAGE-01",
+                    "serial": "SERIAL-CAMERA-01",
                     "password_hint": "dummy-camera-password-01",
                     "media_key_hint": "dummy-enc-key-03",
                 }
@@ -377,10 +518,10 @@ def test_success_artifacts_redact_child_save_artifacts(
             command,
             0,
             stdout=(
-                b'{"ok":true,"serial":"SERIAL-GARAGE-01",'
+                b'{"ok":true,"serial":"SERIAL-CAMERA-01",'
                 b'"media_key":"dummy-enc-key-03"}\n'
             ),
-            stderr=b"connected SERIAL-GARAGE-01 with dummy-camera-password-01\n",
+            stderr=b"connected SERIAL-CAMERA-01 with dummy-camera-password-01\n",
         )
 
     monkeypatch.setattr(tool, "_run", fake_run)
@@ -395,12 +536,17 @@ def test_success_artifacts_redact_child_save_artifacts(
     )
 
     assert result["ok"] is True
+    assert result["diagnosis"] == "playable_mpegts"
+    assert result["stderr_tail"] == ""
     stdout_text = Path(result["artifacts"]["save_stdout"]).read_text(encoding="utf-8")
     stderr_text = Path(result["artifacts"]["save_stderr"]).read_text(encoding="utf-8")
     metadata_text = Path(result["artifacts"]["metadata"]).read_text(encoding="utf-8")
+    decode_stderr_text = Path(result["artifacts"]["decode_stderr"]).read_text(
+        encoding="utf-8"
+    )
     rendered = json.dumps(result)
-    for text in (stdout_text, stderr_text, metadata_text, rendered):
-        assert "SERIAL-GARAGE-01" not in text
+    for text in (stdout_text, stderr_text, metadata_text, decode_stderr_text, rendered):
+        assert "SERIAL-CAMERA-01" not in text
         assert "dummy-camera-password-01" not in text
         assert "dummy-enc-key-03" not in text
     assert stdout_text.count("<redacted>") == 2
@@ -408,12 +554,232 @@ def test_success_artifacts_redact_child_save_artifacts(
     assert metadata_text.count("<redacted>") == 3
 
 
+def test_decode_warnings_fail_successful_capture(tmp_path: Path, monkeypatch: Any) -> None:
+    tool = _load_tool()
+    args = argparse.Namespace(
+        python="python",
+        command_port="8000",
+        channel="1",
+        native_plan="app-lan-live-view",
+        duration="5s",
+        timeout="12",
+        ffmpeg_path="ffmpeg",
+        ffprobe_path="ffprobe",
+        local_ip=None,
+        decrypt_video=False,
+        no_try_enc_key_password=True,
+        no_skip_initial_idr=False,
+        wait_for_clean_idr_window=False,
+        clean_idr_wait_seconds="60",
+        clean_idr_max_windows="32",
+        dry_run=False,
+    )
+    item = tool.CameraInventoryItem(
+        name="Camera",
+        serial="SERIAL-CAMERA-01",
+        password="dummy-camera-password-01",
+    )
+
+    def fake_run(command: list[str], *, cwd: Path) -> subprocess.CompletedProcess[bytes]:
+        if command[0] == "ffprobe":
+            return subprocess.CompletedProcess(
+                command,
+                0,
+                stdout=(
+                    b'{"streams":[{"index":0,"codec_type":"video",'
+                    b'"codec_name":"hevc","width":1920,"height":1080}],'
+                    b'"format":{"duration":"5.0"}}'
+                ),
+                stderr=b"",
+            )
+        if command[0] == "ffmpeg":
+            return subprocess.CompletedProcess(
+                command,
+                0,
+                stdout=b"",
+                stderr=b"[hevc] Skipping invalid undecodable NALU: 19\n",
+            )
+        capture_path = Path(command[command.index("--output") + 1])
+        metadata_path = Path(
+            command[command.index("--hcnetsdk-command-metadata-output") + 1]
+        )
+        capture_path.write_bytes(b"mpegts")
+        metadata_path.write_text('{"bootstrap_complete": true}', encoding="utf-8")
+        return subprocess.CompletedProcess(command, 0, stdout=b"{}", stderr=b"")
+
+    monkeypatch.setattr(tool, "_run", fake_run)
+
+    result = tool._check_item(  # noqa: SLF001
+        args=args,
+        item=item,
+        output_dir=tmp_path,
+        host="192.0.2.10",
+        host_source="override",
+        camera_index=1,
+    )
+
+    assert result["ok"] is False
+    assert result["stage"] == "decode"
+    assert result["diagnosis"] == "decode_warnings"
+    assert result["streams"][0]["codec_name"] == "hevc"
+    assert "Skipping invalid undecodable NALU" in result["stderr_tail"]
+    assert Path(result["artifacts"]["decode_stderr"]).read_text(encoding="utf-8")
+
+
+def test_h264_decode_failure_fails_successful_capture(
+    tmp_path: Path,
+    monkeypatch: Any,
+) -> None:
+    tool = _load_tool()
+    args = argparse.Namespace(
+        python="python",
+        command_port="8000",
+        channel="1",
+        native_plan="app-lan-live-view",
+        duration="5s",
+        timeout="12",
+        ffmpeg_path="ffmpeg",
+        ffprobe_path="ffprobe",
+        local_ip=None,
+        decrypt_video=False,
+        no_try_enc_key_password=True,
+        no_skip_initial_idr=False,
+        wait_for_clean_idr_window=False,
+        clean_idr_wait_seconds="60",
+        clean_idr_max_windows="32",
+        dry_run=False,
+    )
+    item = tool.CameraInventoryItem(
+        name="Camera",
+        serial="SERIAL-CAMERA-01",
+        password="dummy-camera-password-01",
+    )
+
+    def fake_run(command: list[str], *, cwd: Path) -> subprocess.CompletedProcess[bytes]:
+        if command[0] == "ffprobe":
+            return subprocess.CompletedProcess(
+                command,
+                0,
+                stdout=(
+                    b'{"streams":[{"index":0,"codec_type":"video",'
+                    b'"codec_name":"h264","width":1920,"height":1080}],'
+                    b'"format":{"duration":"5.0"}}'
+                ),
+                stderr=b"",
+            )
+        if command[0] == "ffmpeg":
+            return subprocess.CompletedProcess(
+                command,
+                1,
+                stdout=b"",
+                stderr=b"[h264] error while decoding MB 0 0\n",
+            )
+        capture_path = Path(command[command.index("--output") + 1])
+        metadata_path = Path(
+            command[command.index("--hcnetsdk-command-metadata-output") + 1]
+        )
+        capture_path.write_bytes(b"mpegts")
+        metadata_path.write_text('{"bootstrap_complete": true}', encoding="utf-8")
+        return subprocess.CompletedProcess(command, 0, stdout=b"{}", stderr=b"")
+
+    monkeypatch.setattr(tool, "_run", fake_run)
+
+    result = tool._check_item(  # noqa: SLF001
+        args=args,
+        item=item,
+        output_dir=tmp_path,
+        host="192.0.2.10",
+        host_source="override",
+        camera_index=1,
+    )
+
+    assert result["ok"] is False
+    assert result["stage"] == "decode"
+    assert result["diagnosis"] == "decode_failed"
+    assert result["streams"][0]["codec_name"] == "h264"
+    assert "error while decoding" in result["stderr_tail"]
+
+
+def test_h264_decode_warnings_pass_successful_capture(
+    tmp_path: Path,
+    monkeypatch: Any,
+) -> None:
+    tool = _load_tool()
+    args = argparse.Namespace(
+        python="python",
+        command_port="8000",
+        channel="1",
+        native_plan="app-lan-live-view",
+        duration="5s",
+        timeout="12",
+        ffmpeg_path="ffmpeg",
+        ffprobe_path="ffprobe",
+        local_ip=None,
+        decrypt_video=False,
+        no_try_enc_key_password=True,
+        no_skip_initial_idr=False,
+        wait_for_clean_idr_window=False,
+        clean_idr_wait_seconds="60",
+        clean_idr_max_windows="32",
+        dry_run=False,
+    )
+    item = tool.CameraInventoryItem(
+        name="Camera",
+        serial="SERIAL-CAMERA-01",
+        password="dummy-camera-password-01",
+    )
+
+    def fake_run(command: list[str], *, cwd: Path) -> subprocess.CompletedProcess[bytes]:
+        if command[0] == "ffprobe":
+            return subprocess.CompletedProcess(
+                command,
+                0,
+                stdout=(
+                    b'{"streams":[{"index":0,"codec_type":"video",'
+                    b'"codec_name":"h264","width":1920,"height":1080}],'
+                    b'"format":{"duration":"5.0"}}'
+                ),
+                stderr=b"",
+            )
+        if command[0] == "ffmpeg":
+            return subprocess.CompletedProcess(
+                command,
+                0,
+                stdout=b"",
+                stderr=b"[h264] corrupt decoded frame in stream 0\n",
+            )
+        capture_path = Path(command[command.index("--output") + 1])
+        metadata_path = Path(
+            command[command.index("--hcnetsdk-command-metadata-output") + 1]
+        )
+        capture_path.write_bytes(b"mpegts")
+        metadata_path.write_text('{"bootstrap_complete": true}', encoding="utf-8")
+        return subprocess.CompletedProcess(command, 0, stdout=b"{}", stderr=b"")
+
+    monkeypatch.setattr(tool, "_run", fake_run)
+
+    result = tool._check_item(  # noqa: SLF001
+        args=args,
+        item=item,
+        output_dir=tmp_path,
+        host="192.0.2.10",
+        host_source="override",
+        camera_index=1,
+    )
+
+    assert result["ok"] is True
+    assert result["stage"] == "complete"
+    assert result["diagnosis"] == "playable_mpegts_with_h264_decode_warnings"
+    assert result["streams"][0]["codec_name"] == "h264"
+    assert "corrupt decoded frame" in result["stderr_tail"]
+
+
 def test_credential_attempts_can_skip_encryption_key_password() -> None:
     tool = _load_tool()
     args = argparse.Namespace(no_try_enc_key_password=True)
     item = tool.CameraInventoryItem(
-        name="Garage",
-        serial="SERIAL-GARAGE-01",
+        name="Camera",
+        serial="SERIAL-CAMERA-01",
         password="dummy-camera-password-01",
         enc_key="dummy-enc-key-03",
     )
@@ -426,22 +792,22 @@ def test_credential_attempts_can_skip_encryption_key_password() -> None:
 def test_recursive_redaction_covers_serial_password_and_enc_key() -> None:
     tool = _load_tool()
     item = tool.CameraInventoryItem(
-        name="Garage",
-        serial="SERIAL-GARAGE-01",
+        name="Camera",
+        serial="SERIAL-CAMERA-01",
         password="dummy-camera-password-01",
         enc_key="dummy-enc-key-03",
     )
 
     redacted = tool._redact_sensitive(  # noqa: SLF001
         {
-            "stderr": "SERIAL-GARAGE-01 dummy-camera-password-01 dummy-enc-key-03",
-            "nested": ["prefix-SERIAL-GARAGE-01"],
+            "stderr": "SERIAL-CAMERA-01 dummy-camera-password-01 dummy-enc-key-03",
+            "nested": ["prefix-SERIAL-CAMERA-01"],
         },
         item,
     )
 
     rendered = json.dumps(redacted)
-    assert "SERIAL-GARAGE-01" not in rendered
+    assert "SERIAL-CAMERA-01" not in rendered
     assert "dummy-camera-password-01" not in rendered
     assert "dummy-enc-key-03" not in rendered
     assert rendered.count("<redacted>") == 4
@@ -450,7 +816,7 @@ def test_recursive_redaction_covers_serial_password_and_enc_key() -> None:
 def test_redaction_handles_overlapping_sensitive_values() -> None:
     tool = _load_tool()
     item = tool.CameraInventoryItem(
-        name="Garage",
+        name="Camera",
         serial="dummy-secret",
         password="dummy-secret-password",
         enc_key="dummy-secret-password-key",

--- a/tests/test_http_helpers.py
+++ b/tests/test_http_helpers.py
@@ -2785,12 +2785,14 @@ def test_save_clip_forwards_h264_options_to_decrypted_hcnetsdk_command_port(
         hcnetsdk_h264_skip_initial_idr_windows=1,
         hcnetsdk_h264_trim_to_clean_idr_window=True,
         hcnetsdk_h264_clean_idr_max_windows=HCNETSDK_CLEAN_IDR_MAX_WINDOWS,
+        nalu_header_size=0,
         duration_seconds=HCNETSDK_SAVE_DURATION,
         max_packets=4,
     )
 
     assert calls[1]["media_key"] == "MEDIAKEY"
     assert calls[1]["ffmpeg_path"] == "ffmpeg"
+    assert calls[1]["nalu_header_size"] == 0
     assert calls[1]["max_packets"] == 4
     assert calls[1]["duration_seconds"] == HCNETSDK_SAVE_DURATION
     assert calls[1]["h264_skip_initial_idr_windows"] == 1

--- a/tests/test_local_stream.py
+++ b/tests/test_local_stream.py
@@ -3013,7 +3013,7 @@ def test_copy_local_stream_to_mpegts_can_preroll_before_clean_idr_trim(
         FakeStream(),
         output,
         ffmpeg_path=str(fake_ffmpeg),
-        duration_seconds=1.0,
+        duration_seconds=0.5,
         monotonic=lambda: next(times),
         h264_trim_to_clean_idr_window=True,
         h264_clean_idr_preroll_seconds=2.0,
@@ -3338,7 +3338,7 @@ def test_collect_idmx_annexb_after_clean_video_window_selects_hevc_irap(
                 next_irap,
             )
         ),
-        duration_seconds=1.0,
+        duration_seconds=0.5,
         monotonic=iter([0.0, 0.25, 0.5, 0.75, 1.0, 1.25, 1.5]).__next__,
         ffmpeg_path=str(fake_ffmpeg),
         wait_seconds=10.0,
@@ -3960,14 +3960,19 @@ def test_collect_idmx_annexb_after_first_clean_video_window_trims_hevc_suffix(
         "pyezvizapi.local_stream._ffmpeg_hevc_decode_errors",
         fake_errors,
     )
+    def fake_probe(packets: list[bytes], *_args: Any, **_kwargs: Any) -> tuple[Any, ...]:
+        if len(packets) < 9:
+            return None, None, None, SimpleNamespace()
+        return 0, "hevc", None, SimpleNamespace()
+
     monkeypatch.setattr(
         "pyezvizapi.local_stream._probe_first_clean_idmx_video_window",
-        lambda *_args, **_kwargs: (0, "hevc", None, SimpleNamespace()),
+        fake_probe,
     )
 
     annexb, codec = collect_idmx_annexb_after_first_clean_video_window(
         packets,
-        duration_seconds=0.05,
+        duration_seconds=0.02,
         monotonic=fake_monotonic,
         ffmpeg_path="fake-ffmpeg",
     )
@@ -4048,7 +4053,13 @@ def test_collect_h264_after_clean_idr_waits_for_clean_final_suffix(
     )
     trim_calls = 0
 
-    def fake_trim(data: bytes, *, ffmpeg_path: str, max_windows: int) -> bytes:
+    def fake_trim(
+        data: bytes,
+        *,
+        ffmpeg_path: str,
+        max_windows: int,
+        accept_start_offset: Any | None = None,
+    ) -> bytes:
         nonlocal trim_calls
         assert ffmpeg_path == "fake-ffmpeg"
         assert max_windows == 7
@@ -4105,7 +4116,13 @@ def test_collect_decrypted_h264_after_clean_idr_retries_final_suffix_clear_first
     )
     trim_calls = 0
 
-    def fake_trim(data: bytes, *, ffmpeg_path: str, max_windows: int) -> bytes:
+    def fake_trim(
+        data: bytes,
+        *,
+        ffmpeg_path: str,
+        max_windows: int,
+        accept_start_offset: Any | None = None,
+    ) -> bytes:
         nonlocal trim_calls
         assert ffmpeg_path == "fake-ffmpeg"
         assert max_windows == 5

--- a/tests/test_local_stream.py
+++ b/tests/test_local_stream.py
@@ -117,6 +117,24 @@ def _media(
     )
 
 
+def _raw_media(
+    payload: bytes,
+    *,
+    channel: int = 0,
+    prefix: bytes = b"",
+) -> EzvizInterleavedRtpFrameWithPrefix:
+    return EzvizInterleavedRtpFrameWithPrefix(
+        prefix=prefix,
+        frame=EzvizInterleavedRtpFrame(
+            header=EzvizInterleavedRtpFrameHeader(
+                channel=channel,
+                payload_length=len(payload),
+            ),
+            payload=payload,
+        ),
+    )
+
+
 def _preview_request() -> EzvizLocalPreviewRequest:
     return EzvizLocalPreviewRequest(
         operation_code="op",
@@ -933,6 +951,26 @@ def test_hcnetsdk_command_port_media_stream_strips_rtp_continuation_fragments() 
         b"def",
     ]
     assert command_client.read_prefix_limits == [128]
+
+
+def test_hcnetsdk_command_port_media_stream_keeps_malformed_rtp_like_payload() -> None:
+    payload = (
+        b"\x90\x60\x00\x01"
+        b"\x00\x00\x00\x01"
+        b"\x01\x02\x03\x04"
+        b"\xbe\xde\xff\xff"
+        b"raw-command-port-payload"
+    )
+    command_client = _FakeCommandPortClient(_raw_media(payload))
+    stream = HcNetSdkCommandPortMediaStream(
+        command_client,  # type: ignore[arg-type]
+        (b"preview-start",),
+        max_prefix_bytes=128,
+    )
+
+    packets = list(stream.iter_packets(max_packets=1))
+
+    assert packets[0].body == payload
 
 
 def test_local_sdk_media_stream_respects_zero_packet_limit() -> None:

--- a/tests/test_local_stream.py
+++ b/tests/test_local_stream.py
@@ -59,6 +59,7 @@ from pyezvizapi.local_stream import (
     open_local_sdk_stream,
     open_local_sdk_stream_from_client,
     skip_h264_annexb_initial_idr_windows,
+    skip_hevc_annexb_initial_irap_windows,
     summarize_h264_annexb_idr_windows,
     summarize_h264_annexb_units,
     summarize_hevc_annexb_irap_windows,
@@ -2648,7 +2649,6 @@ def test_copy_local_stream_to_mpegts_prefers_direct_hevc_over_partial_h264(
         output,
         ffmpeg_path=str(fake_ffmpeg),
         max_packets=4,
-        h264_skip_initial_idr_windows=1,
     )
 
     assert output.getvalue() == (
@@ -2694,7 +2694,6 @@ def test_copy_local_stream_to_mpegts_prefers_hevc_idr_over_h264_sei_shape(
         output,
         ffmpeg_path=str(fake_ffmpeg),
         max_packets=1,
-        h264_skip_initial_idr_windows=1,
     )
 
     assert output.getvalue() == (
@@ -2977,6 +2976,22 @@ def test_copy_local_stream_to_mpegts_can_skip_initial_h264_idr_windows(
     )
 
     assert output.getvalue() == b"ts:\x00\x00\x00\x01" + idr_good
+
+
+def test_skip_hevc_annexb_initial_irap_windows_requires_requested_window() -> None:
+    data = (
+        b"\x00\x00\x00\x01\x40\x01vps"
+        b"\x00\x00\x00\x01\x42\x01sps"
+        b"\x00\x00\x00\x01\x44\x01pps"
+        b"\x00\x00\x00\x01\x26\x01irap"
+        b"\x00\x00\x00\x01\x02\x01trail"
+    )
+
+    with pytest.raises(
+        PyEzvizError,
+        match="HEVC stream did not contain enough IRAP windows",
+    ):
+        skip_hevc_annexb_initial_irap_windows(data, 1)
 
 
 def test_copy_local_stream_to_mpegts_can_preroll_before_clean_idr_trim(

--- a/tests/test_local_stream.py
+++ b/tests/test_local_stream.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from collections.abc import Iterator
 from datetime import date
 import io
+import subprocess
+import sys
 import time
 from types import SimpleNamespace
 from typing import Any, cast
@@ -37,6 +39,8 @@ from pyezvizapi.local_stream import (
     HcNetSdkCommandPortMultiSocketPlan,
     HcNetSdkCommandPortSocketStep,
     _ffmpeg_h264_decode_errors,
+    _ffmpeg_stderr_tail,
+    _start_ffmpeg_stderr_drain,
     collect_decrypted_h264_idmx_annexb_after_first_clean_idr_window,
     collect_h264_idmx_annexb_after_first_clean_idr_window,
     collect_idmx_annexb_after_first_clean_video_window,
@@ -2375,7 +2379,7 @@ def test_copy_local_stream_to_mpegts_handles_direct_hevc_fu_without_continuation
     )
 
 
-def test_copy_local_stream_to_mpegts_drops_invalid_hevc_type_zero(
+def test_copy_local_stream_to_mpegts_keeps_hevc_trail_n(
     tmp_path,
 ) -> None:
     fake_ffmpeg = tmp_path / "fake-ffmpeg"
@@ -2399,7 +2403,7 @@ def test_copy_local_stream_to_mpegts_drops_invalid_hevc_type_zero(
             + body
         )
 
-    invalid_type_zero = b"\x00\x01invalid"
+    trail_n = b"\x00\x01trail-n"
     vps = b"\x40\x01vps"
     sps = b"\x42\x01sps"
     idr = b"\x26\x01idr"
@@ -2408,7 +2412,7 @@ def test_copy_local_stream_to_mpegts_drops_invalid_hevc_type_zero(
         def iter_packets(self, *, max_packets: int | None = None) -> list[Any]:
             assert max_packets == 4
             return [
-                SimpleNamespace(body=frame(invalid_type_zero, sequence=sequence_base)),
+                SimpleNamespace(body=frame(trail_n, sequence=sequence_base)),
                 SimpleNamespace(body=frame(vps, sequence=sequence_base + 1)),
                 SimpleNamespace(body=frame(sps, sequence=sequence_base + 2)),
                 SimpleNamespace(body=frame(idr, sequence=sequence_base + 3)),
@@ -2425,12 +2429,36 @@ def test_copy_local_stream_to_mpegts_drops_invalid_hevc_type_zero(
 
     assert output.getvalue() == (
         b"hevc:\x00\x00\x00\x01"
+        + trail_n
+        + b"\x00\x00\x00\x01"
         + vps
         + b"\x00\x00\x00\x01"
         + sps
         + b"\x00\x00\x00\x01"
         + idr
     )
+
+
+def test_ffmpeg_stderr_drain_keeps_bounded_tail() -> None:
+    process = subprocess.Popen(
+        [
+            sys.executable,
+            "-c",
+            (
+                "import sys\n"
+                "sys.stderr.buffer.write(b'x' * 70000 + b'final-marker')\n"
+                "sys.stderr.flush()\n"
+            ),
+        ],
+        stderr=subprocess.PIPE,
+    )
+
+    chunks, reader = _start_ffmpeg_stderr_drain(process, max_bytes=128)
+    assert reader is not None
+    assert process.wait(timeout=5) == 0
+    reader.join(timeout=5)
+
+    assert _ffmpeg_stderr_tail(chunks, max_chars=64).endswith("final-marker")
 
 
 def test_copy_local_stream_to_mpegts_prefers_direct_hevc_over_partial_h264(

--- a/tests/test_local_stream.py
+++ b/tests/test_local_stream.py
@@ -41,6 +41,7 @@ from pyezvizapi.local_stream import (
     _ffmpeg_h264_decode_errors,
     _ffmpeg_stderr_tail,
     _start_ffmpeg_stderr_drain,
+    _try_first_clean_hevc_annexb_irap_window_offset,
     collect_decrypted_h264_idmx_annexb_after_first_clean_idr_window,
     collect_h264_idmx_annexb_after_first_clean_idr_window,
     collect_idmx_annexb_after_first_clean_video_window,
@@ -3748,7 +3749,7 @@ def test_trim_hevc_annexb_to_first_clean_irap_window_uses_ffmpeg(
     assert trimmed == clean_window
 
 
-def test_trim_hevc_annexb_accepts_successful_ffmpeg_with_stderr(
+def test_trim_hevc_annexb_rejects_successful_ffmpeg_with_stderr(
     tmp_path,
 ) -> None:
     fake_ffmpeg = tmp_path / "fake-ffmpeg"
@@ -3767,12 +3768,54 @@ def test_trim_hevc_annexb_accepts_successful_ffmpeg_with_stderr(
         b"\x00\x00\x00\x01\x26\x01irap"
     )
 
-    trimmed = trim_hevc_annexb_to_first_clean_irap_window(
-        data,
-        ffmpeg_path=str(fake_ffmpeg),
+    with pytest.raises(
+        PyEzvizError,
+        match="HEVC stream did not contain a clean sampled IRAP window",
+    ):
+        trim_hevc_annexb_to_first_clean_irap_window(
+            data,
+            ffmpeg_path=str(fake_ffmpeg),
+        )
+
+def test_try_first_clean_hevc_irap_probe_rejects_successful_ffmpeg_with_stderr(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    annexb = (
+        b"\x00\x00\x00\x01\x40\x01vps"
+        b"\x00\x00\x00\x01\x42\x01sps"
+        b"\x00\x00\x00\x01\x44\x01pps"
+        b"\x00\x00\x00\x01\x26\x01irap"
+        b"\x00\x00\x00\x01\x02\x01tail"
+        b"\x00\x00\x00\x01\x26\x01next-irap"
     )
 
-    assert trimmed == data
+    def fake_errors(
+        data: bytes,
+        *,
+        ffmpeg_path: str,
+        accept_success_with_stderr: bool = True,
+    ) -> list[str]:
+        assert ffmpeg_path == "fake-ffmpeg"
+        assert accept_success_with_stderr is False
+        return ["cu_qp_delta outside valid range"]
+
+    monkeypatch.setattr(
+        "pyezvizapi.local_stream._idmx_local_packets_to_hevc_annexb",
+        lambda packets: annexb,
+    )
+    monkeypatch.setattr(
+        "pyezvizapi.local_stream._ffmpeg_hevc_decode_errors",
+        fake_errors,
+    )
+
+    result = _try_first_clean_hevc_annexb_irap_window_offset(
+        [b"packet"],
+        ffmpeg_path="fake-ffmpeg",
+        max_windows=4,
+    )
+
+    assert result.start_offset is None
+    assert result.first_decode_error == "cu_qp_delta outside valid range"
 
 
 def test_trim_hevc_annexb_to_first_error_free_suffix_recovers_at_later_irap(

--- a/tests/test_local_stream.py
+++ b/tests/test_local_stream.py
@@ -36,7 +36,10 @@ from pyezvizapi.local_stream import (
     HcNetSdkCommandPortMultiSocketMediaStream,
     HcNetSdkCommandPortMultiSocketPlan,
     HcNetSdkCommandPortSocketStep,
+    _ffmpeg_h264_decode_errors,
+    collect_decrypted_h264_idmx_annexb_after_first_clean_idr_window,
     collect_h264_idmx_annexb_after_first_clean_idr_window,
+    collect_idmx_annexb_after_first_clean_video_window,
     collect_local_stream_mpegps,
     copy_hcnetsdk_real_data_to_mpegts,
     copy_local_sdk_stream_from_client,
@@ -53,9 +56,13 @@ from pyezvizapi.local_stream import (
     skip_h264_annexb_initial_idr_windows,
     summarize_h264_annexb_idr_windows,
     summarize_h264_annexb_units,
+    summarize_hevc_annexb_irap_windows,
     summarize_idmx_h264_local_packets,
     time as local_stream_time,
     trim_h264_annexb_to_first_clean_idr_window,
+    trim_h264_annexb_to_first_error_free_suffix,
+    trim_hevc_annexb_to_first_clean_irap_window,
+    trim_hevc_annexb_to_first_error_free_suffix,
 )
 
 FIRST_PREFIX = b"preface"
@@ -1542,6 +1549,346 @@ def test_copy_local_stream_to_decrypted_mpegts_decrypts_idmx_payload(
     )
 
 
+def test_copy_local_stream_to_decrypted_mpegts_decrypts_direct_hevc_idmx_payload(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_ffmpeg = tmp_path / "fake-ffmpeg"
+    fake_ffmpeg.write_text(
+        "#!/usr/bin/env python3\n"
+        "import sys\n"
+        "codec = sys.argv[sys.argv.index('-f') + 1]\n"
+        "sys.stdout.buffer.write(codec.encode() + b':' + sys.stdin.buffer.read())\n",
+        encoding="utf-8",
+    )
+    fake_ffmpeg.chmod(0o755)
+    decrypted_nals: list[bytes] = []
+
+    def fake_decrypt_hevc_nal_prefix(nal: bytes, _aes_key: bytes) -> bytes:
+        decrypted_nals.append(nal)
+        return nal
+
+    monkeypatch.setattr(
+        "pyezvizapi.local_stream._decrypt_hevc_nal_prefix",
+        fake_decrypt_hevc_nal_prefix,
+    )
+    rtp_timestamp = 0x3601D1EF
+    sequence_base = 0x7000
+
+    def idmx_frame(body: bytes, *, sequence: int) -> bytes:
+        idmx_header = (
+            b"\x80\x60"
+            + sequence.to_bytes(2, "big")
+            + rtp_timestamp.to_bytes(4, "big")
+            + b"\x55\x66\x77\x88"
+        )
+        frame = idmx_header + body
+        return len(frame).to_bytes(4, "little") + frame
+
+    vps = b"\x40\x01vps"
+    first_fu = b"\x62\x01\x93slice-"
+    last_fu = b"\x62\x01\x53payload"
+
+    class FakeStream:
+        def iter_packets(self, *, max_packets: int | None = None) -> list[Any]:
+            assert max_packets == 3
+            return [
+                SimpleNamespace(body=idmx_frame(vps, sequence=sequence_base)),
+                SimpleNamespace(body=idmx_frame(first_fu, sequence=sequence_base + 1)),
+                SimpleNamespace(body=idmx_frame(last_fu, sequence=sequence_base + 2)),
+            ]
+
+    output = io.BytesIO()
+
+    copy_local_stream_to_decrypted_mpegts(
+        FakeStream(),
+        output,
+        IDMX_MEDIA_KEY,
+        ffmpeg_path=str(fake_ffmpeg),
+        max_packets=3,
+    )
+
+    assert decrypted_nals == [b"\x26\x01slice-payload"]
+    assert output.getvalue() == (
+        b"hevc:\x00\x00\x00\x01"
+        + vps
+        + b"\x00\x00\x00\x01\x26\x01slice-payload"
+    )
+
+
+def test_copy_local_stream_to_decrypted_mpegts_decrypts_h264_idmx_payload(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_ffmpeg = tmp_path / "fake-ffmpeg"
+    fake_ffmpeg.write_text(
+        "#!/usr/bin/env python3\n"
+        "import sys\n"
+        "codec = sys.argv[sys.argv.index('-f') + 1]\n"
+        "sys.stdout.buffer.write(codec.encode() + b':' + sys.stdin.buffer.read())\n",
+        encoding="utf-8",
+    )
+    fake_ffmpeg.chmod(0o755)
+    decrypted_nals: list[bytes] = []
+
+    def fake_decrypt_h264_nal_prefix(
+        nal: bytes,
+        _aes_key: bytes,
+        *,
+        nalu_header_size: int = 1,
+    ) -> bytes:
+        assert nalu_header_size == 1
+        decrypted_nals.append(nal)
+        return nal[:1] + b"plain-" + nal[1:]
+
+    monkeypatch.setattr(
+        "pyezvizapi.local_stream._decrypt_h264_nal_prefix",
+        fake_decrypt_h264_nal_prefix,
+    )
+    idmx_header = b"\x80\x60\x02\x03\x04\x05\x06\x07\x55\x66\x77\x88"
+    sps = b"\x67\x4d\x00"
+    pps = b"\x68\xee\x38"
+    non_idr = b"\x41cipher"
+
+    def idmx_frame(body: bytes) -> bytes:
+        frame = idmx_header + body
+        return len(frame).to_bytes(4, "little") + frame
+
+    class FakeStream:
+        def iter_packets(self, *, max_packets: int | None = None) -> list[Any]:
+            assert max_packets == 3
+            return [
+                SimpleNamespace(body=idmx_frame(body))
+                for body in (sps, pps, non_idr)
+            ]
+
+    output = io.BytesIO()
+
+    copy_local_stream_to_decrypted_mpegts(
+        FakeStream(),
+        output,
+        IDMX_MEDIA_KEY,
+        ffmpeg_path=str(fake_ffmpeg),
+        max_packets=3,
+    )
+
+    assert decrypted_nals == [non_idr]
+    assert output.getvalue() == (
+        b"h264:\x00\x00\x00\x01"
+        + sps
+        + b"\x00\x00\x00\x01"
+        + pps
+        + b"\x00\x00\x00\x01"
+        + b"\x41plain-cipher"
+    )
+
+
+def test_copy_local_stream_to_decrypted_mpegts_decrypts_fragmented_h264_idmx_payload(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_ffmpeg = tmp_path / "fake-ffmpeg"
+    fake_ffmpeg.write_text(
+        "#!/usr/bin/env python3\n"
+        "import sys\n"
+        "codec = sys.argv[sys.argv.index('-f') + 1]\n"
+        "sys.stdout.buffer.write(codec.encode() + b':' + sys.stdin.buffer.read())\n",
+        encoding="utf-8",
+    )
+    fake_ffmpeg.chmod(0o755)
+    decrypted_nals: list[bytes] = []
+
+    def fake_decrypt_h264_nal_prefix(
+        nal: bytes,
+        _aes_key: bytes,
+        *,
+        nalu_header_size: int = 1,
+    ) -> bytes:
+        assert nalu_header_size == 1
+        decrypted_nals.append(nal)
+        return nal[:1] + b"plain-" + nal[1:]
+
+    monkeypatch.setattr(
+        "pyezvizapi.local_stream._decrypt_h264_nal_prefix",
+        fake_decrypt_h264_nal_prefix,
+    )
+    rtp_timestamp = 0x3601D1EF
+    sequence_base = 0x7000
+
+    def idmx_frame(body: bytes, *, sequence: int) -> bytes:
+        idmx_header = (
+            b"\x80\x60"
+            + sequence.to_bytes(2, "big")
+            + rtp_timestamp.to_bytes(4, "big")
+            + b"\x55\x66\x77\x88"
+        )
+        frame = idmx_header + body
+        return len(frame).to_bytes(4, "little") + frame
+
+    first_fu = b"\x7c\x85cipher-"
+    last_fu = b"\x7c\x45payload"
+
+    class FakeStream:
+        def iter_packets(self, *, max_packets: int | None = None) -> list[Any]:
+            assert max_packets == 2
+            return [
+                SimpleNamespace(body=idmx_frame(first_fu, sequence=sequence_base)),
+                SimpleNamespace(body=idmx_frame(last_fu, sequence=sequence_base + 1)),
+            ]
+
+    output = io.BytesIO()
+
+    copy_local_stream_to_decrypted_mpegts(
+        FakeStream(),
+        output,
+        IDMX_MEDIA_KEY,
+        ffmpeg_path=str(fake_ffmpeg),
+        max_packets=2,
+    )
+
+    expected_output = b"h264:\x00\x00\x00\x01\x65plain-cipher-payload"
+    assert decrypted_nals == [b"\x65cipher-payload"]
+    assert output.getvalue() == expected_output
+
+
+def test_copy_local_stream_to_decrypted_mpegts_decrypts_h264_encrypted_header_idmx_payload(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_ffmpeg = tmp_path / "fake-ffmpeg"
+    fake_ffmpeg.write_text(
+        "#!/usr/bin/env python3\n"
+        "import sys\n"
+        "codec = sys.argv[sys.argv.index('-f') + 1]\n"
+        "sys.stdout.buffer.write(codec.encode() + b':' + sys.stdin.buffer.read())\n",
+        encoding="utf-8",
+    )
+    fake_ffmpeg.chmod(0o755)
+    decrypted_nals: list[bytes] = []
+
+    def fake_decrypt_h264_nal_prefix(
+        nal: bytes,
+        _aes_key: bytes,
+        *,
+        nalu_header_size: int = 1,
+    ) -> bytes:
+        assert nalu_header_size == 0
+        decrypted_nals.append(nal)
+        return b"\x65plain-" + nal[1:]
+
+    monkeypatch.setattr(
+        "pyezvizapi.local_stream._decrypt_h264_nal_prefix",
+        fake_decrypt_h264_nal_prefix,
+    )
+    idmx_header = b"\x80\x60\x02\x03\x04\x05\x06\x07\x55\x66\x77\x88"
+    encrypted_idr = b"\xaecipher"
+
+    def idmx_frame(body: bytes) -> bytes:
+        frame = idmx_header + body
+        return len(frame).to_bytes(4, "little") + frame
+
+    class FakeStream:
+        def iter_packets(self, *, max_packets: int | None = None) -> list[Any]:
+            assert max_packets == 1
+            return [SimpleNamespace(body=idmx_frame(encrypted_idr))]
+
+    output = io.BytesIO()
+
+    copy_local_stream_to_decrypted_mpegts(
+        FakeStream(),
+        output,
+        IDMX_MEDIA_KEY,
+        ffmpeg_path=str(fake_ffmpeg),
+        max_packets=1,
+        nalu_header_size=0,
+    )
+
+    expected_output = b"h264:\x00\x00\x00\x01\x65plain-cipher"
+    assert decrypted_nals == [encrypted_idr]
+    assert output.getvalue() == expected_output
+
+
+def test_copy_local_stream_to_decrypted_mpegts_handles_direct_hevc_fu_without_continuation_headers(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_ffmpeg = tmp_path / "fake-ffmpeg"
+    fake_ffmpeg.write_text(
+        "#!/usr/bin/env python3\n"
+        "import sys\n"
+        "codec = sys.argv[sys.argv.index('-f') + 1]\n"
+        "sys.stdout.buffer.write(codec.encode() + b':' + sys.stdin.buffer.read())\n",
+        encoding="utf-8",
+    )
+    fake_ffmpeg.chmod(0o755)
+    decrypted_nals: list[bytes] = []
+
+    def fake_decrypt_hevc_nal_prefix(nal: bytes, _aes_key: bytes) -> bytes:
+        decrypted_nals.append(nal)
+        return nal
+
+    monkeypatch.setattr(
+        "pyezvizapi.local_stream._decrypt_hevc_nal_prefix",
+        fake_decrypt_hevc_nal_prefix,
+    )
+    rtp_timestamp = 0x3601D1EF
+    sequence_base = 0x7000
+
+    def idmx_frame(
+        body: bytes,
+        *,
+        sequence: int,
+        marker: bool = False,
+    ) -> bytes:
+        marker_payload_type = (0x80 if marker else 0x00) | 0x60
+        idmx_header = (
+            bytes([0x80, marker_payload_type])
+            + sequence.to_bytes(2, "big")
+            + rtp_timestamp.to_bytes(4, "big")
+            + b"\x55\x66\x77\x88"
+        )
+        frame = idmx_header + body
+        return len(frame).to_bytes(4, "little") + frame
+
+    vps = b"\x40\x01vps"
+    first_fu = b"\x62\x01\x93slice-"
+    middle_fu = b"\x62\x01payload-"
+    last_fu = b"\x62\x01tail"
+
+    class FakeStream:
+        def iter_packets(self, *, max_packets: int | None = None) -> list[Any]:
+            assert max_packets == 4
+            return [
+                SimpleNamespace(body=idmx_frame(vps, sequence=sequence_base)),
+                SimpleNamespace(body=idmx_frame(first_fu, sequence=sequence_base + 1)),
+                SimpleNamespace(body=idmx_frame(middle_fu, sequence=sequence_base + 2)),
+                SimpleNamespace(
+                    body=idmx_frame(
+                        last_fu,
+                        sequence=sequence_base + 3,
+                        marker=True,
+                    )
+                ),
+            ]
+
+    output = io.BytesIO()
+
+    copy_local_stream_to_decrypted_mpegts(
+        FakeStream(),
+        output,
+        IDMX_MEDIA_KEY,
+        ffmpeg_path=str(fake_ffmpeg),
+        max_packets=4,
+    )
+
+    assert decrypted_nals == [b"\x26\x01slice-payload-tail"]
+    assert output.getvalue() == (
+        b"hevc:\x00\x00\x00\x01"
+        + vps
+        + b"\x00\x00\x00\x01\x26\x01slice-payload-tail"
+    )
+
+
 def test_copy_local_stream_to_decrypted_mpegts_applies_h264_startup_trim(
     tmp_path,
 ) -> None:
@@ -1633,6 +1980,7 @@ def test_copy_local_stream_to_decrypted_mpegts_wait_for_clean_idr_bounds_output(
         "data = sys.stdin.buffer.read()\n"
         "if b'bad' in data:\n"
         "    sys.stderr.write('decode failed\\n')\n"
+        "    sys.exit(1)\n"
         "elif '-f' in sys.argv and sys.argv[sys.argv.index('-f') + 1] == 'null':\n"
         "    pass\n"
         "else:\n"
@@ -1678,6 +2026,20 @@ def test_copy_local_stream_to_decrypted_mpegts_wait_for_clean_idr_bounds_output(
         "pyezvizapi.local_stream._iter_local_stream_payloads",
         fake_iter_payloads,
     )
+    decrypt_probe_calls: list[list[bytes]] = []
+
+    def fake_decrypt_idmx_local_packets_to_annexb(
+        probe_packets: list[bytes],
+        *args: Any,
+        **kwargs: Any,
+    ) -> bytes:
+        decrypt_probe_calls.append(list(probe_packets))
+        return b"\x00\x00\x00\x01\x65bad"
+
+    monkeypatch.setattr(
+        "pyezvizapi.local_stream._decrypt_idmx_local_packets_to_annexb",
+        fake_decrypt_idmx_local_packets_to_annexb,
+    )
 
     output = io.BytesIO()
     stream = object()
@@ -1698,6 +2060,7 @@ def test_copy_local_stream_to_decrypted_mpegts_wait_for_clean_idr_bounds_output(
     assert seen["stream"] is stream
     assert seen["max_packets"] is None
     assert seen["duration_seconds"] == requested_duration + wait_seconds
+    assert [len(call) for call in decrypt_probe_calls] == [1, 2, 3, 4]
     assert output.getvalue() == (
         b"ts:\x00\x00\x00\x01"
         + sps
@@ -1739,16 +2102,20 @@ def test_copy_local_stream_to_mpegts_remuxes_direct_idmx_hevc_payload(
     pps = b"\x44\x01pps"
     first_fu = b"\x62\x01\x93slice-"
     last_fu = b"\x62\x01\x53payload"
+    second_vps = b"\x40\x01vps2"
+    second_fu = b"\x26\x01clean"
 
     class FakeStream:
         def iter_packets(self, *, max_packets: int | None = None) -> list[Any]:
-            assert max_packets == 5
+            assert max_packets == 7
             return [
                 SimpleNamespace(body=frame(vps, sequence=sequence_base)),
                 SimpleNamespace(body=frame(sps, sequence=sequence_base + 1)),
                 SimpleNamespace(body=frame(pps, sequence=sequence_base + 2)),
                 SimpleNamespace(body=frame(first_fu, sequence=sequence_base + 3)),
                 SimpleNamespace(body=frame(last_fu, sequence=sequence_base + 4)),
+                SimpleNamespace(body=frame(second_vps, sequence=sequence_base + 5)),
+                SimpleNamespace(body=frame(second_fu, sequence=sequence_base + 6)),
             ]
 
     output = io.BytesIO()
@@ -1757,19 +2124,74 @@ def test_copy_local_stream_to_mpegts_remuxes_direct_idmx_hevc_payload(
         FakeStream(),
         output,
         ffmpeg_path=str(fake_ffmpeg),
-        max_packets=5,
+        max_packets=7,
         h264_skip_initial_idr_windows=1,
+    )
+
+    assert output.getvalue() == (
+        b"hevc:\x00\x00\x00\x01"
+        + second_vps
+        + b"\x00\x00\x00\x01"
+        + second_fu
+    )
+
+
+def test_copy_local_stream_to_mpegts_skips_ezviz_hevc_fu_pseudo_headers(
+    tmp_path,
+) -> None:
+    fake_ffmpeg = tmp_path / "fake-ffmpeg"
+    fake_ffmpeg.write_text(
+        "#!/usr/bin/env python3\n"
+        "import sys\n"
+        "codec = sys.argv[sys.argv.index('-f') + 1]\n"
+        "sys.stdout.buffer.write(codec.encode() + b':' + sys.stdin.buffer.read())\n",
+        encoding="utf-8",
+    )
+    fake_ffmpeg.chmod(0o755)
+    rtp_timestamp = 0x3601D1EF
+    sequence_base = 0x7000
+
+    def frame(body: bytes, *, sequence: int, marker: bool = False) -> bytes:
+        marker_payload_type = (0x80 if marker else 0x00) | 0x60
+        return (
+            bytes([0x80, marker_payload_type])
+            + sequence.to_bytes(2, "big")
+            + rtp_timestamp.to_bytes(4, "big")
+            + b"\x55\x66\x77\x88"
+            + body
+        )
+
+    vps = b"\x40\x01vps"
+    first_fu = b"\x62\x01\x93slice-"
+    middle_fu = b"\x62\x01\x26payload-"
+    last_fu = b"\x62\x01\x66tail"
+
+    class FakeStream:
+        def iter_packets(self, *, max_packets: int | None = None) -> list[Any]:
+            assert max_packets == 4
+            return [
+                SimpleNamespace(body=frame(vps, sequence=sequence_base)),
+                SimpleNamespace(body=frame(first_fu, sequence=sequence_base + 1)),
+                SimpleNamespace(body=frame(middle_fu, sequence=sequence_base + 2)),
+                SimpleNamespace(
+                    body=frame(last_fu, sequence=sequence_base + 3, marker=True)
+                ),
+            ]
+
+    output = io.BytesIO()
+
+    copy_local_stream_to_mpegts(
+        FakeStream(),
+        output,
+        ffmpeg_path=str(fake_ffmpeg),
+        max_packets=4,
     )
 
     assert output.getvalue() == (
         b"hevc:\x00\x00\x00\x01"
         + vps
         + b"\x00\x00\x00\x01"
-        + sps
-        + b"\x00\x00\x00\x01"
-        + pps
-        + b"\x00\x00\x00\x01"
-        + b"\x26\x01slice-payload"
+        + b"\x26\x01slice-payload-tail"
     )
 
 
@@ -1828,6 +2250,186 @@ def test_copy_local_stream_to_mpegts_drops_hevc_fu_until_start(
         + vps
         + b"\x00\x00\x00\x01"
         + b"\x26\x01slice-payload"
+    )
+
+
+def test_copy_local_stream_to_mpegts_drops_hevc_fu_on_sequence_gap(
+    tmp_path,
+) -> None:
+    fake_ffmpeg = tmp_path / "fake-ffmpeg"
+    fake_ffmpeg.write_text(
+        "#!/usr/bin/env python3\n"
+        "import sys\n"
+        "codec = sys.argv[sys.argv.index('-f') + 1]\n"
+        "sys.stdout.buffer.write(codec.encode() + b':' + sys.stdin.buffer.read())\n",
+        encoding="utf-8",
+    )
+    fake_ffmpeg.chmod(0o755)
+    rtp_timestamp = 0x3601D1EF
+    sequence_base = 0x7000
+
+    def frame(body: bytes, *, sequence: int) -> bytes:
+        return (
+            b"\x80\x60"
+            + sequence.to_bytes(2, "big")
+            + rtp_timestamp.to_bytes(4, "big")
+            + b"\x55\x66\x77\x88"
+            + body
+        )
+
+    vps = b"\x40\x01vps"
+    broken_start_fu = b"\x62\x01\x93broken-"
+    broken_end_fu = b"\x62\x01\x53tail"
+    valid_start_fu = b"\x62\x01\x93slice-"
+    valid_end_fu = b"\x62\x01\x53payload"
+
+    class FakeStream:
+        def iter_packets(self, *, max_packets: int | None = None) -> list[Any]:
+            assert max_packets == 5
+            return [
+                SimpleNamespace(body=frame(vps, sequence=sequence_base)),
+                SimpleNamespace(body=frame(broken_start_fu, sequence=sequence_base + 1)),
+                SimpleNamespace(body=frame(broken_end_fu, sequence=sequence_base + 3)),
+                SimpleNamespace(body=frame(valid_start_fu, sequence=sequence_base + 4)),
+                SimpleNamespace(body=frame(valid_end_fu, sequence=sequence_base + 5)),
+            ]
+
+    output = io.BytesIO()
+
+    copy_local_stream_to_mpegts(
+        FakeStream(),
+        output,
+        ffmpeg_path=str(fake_ffmpeg),
+        max_packets=5,
+    )
+
+    assert output.getvalue() == (
+        b"hevc:\x00\x00\x00\x01"
+        + vps
+        + b"\x00\x00\x00\x01"
+        + b"\x26\x01slice-payload"
+    )
+
+
+def test_copy_local_stream_to_mpegts_handles_direct_hevc_fu_without_continuation_headers(
+    tmp_path,
+) -> None:
+    fake_ffmpeg = tmp_path / "fake-ffmpeg"
+    fake_ffmpeg.write_text(
+        "#!/usr/bin/env python3\n"
+        "import sys\n"
+        "codec = sys.argv[sys.argv.index('-f') + 1]\n"
+        "sys.stdout.buffer.write(codec.encode() + b':' + sys.stdin.buffer.read())\n",
+        encoding="utf-8",
+    )
+    fake_ffmpeg.chmod(0o755)
+    rtp_timestamp = 0x3601D1EF
+    sequence_base = 0x7000
+
+    def frame(
+        body: bytes,
+        *,
+        sequence: int,
+        marker: bool = False,
+    ) -> bytes:
+        marker_payload_type = (0x80 if marker else 0x00) | 0x60
+        return (
+            bytes([0x80, marker_payload_type])
+            + sequence.to_bytes(2, "big")
+            + rtp_timestamp.to_bytes(4, "big")
+            + b"\x55\x66\x77\x88"
+            + body
+        )
+
+    vps = b"\x40\x01vps"
+    start_fu = b"\x62\x01\x93slice-"
+    middle_fu = b"\x62\x01payload-"
+    end_fu = b"\x62\x01tail"
+
+    class FakeStream:
+        def iter_packets(self, *, max_packets: int | None = None) -> list[Any]:
+            assert max_packets == 4
+            return [
+                SimpleNamespace(body=frame(vps, sequence=sequence_base)),
+                SimpleNamespace(body=frame(start_fu, sequence=sequence_base + 1)),
+                SimpleNamespace(body=frame(middle_fu, sequence=sequence_base + 2)),
+                SimpleNamespace(
+                    body=frame(end_fu, sequence=sequence_base + 3, marker=True)
+                ),
+            ]
+
+    output = io.BytesIO()
+
+    copy_local_stream_to_mpegts(
+        FakeStream(),
+        output,
+        ffmpeg_path=str(fake_ffmpeg),
+        max_packets=4,
+    )
+
+    assert output.getvalue() == (
+        b"hevc:\x00\x00\x00\x01"
+        + vps
+        + b"\x00\x00\x00\x01"
+        + b"\x26\x01slice-payload-tail"
+    )
+
+
+def test_copy_local_stream_to_mpegts_drops_invalid_hevc_type_zero(
+    tmp_path,
+) -> None:
+    fake_ffmpeg = tmp_path / "fake-ffmpeg"
+    fake_ffmpeg.write_text(
+        "#!/usr/bin/env python3\n"
+        "import sys\n"
+        "codec = sys.argv[sys.argv.index('-f') + 1]\n"
+        "sys.stdout.buffer.write(codec.encode() + b':' + sys.stdin.buffer.read())\n",
+        encoding="utf-8",
+    )
+    fake_ffmpeg.chmod(0o755)
+    rtp_timestamp = 0x3601D1EF
+    sequence_base = 0x7000
+
+    def frame(body: bytes, *, sequence: int) -> bytes:
+        return (
+            b"\x80\x60"
+            + sequence.to_bytes(2, "big")
+            + rtp_timestamp.to_bytes(4, "big")
+            + b"\x55\x66\x77\x88"
+            + body
+        )
+
+    invalid_type_zero = b"\x00\x01invalid"
+    vps = b"\x40\x01vps"
+    sps = b"\x42\x01sps"
+    idr = b"\x26\x01idr"
+
+    class FakeStream:
+        def iter_packets(self, *, max_packets: int | None = None) -> list[Any]:
+            assert max_packets == 4
+            return [
+                SimpleNamespace(body=frame(invalid_type_zero, sequence=sequence_base)),
+                SimpleNamespace(body=frame(vps, sequence=sequence_base + 1)),
+                SimpleNamespace(body=frame(sps, sequence=sequence_base + 2)),
+                SimpleNamespace(body=frame(idr, sequence=sequence_base + 3)),
+            ]
+
+    output = io.BytesIO()
+
+    copy_local_stream_to_mpegts(
+        FakeStream(),
+        output,
+        ffmpeg_path=str(fake_ffmpeg),
+        max_packets=4,
+    )
+
+    assert output.getvalue() == (
+        b"hevc:\x00\x00\x00\x01"
+        + vps
+        + b"\x00\x00\x00\x01"
+        + sps
+        + b"\x00\x00\x00\x01"
+        + idr
     )
 
 
@@ -2268,6 +2870,7 @@ def test_copy_local_stream_to_mpegts_can_wait_for_clean_idr_before_duration(
         "data = sys.stdin.buffer.read()\n"
         "if b'bad' in data:\n"
         "    sys.stderr.write('decode failed\\n')\n"
+        "    sys.exit(1)\n"
         "else:\n"
         "    sys.stdout.buffer.write(data)\n",
         encoding="utf-8",
@@ -2375,12 +2978,12 @@ def test_copy_local_stream_to_mpegts_wait_for_clean_idr_bounds_payloads(
         ffmpeg_path: str,
         max_windows: int,
         wait_seconds: float,
-    ) -> bytes:
+    ) -> tuple[bytes, str]:
         seen["collect_packets"] = list(packets)
         seen["collect_duration_seconds"] = duration_seconds
         seen["collect_wait_seconds"] = wait_seconds
         seen["collect_max_windows"] = max_windows
-        return clean_annexb
+        return clean_annexb, "h264"
 
     monkeypatch.setattr(
         "pyezvizapi.local_stream._iter_local_stream_payloads",
@@ -2391,7 +2994,7 @@ def test_copy_local_stream_to_mpegts_wait_for_clean_idr_bounds_payloads(
         lambda payload: True,
     )
     monkeypatch.setattr(
-        "pyezvizapi.local_stream.collect_h264_idmx_annexb_after_first_clean_idr_window",
+        "pyezvizapi.local_stream.collect_idmx_annexb_after_first_clean_video_window",
         fake_collect,
     )
     output = io.BytesIO()
@@ -2420,6 +3023,58 @@ def test_copy_local_stream_to_mpegts_wait_for_clean_idr_bounds_payloads(
     assert seen["collect_max_windows"] == 11
 
 
+def test_copy_local_stream_to_mpegts_wait_for_clean_irap_uses_hevc_remux(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    fake_ffmpeg = tmp_path / "fake-ffmpeg"
+    fake_ffmpeg.write_text(
+        "#!/usr/bin/env python3\n"
+        "import sys\n"
+        "codec = sys.argv[sys.argv.index('-f') + 1]\n"
+        "sys.stdout.buffer.write(codec.encode() + b':' + sys.stdin.buffer.read())\n",
+        encoding="utf-8",
+    )
+    fake_ffmpeg.chmod(0o755)
+    clean_annexb = b"\x00\x00\x00\x01\x40\x01vps\x00\x00\x00\x01\x26\x01clean"
+
+    def fake_collect(
+        packets: Iterator[bytes],
+        *,
+        duration_seconds: float | None,
+        monotonic: Any,
+        ffmpeg_path: str,
+        max_windows: int,
+        wait_seconds: float,
+    ) -> tuple[bytes, str]:
+        assert list(packets) == [b"idmx-payload"]
+        return clean_annexb, "hevc"
+
+    monkeypatch.setattr(
+        "pyezvizapi.local_stream._iter_local_stream_payloads",
+        lambda *args, **kwargs: iter([b"idmx-payload"]),
+    )
+    monkeypatch.setattr(
+        "pyezvizapi.local_stream._looks_like_idmx_local_payload",
+        lambda payload: True,
+    )
+    monkeypatch.setattr(
+        "pyezvizapi.local_stream.collect_idmx_annexb_after_first_clean_video_window",
+        fake_collect,
+    )
+    output = io.BytesIO()
+
+    copy_local_stream_to_mpegts(
+        object(),
+        output,
+        ffmpeg_path=str(fake_ffmpeg),
+        duration_seconds=2.0,
+        h264_wait_for_clean_idr_window=True,
+    )
+
+    assert output.getvalue() == b"hevc:" + clean_annexb
+
+
 def test_collect_h264_idmx_annexb_after_clean_idr_excludes_deadline_packet(
     tmp_path,
 ) -> None:
@@ -2430,6 +3085,7 @@ def test_collect_h264_idmx_annexb_after_clean_idr_excludes_deadline_packet(
         "data = sys.stdin.buffer.read()\n"
         "if b'bad' in data:\n"
         "    sys.stderr.write('decode failed\\n')\n"
+        "    sys.exit(1)\n"
         "else:\n"
         "    sys.stdout.buffer.write(data)\n",
         encoding="utf-8",
@@ -2472,13 +3128,117 @@ def test_collect_h264_idmx_annexb_after_clean_idr_excludes_deadline_packet(
     assert post_deadline_body not in annexb
 
 
+def test_collect_idmx_annexb_after_clean_video_window_selects_hevc_irap(
+    tmp_path,
+) -> None:
+    fake_ffmpeg = tmp_path / "fake-ffmpeg"
+    fake_ffmpeg.write_text(
+        "#!/usr/bin/env python3\n"
+        "import sys\n"
+        "codec = sys.argv[sys.argv.index('-f') + 1]\n"
+        "data = sys.stdin.buffer.read()\n"
+        "if codec == 'h264' or b'bad' in data:\n"
+        "    sys.stderr.write('decode failed\\n')\n"
+        "    sys.exit(1)\n"
+        "else:\n"
+        "    sys.stdout.buffer.write(data)\n",
+        encoding="utf-8",
+    )
+    fake_ffmpeg.chmod(0o755)
+    idmx_header = b"\x80\x60\x02\x03\x04\x05\x06\x07\x55\x66\x77\x88"
+    bad_vps = b"\x40\x01bad-vps"
+    bad_irap = b"\x26\x01bad-irap"
+    clean_vps = b"\x40\x01clean-vps"
+    clean_irap = b"\x26\x01clean-irap"
+    clean_delta = b"\x02\x01clean-delta"
+    next_irap = b"\x26\x01next-irap"
+
+    def idmx_frame(body: bytes) -> bytes:
+        frame = idmx_header + body
+        return len(frame).to_bytes(4, "little") + frame
+
+    annexb, codec = collect_idmx_annexb_after_first_clean_video_window(
+        (
+            idmx_frame(body)
+            for body in (
+                bad_vps,
+                bad_irap,
+                clean_vps,
+                clean_irap,
+                clean_delta,
+                next_irap,
+            )
+        ),
+        duration_seconds=1.0,
+        monotonic=iter([0.0, 0.25, 0.5, 0.75, 1.0, 1.25, 1.5]).__next__,
+        ffmpeg_path=str(fake_ffmpeg),
+        wait_seconds=10.0,
+    )
+
+    assert codec == "hevc"
+    assert annexb == (
+        b"\x00\x00\x00\x01"
+        + clean_vps
+        + b"\x00\x00\x00\x01"
+        + clean_irap
+        + b"\x00\x00\x00\x01"
+        + clean_delta
+        + b"\x00\x00\x00\x01"
+        + next_irap
+    )
+
+
+def test_h264_decode_probe_accepts_success_with_warnings(tmp_path) -> None:
+    fake_ffmpeg = tmp_path / "fake-ffmpeg"
+    fake_ffmpeg.write_text(
+        "#!/usr/bin/env python3\n"
+        "import sys\n"
+        "sys.stdin.buffer.read()\n"
+        "sys.stderr.write('corrupt decoded frame\\n')\n",
+        encoding="utf-8",
+    )
+    fake_ffmpeg.chmod(0o755)
+
+    assert _ffmpeg_h264_decode_errors(
+        b"\x00\x00\x00\x01\x65frame",
+        ffmpeg_path=str(fake_ffmpeg),
+    ) == []
+    assert _ffmpeg_h264_decode_errors(
+        b"\x00\x00\x00\x01\x65frame",
+        ffmpeg_path=str(fake_ffmpeg),
+        accept_success_with_stderr=False,
+    ) == ["corrupt decoded frame"]
+
+
+def test_summarize_hevc_irap_window_keeps_aud_with_parameter_sets() -> None:
+    vps = b"\x40\x01vps"
+    aud = b"\x46\x01aud"
+    irap = b"\x26\x01irap"
+    annexb = (
+        b"\x00\x00\x00\x01"
+        + vps
+        + b"\x00\x00\x00\x01"
+        + aud
+        + b"\x00\x00\x00\x01"
+        + irap
+    )
+
+    summary = summarize_hevc_annexb_irap_windows(annexb)
+    samples = summary["samples"]
+    assert isinstance(samples, list)
+
+    assert samples[0]["start_code_offset"] == 0
+    assert samples[0]["leading_nal_types"] == [32, 35]
+
+
 def test_collect_h264_idmx_annexb_after_clean_idr_times_out(tmp_path) -> None:
     fake_ffmpeg = tmp_path / "fake-ffmpeg"
     fake_ffmpeg.write_text(
         "#!/usr/bin/env python3\n"
         "import sys\n"
         "sys.stdin.buffer.read()\n"
-        "sys.stderr.write('decode failed\\n')\n",
+        "sys.stderr.write('decode failed\\n')\n"
+        "sys.exit(1)\n",
         encoding="utf-8",
     )
     fake_ffmpeg.chmod(0o755)
@@ -2632,6 +3392,69 @@ def test_copy_local_stream_to_mpegts_passes_clean_idr_max_windows(
     assert output.getvalue() == b"\x00\x00\x00\x01" + idr
 
 
+def test_copy_local_stream_to_mpegts_passes_clean_irap_max_windows_for_hevc(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    fake_ffmpeg = tmp_path / "fake-ffmpeg"
+    fake_ffmpeg.write_text(
+        "#!/usr/bin/env python3\n"
+        "import sys\n"
+        "codec = sys.argv[sys.argv.index('-f') + 1]\n"
+        "sys.stdout.buffer.write(codec.encode() + b':' + sys.stdin.buffer.read())\n",
+        encoding="utf-8",
+    )
+    fake_ffmpeg.chmod(0o755)
+    rtp_timestamp = 0x3601D1EF
+    sequence_base = 0x7000
+    irap = b"\x26\x01clean"
+    calls: list[dict[str, Any]] = []
+
+    def idmx_frame(body: bytes, *, sequence: int) -> bytes:
+        frame = (
+            b"\x80\x60"
+            + sequence.to_bytes(2, "big")
+            + rtp_timestamp.to_bytes(4, "big")
+            + b"\x55\x66\x77\x88"
+            + body
+        )
+        return len(frame).to_bytes(4, "little") + frame
+
+    def fake_trim(data: bytes, *, ffmpeg_path: str, max_windows: int) -> bytes:
+        calls.append(
+            {
+                "data": data,
+                "ffmpeg_path": ffmpeg_path,
+                "max_windows": max_windows,
+            }
+        )
+        return data
+
+    class FakeStream:
+        def iter_packets(self, *, max_packets: int | None = None) -> list[Any]:
+            assert max_packets == 1
+            return [SimpleNamespace(body=idmx_frame(irap, sequence=sequence_base))]
+
+    monkeypatch.setattr(
+        "pyezvizapi.local_stream.trim_hevc_annexb_to_first_clean_irap_window",
+        fake_trim,
+    )
+    output = io.BytesIO()
+
+    copy_local_stream_to_mpegts(
+        FakeStream(),
+        output,
+        ffmpeg_path=str(fake_ffmpeg),
+        max_packets=1,
+        h264_trim_to_clean_idr_window=True,
+        h264_clean_idr_max_windows=64,
+    )
+
+    assert calls[0]["ffmpeg_path"] == str(fake_ffmpeg)
+    assert calls[0]["max_windows"] == 64
+    assert output.getvalue() == b"hevc:\x00\x00\x00\x01" + irap
+
+
 def test_copy_local_stream_to_mpegts_rejects_invalid_clean_idr_max_windows() -> None:
     class FakeStream:
         def iter_packets(self, *, max_packets: int | None = None) -> list[Any]:
@@ -2659,7 +3482,8 @@ def test_trim_h264_annexb_to_first_clean_idr_window_uses_ffmpeg(
         "import sys\n"
         "data = sys.stdin.buffer.read()\n"
         "if b'bad' in data:\n"
-        "    sys.stderr.write('decode failed\\n')\n",
+        "    sys.stderr.write('decode failed\\n')\n"
+        "    sys.exit(1)\n",
         encoding="utf-8",
     )
     fake_ffmpeg.chmod(0o755)
@@ -2686,6 +3510,543 @@ def test_trim_h264_annexb_to_first_clean_idr_window_uses_ffmpeg(
     assert trimmed == clean_window
 
 
+def test_trim_h264_annexb_requires_warning_free_decode(tmp_path) -> None:
+    fake_ffmpeg = tmp_path / "fake-ffmpeg"
+    fake_ffmpeg.write_text(
+        "#!/usr/bin/env python3\n"
+        "import sys\n"
+        "data = sys.stdin.buffer.read()\n"
+        "if b'warn' in data:\n"
+        "    sys.stderr.write('corrupt decoded frame\\n')\n"
+        "elif b'bad' in data:\n"
+        "    sys.stderr.write('decode failed\\n')\n"
+        "    sys.exit(1)\n",
+        encoding="utf-8",
+    )
+    fake_ffmpeg.chmod(0o755)
+    data = (
+        b"\x00\x00\x00\x01\x67sps"
+        b"\x00\x00\x00\x01\x68pps"
+        b"\x00\x00\x00\x01\x65warn"
+        b"\x00\x00\x00\x01\x41delta"
+        b"\x00\x00\x00\x01\x67sps2"
+        b"\x00\x00\x00\x01\x68pps2"
+        b"\x00\x00\x00\x01\x65good"
+    )
+
+    trimmed = trim_h264_annexb_to_first_clean_idr_window(
+        data,
+        ffmpeg_path=str(fake_ffmpeg),
+    )
+
+    expected_trimmed = (
+        b"\x00\x00\x00\x01\x67sps2"
+        b"\x00\x00\x00\x01\x68pps2"
+        b"\x00\x00\x00\x01\x65good"
+    )
+    assert trimmed == expected_trimmed
+
+
+def test_trim_h264_annexb_to_first_error_free_suffix_recovers_at_later_idr(
+    tmp_path,
+) -> None:
+    fake_ffmpeg = tmp_path / "fake-ffmpeg"
+    fake_ffmpeg.write_text(
+        "#!/usr/bin/env python3\n"
+        "import sys\n"
+        "data = sys.stdin.buffer.read()\n"
+        "if b'bad-tail' in data:\n"
+        "    sys.stderr.write('error while decoding MB 22 34\\n')\n"
+        "    sys.exit(1)\n",
+        encoding="utf-8",
+    )
+    fake_ffmpeg.chmod(0o755)
+    first = (
+        b"\x00\x00\x00\x01\x67sps"
+        b"\x00\x00\x00\x01\x68pps"
+        b"\x00\x00\x00\x01\x65first-idr"
+        b"\x00\x00\x00\x01\x41bad-tail"
+    )
+    second = (
+        b"\x00\x00\x00\x01\x67sps2"
+        b"\x00\x00\x00\x01\x68pps2"
+        b"\x00\x00\x00\x01\x65second-idr"
+        b"\x00\x00\x00\x01\x41good-tail"
+    )
+
+    trimmed = trim_h264_annexb_to_first_error_free_suffix(
+        first + second,
+        ffmpeg_path=str(fake_ffmpeg),
+    )
+
+    assert trimmed == second
+
+
+def test_h264_strict_decode_probe_ignores_missing_picture_probe_artifact(
+    tmp_path,
+) -> None:
+    fake_ffmpeg = tmp_path / "fake-ffmpeg"
+    fake_ffmpeg.write_text(
+        "#!/usr/bin/env python3\n"
+        "import sys\n"
+        "sys.stdin.buffer.read()\n"
+        "sys.stderr.write('[h264] missing picture in access unit with size 36\\n')\n"
+        "sys.stderr.write('[h264] no frame!\\n')\n"
+        "sys.stderr.write('Decoding error: Invalid data found when processing input\\n')\n",
+        encoding="utf-8",
+    )
+    fake_ffmpeg.chmod(0o755)
+
+    assert _ffmpeg_h264_decode_errors(
+        b"\x00\x00\x00\x01\x67sps\x00\x00\x00\x01\x65idr",
+        ffmpeg_path=str(fake_ffmpeg),
+        accept_success_with_stderr=False,
+    ) == []
+
+
+def test_trim_hevc_annexb_to_first_clean_irap_window_uses_ffmpeg(
+    tmp_path,
+) -> None:
+    fake_ffmpeg = tmp_path / "fake-ffmpeg"
+    fake_ffmpeg.write_text(
+        "#!/usr/bin/env python3\n"
+        "import sys\n"
+        "data = sys.stdin.buffer.read()\n"
+        "if b'bad' in data:\n"
+        "    sys.stderr.write('decode failed\\n')\n"
+        "    sys.exit(1)\n",
+        encoding="utf-8",
+    )
+    fake_ffmpeg.chmod(0o755)
+    data = (
+        b"\x00\x00\x00\x01\x40\x01vps"
+        b"\x00\x00\x00\x01\x42\x01sps"
+        b"\x00\x00\x00\x01\x44\x01pps"
+        b"\x00\x00\x00\x01\x26\x01bad"
+        b"\x00\x00\x00\x01\x02\x01delta"
+        b"\x00\x00\x00\x01\x40\x01vps2"
+        b"\x00\x00\x00\x01\x42\x01sps2"
+        b"\x00\x00\x00\x01\x44\x01pps2"
+        b"\x00\x00\x00\x01\x26\x01good"
+    )
+    clean_window = (
+        b"\x00\x00\x00\x01\x40\x01vps2"
+        b"\x00\x00\x00\x01\x42\x01sps2"
+        b"\x00\x00\x00\x01\x44\x01pps2"
+        b"\x00\x00\x00\x01\x26\x01good"
+    )
+
+    trimmed = trim_hevc_annexb_to_first_clean_irap_window(
+        data,
+        ffmpeg_path=str(fake_ffmpeg),
+    )
+
+    assert trimmed == clean_window
+
+
+def test_trim_hevc_annexb_accepts_successful_ffmpeg_with_stderr(
+    tmp_path,
+) -> None:
+    fake_ffmpeg = tmp_path / "fake-ffmpeg"
+    fake_ffmpeg.write_text(
+        "#!/usr/bin/env python3\n"
+        "import sys\n"
+        "sys.stdin.buffer.read()\n"
+        "sys.stderr.write('non-fatal slice warning\\n')\n",
+        encoding="utf-8",
+    )
+    fake_ffmpeg.chmod(0o755)
+    data = (
+        b"\x00\x00\x00\x01\x40\x01vps"
+        b"\x00\x00\x00\x01\x42\x01sps"
+        b"\x00\x00\x00\x01\x44\x01pps"
+        b"\x00\x00\x00\x01\x26\x01irap"
+    )
+
+    trimmed = trim_hevc_annexb_to_first_clean_irap_window(
+        data,
+        ffmpeg_path=str(fake_ffmpeg),
+    )
+
+    assert trimmed == data
+
+
+def test_trim_hevc_annexb_to_first_error_free_suffix_recovers_at_later_irap(
+    tmp_path,
+) -> None:
+    fake_ffmpeg = tmp_path / "fake-ffmpeg"
+    fake_ffmpeg.write_text(
+        "#!/usr/bin/env python3\n"
+        "import sys\n"
+        "data = sys.stdin.buffer.read()\n"
+        "if b'bad-tail' in data:\n"
+        "    sys.stderr.write('cu_qp_delta outside valid range\\n')\n",
+        encoding="utf-8",
+    )
+    fake_ffmpeg.chmod(0o755)
+    first = (
+        b"\x00\x00\x00\x01\x40\x01vps"
+        b"\x00\x00\x00\x01\x42\x01sps"
+        b"\x00\x00\x00\x01\x44\x01pps"
+        b"\x00\x00\x00\x01\x26\x01first-irap"
+        b"\x00\x00\x00\x01\x02\x01bad-tail"
+    )
+    second = (
+        b"\x00\x00\x00\x01\x40\x01vps2"
+        b"\x00\x00\x00\x01\x42\x01sps2"
+        b"\x00\x00\x00\x01\x44\x01pps2"
+        b"\x00\x00\x00\x01\x26\x01second-irap"
+        b"\x00\x00\x00\x01\x02\x01good-tail"
+    )
+
+    trimmed = trim_hevc_annexb_to_first_error_free_suffix(
+        first + second,
+        ffmpeg_path=str(fake_ffmpeg),
+    )
+
+    assert trimmed == second
+
+
+def test_collect_idmx_annexb_after_first_clean_video_window_trims_hevc_suffix(
+    monkeypatch,
+) -> None:
+    idmx_header = b"\x80\x60\x02\x03\x04\x05\x06\x07\x55\x66\x77\x88"
+
+    def idmx_frame(body: bytes) -> bytes:
+        frame = idmx_header + body
+        return len(frame).to_bytes(4, "little") + frame
+
+    packets = [
+        idmx_frame(b"\x40\x01vps"),
+        idmx_frame(b"\x42\x01sps"),
+        idmx_frame(b"\x44\x01pps"),
+        idmx_frame(b"\x26\x01first-irap"),
+        idmx_frame(b"\x02\x01bad-tail"),
+        idmx_frame(b"\x40\x01vps2"),
+        idmx_frame(b"\x42\x01sps2"),
+        idmx_frame(b"\x44\x01pps2"),
+        idmx_frame(b"\x26\x01second-irap"),
+        idmx_frame(b"\x02\x01good-tail"),
+    ]
+    times = iter([0.0, 0.01, 0.02, 0.03, 0.04, 0.10, 0.11, 0.12, 0.13, 0.14])
+
+    def fake_monotonic() -> float:
+        return next(times, 0.14)
+
+    def fake_errors(
+        data: bytes,
+        *,
+        ffmpeg_path: str,
+        accept_success_with_stderr: bool = True,
+    ) -> list[str]:
+        assert ffmpeg_path == "fake-ffmpeg"
+        first_irap_marker = b"first-irap"
+        if first_irap_marker in data and not accept_success_with_stderr:
+            return ["cu_qp_delta outside valid range"]
+        return []
+
+    monkeypatch.setattr(
+        "pyezvizapi.local_stream._ffmpeg_hevc_decode_errors",
+        fake_errors,
+    )
+    monkeypatch.setattr(
+        "pyezvizapi.local_stream._probe_first_clean_idmx_video_window",
+        lambda *_args, **_kwargs: (0, "hevc", None, SimpleNamespace()),
+    )
+
+    annexb, codec = collect_idmx_annexb_after_first_clean_video_window(
+        packets,
+        duration_seconds=0.05,
+        monotonic=fake_monotonic,
+        ffmpeg_path="fake-ffmpeg",
+    )
+
+    assert codec == "hevc"
+    expected_annexb = (
+        b"\x00\x00\x00\x01\x40\x01vps2"
+        b"\x00\x00\x00\x01\x42\x01sps2"
+        b"\x00\x00\x00\x01\x44\x01pps2"
+        b"\x00\x00\x00\x01\x26\x01second-irap"
+        b"\x00\x00\x00\x01\x02\x01good-tail"
+    )
+    assert annexb == expected_annexb
+
+
+def test_collect_h264_after_clean_idr_waits_for_clean_final_suffix(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    idmx_header = b"\x80\x60\x02\x03\x04\x05\x06\x07\x55\x66\x77\x88"
+
+    def idmx_frame(body: bytes) -> bytes:
+        frame = idmx_header + body
+        return len(frame).to_bytes(4, "little") + frame
+
+    packets = [idmx_frame(b"\x65first-idr")] + [
+        idmx_frame(b"\x41tail-%02d" % index) for index in range(34)
+    ]
+    times = iter([0.0, 0.02, *([0.05] * 33)])
+
+    monkeypatch.setattr(
+        "pyezvizapi.local_stream._try_first_clean_h264_annexb_idr_window_offset",
+        lambda *_args, **_kwargs: SimpleNamespace(
+            start_offset=0,
+            idr_start_offset=0,
+            first_decode_error=None,
+        ),
+    )
+    trim_calls = 0
+
+    def fake_trim(data: bytes, *, ffmpeg_path: str, max_windows: int) -> bytes:
+        nonlocal trim_calls
+        assert ffmpeg_path == "fake-ffmpeg"
+        assert max_windows == 7
+        trim_calls += 1
+        if trim_calls == 1:
+            raise PyEzvizError("first suffix still corrupt")
+        return data
+
+    monkeypatch.setattr(
+        "pyezvizapi.local_stream.trim_h264_annexb_to_first_error_free_suffix",
+        fake_trim,
+    )
+
+    annexb = collect_h264_idmx_annexb_after_first_clean_idr_window(
+        packets,
+        duration_seconds=0.01,
+        monotonic=lambda: next(times, 0.03),
+        ffmpeg_path="fake-ffmpeg",
+        max_windows=7,
+    )
+
+    assert trim_calls == 2
+    expected_tail_marker = b"tail-31"
+    assert expected_tail_marker in annexb
+
+
+def test_collect_decrypted_h264_after_clean_idr_retries_final_suffix_clear_first(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    packets = [b"packet-%02d" % index for index in range(35)]
+    times = iter([0.0, 0.02, *([0.05] * 33)])
+    annexb_by_count: list[int] = []
+
+    monkeypatch.setattr(
+        "pyezvizapi.local_stream._try_first_clean_h264_annexb_idr_window_offset",
+        lambda *_args, **_kwargs: SimpleNamespace(
+            start_offset=0,
+            idr_start_offset=0,
+            first_decode_error=None,
+        ),
+    )
+    monkeypatch.setattr(
+        "pyezvizapi.local_stream._h264_annexb_packet_index_for_offset",
+        lambda *_args, **_kwargs: 0,
+    )
+
+    def fake_packets_to_annexb(collected: list[bytes]) -> bytes:
+        annexb_by_count.append(len(collected))
+        return b"annexb-count-%d" % len(collected)
+
+    monkeypatch.setattr(
+        "pyezvizapi.local_stream._idmx_local_packets_to_h264_annexb",
+        fake_packets_to_annexb,
+    )
+    trim_calls = 0
+
+    def fake_trim(data: bytes, *, ffmpeg_path: str, max_windows: int) -> bytes:
+        nonlocal trim_calls
+        assert ffmpeg_path == "fake-ffmpeg"
+        assert max_windows == 5
+        trim_calls += 1
+        if trim_calls == 1:
+            raise PyEzvizError("deadline suffix still corrupt")
+        return data
+
+    monkeypatch.setattr(
+        "pyezvizapi.local_stream.trim_h264_annexb_to_first_error_free_suffix",
+        fake_trim,
+    )
+
+    annexb = collect_decrypted_h264_idmx_annexb_after_first_clean_idr_window(
+        packets,
+        IDMX_MEDIA_KEY,
+        duration_seconds=0.01,
+        monotonic=lambda: next(times, 0.03),
+        ffmpeg_path="fake-ffmpeg",
+        max_windows=5,
+    )
+
+    assert trim_calls == 2
+    expected_annexb = b"annexb-count-33"
+    assert annexb == expected_annexb
+    assert annexb_by_count[:2] == [1, 33]
+
+
+def test_collect_h264_after_clean_idr_propagates_dirty_final_suffix(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    idmx_header = b"\x80\x60\x02\x03\x04\x05\x06\x07\x55\x66\x77\x88"
+
+    def idmx_frame(body: bytes) -> bytes:
+        frame = idmx_header + body
+        return len(frame).to_bytes(4, "little") + frame
+
+    packets = [idmx_frame(b"\x65first-idr")] + [
+        idmx_frame(b"\x41tail-%02d" % index) for index in range(34)
+    ]
+    times = iter([0.0, 0.02, *([0.03] * 33)])
+    monkeypatch.setattr(
+        "pyezvizapi.local_stream._try_first_clean_h264_annexb_idr_window_offset",
+        lambda *_args, **_kwargs: SimpleNamespace(
+            start_offset=0,
+            idr_start_offset=0,
+            first_decode_error=None,
+        ),
+    )
+    monkeypatch.setattr(
+        "pyezvizapi.local_stream.trim_h264_annexb_to_first_error_free_suffix",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            PyEzvizError("still dirty")
+        ),
+    )
+
+    with pytest.raises(PyEzvizError, match="still dirty"):
+        collect_h264_idmx_annexb_after_first_clean_idr_window(
+            packets,
+            duration_seconds=0.0,
+            monotonic=lambda: next(times, 0.05),
+            ffmpeg_path="fake-ffmpeg",
+            wait_seconds=0.03,
+        )
+
+
+def test_collect_idmx_after_clean_video_times_out_on_dirty_final_suffix(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    packets = [b"packet-%02d" % index for index in range(35)]
+    times = iter([0.0, 0.02, *([0.05] * 33)])
+    monkeypatch.setattr(
+        "pyezvizapi.local_stream._probe_first_clean_idmx_video_window",
+        lambda *_args, **_kwargs: (
+            0,
+            "h264",
+            None,
+            SimpleNamespace(start_offset=0, first_decode_error=None),
+        ),
+    )
+    monkeypatch.setattr(
+        "pyezvizapi.local_stream._idmx_local_packets_to_h264_annexb",
+        lambda collected: b"annexb-count-%d" % len(collected),
+    )
+    monkeypatch.setattr(
+        "pyezvizapi.local_stream.trim_h264_annexb_to_first_error_free_suffix",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            PyEzvizError("still dirty")
+        ),
+    )
+
+    with pytest.raises(PyEzvizError, match="clean final H264 suffix"):
+        collect_idmx_annexb_after_first_clean_video_window(
+            packets,
+            duration_seconds=0.0,
+            monotonic=lambda: next(times, 0.05),
+            ffmpeg_path="fake-ffmpeg",
+            wait_seconds=0.03,
+        )
+
+
+def test_collect_decrypted_h264_after_clean_idr_times_out_on_dirty_final_suffix(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    packets = [b"packet-%02d" % index for index in range(35)]
+    times = iter([0.0, 0.02, *([0.05] * 33)])
+    monkeypatch.setattr(
+        "pyezvizapi.local_stream._try_first_clean_h264_annexb_idr_window_offset",
+        lambda *_args, **_kwargs: SimpleNamespace(
+            start_offset=0,
+            idr_start_offset=0,
+            first_decode_error=None,
+        ),
+    )
+    monkeypatch.setattr(
+        "pyezvizapi.local_stream._h264_annexb_packet_index_for_offset",
+        lambda *_args, **_kwargs: 0,
+    )
+    monkeypatch.setattr(
+        "pyezvizapi.local_stream._idmx_local_packets_to_h264_annexb",
+        lambda collected: b"annexb-count-%d" % len(collected),
+    )
+    monkeypatch.setattr(
+        "pyezvizapi.local_stream.trim_h264_annexb_to_first_error_free_suffix",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            PyEzvizError("still dirty")
+        ),
+    )
+
+    with pytest.raises(PyEzvizError, match=r"clean final H\.264 suffix"):
+        collect_decrypted_h264_idmx_annexb_after_first_clean_idr_window(
+            packets,
+            IDMX_MEDIA_KEY,
+            duration_seconds=0.0,
+            monotonic=lambda: next(times, 0.05),
+            ffmpeg_path="fake-ffmpeg",
+            wait_seconds=0.03,
+        )
+
+
+def test_clean_video_collectors_validate_window_settings() -> None:
+    packets = [b"packet"]
+
+    with pytest.raises(PyEzvizError, match="duration_seconds is required"):
+        collect_h264_idmx_annexb_after_first_clean_idr_window(
+            packets,
+            duration_seconds=None,
+        )
+    with pytest.raises(PyEzvizError, match="wait_seconds cannot be negative"):
+        collect_h264_idmx_annexb_after_first_clean_idr_window(
+            packets,
+            duration_seconds=1.0,
+            wait_seconds=-1.0,
+        )
+    with pytest.raises(PyEzvizError, match="max_windows must be positive"):
+        collect_h264_idmx_annexb_after_first_clean_idr_window(
+            packets,
+            duration_seconds=1.0,
+            max_windows=0,
+        )
+    with pytest.raises(PyEzvizError, match="duration_seconds is required"):
+        collect_idmx_annexb_after_first_clean_video_window(
+            packets,
+            duration_seconds=None,
+        )
+    with pytest.raises(PyEzvizError, match="wait_seconds cannot be negative"):
+        collect_idmx_annexb_after_first_clean_video_window(
+            packets,
+            duration_seconds=1.0,
+            wait_seconds=-1.0,
+        )
+    with pytest.raises(PyEzvizError, match="duration_seconds is required"):
+        collect_decrypted_h264_idmx_annexb_after_first_clean_idr_window(
+            packets,
+            IDMX_MEDIA_KEY,
+            duration_seconds=None,
+        )
+    with pytest.raises(PyEzvizError, match="wait_seconds cannot be negative"):
+        collect_decrypted_h264_idmx_annexb_after_first_clean_idr_window(
+            packets,
+            IDMX_MEDIA_KEY,
+            duration_seconds=1.0,
+            wait_seconds=-1.0,
+        )
+    with pytest.raises(PyEzvizError, match="max_windows must be positive"):
+        collect_decrypted_h264_idmx_annexb_after_first_clean_idr_window(
+            packets,
+            IDMX_MEDIA_KEY,
+            duration_seconds=1.0,
+            max_windows=0,
+        )
+
+
 def test_copy_local_stream_to_mpegts_models_command_port_h264_fu_a(tmp_path) -> None:
     fake_ffmpeg = tmp_path / "fake-ffmpeg"
     fake_ffmpeg.write_text(
@@ -2695,12 +4056,19 @@ def test_copy_local_stream_to_mpegts_models_command_port_h264_fu_a(tmp_path) -> 
         encoding="utf-8",
     )
     fake_ffmpeg.chmod(0o755)
-    idmx_header = b"\x80\x60\x5d\x5c\x7d\x52\x2a\x3e\x55\x66\x77\x88"
+    rtp_timestamp = 0x7D522A3E
+    sequence_base = 0x5D5C
     first_fu = b"\x7c\x85\x88\x80\x00\x00\x1a\x48native-first"
     next_fu = b"\x7c\x05native-middle"
     last_fu = b"\x7c\x45native-last"
 
-    def idmx_frame(body: bytes) -> bytes:
+    def idmx_frame(body: bytes, *, sequence: int) -> bytes:
+        idmx_header = (
+            b"\x80\x60"
+            + sequence.to_bytes(2, "big")
+            + rtp_timestamp.to_bytes(4, "big")
+            + b"\x55\x66\x77\x88"
+        )
         frame = idmx_header + body
         return len(frame).to_bytes(4, "little") + frame
 
@@ -2709,9 +4077,9 @@ def test_copy_local_stream_to_mpegts_models_command_port_h264_fu_a(tmp_path) -> 
             assert max_packets == 1
             return [
                 SimpleNamespace(
-                    body=idmx_frame(first_fu)
-                    + idmx_frame(next_fu)
-                    + idmx_frame(last_fu)
+                    body=idmx_frame(first_fu, sequence=sequence_base)
+                    + idmx_frame(next_fu, sequence=sequence_base + 1)
+                    + idmx_frame(last_fu, sequence=sequence_base + 2)
                 )
             ]
 
@@ -2733,6 +4101,64 @@ def test_copy_local_stream_to_mpegts_models_command_port_h264_fu_a(tmp_path) -> 
     )
 
 
+def test_copy_local_stream_to_mpegts_drops_h264_fu_a_on_sequence_gap(
+    tmp_path,
+) -> None:
+    fake_ffmpeg = tmp_path / "fake-ffmpeg"
+    fake_ffmpeg.write_text(
+        "#!/usr/bin/env python3\n"
+        "import sys\n"
+        "sys.stdout.buffer.write(b'ts:' + sys.stdin.buffer.read())\n",
+        encoding="utf-8",
+    )
+    fake_ffmpeg.chmod(0o755)
+    rtp_timestamp = 0x7D522A3E
+    sequence_base = 0x5D5C
+
+    def idmx_frame(body: bytes, *, sequence: int) -> bytes:
+        idmx_header = (
+            b"\x80\x60"
+            + sequence.to_bytes(2, "big")
+            + rtp_timestamp.to_bytes(4, "big")
+            + b"\x55\x66\x77\x88"
+        )
+        frame = idmx_header + body
+        return len(frame).to_bytes(4, "little") + frame
+
+    broken_start_fu = b"\x7c\x85broken-first"
+    broken_end_fu = b"\x7c\x45broken-last"
+    valid_start_fu = b"\x7c\x85native-first"
+    valid_end_fu = b"\x7c\x45native-last"
+
+    class FakeStream:
+        def iter_packets(self, *, max_packets: int | None = None) -> list[Any]:
+            assert max_packets == 1
+            return [
+                SimpleNamespace(
+                    body=idmx_frame(broken_start_fu, sequence=sequence_base)
+                    + idmx_frame(broken_end_fu, sequence=sequence_base + 2)
+                    + idmx_frame(valid_start_fu, sequence=sequence_base + 3)
+                    + idmx_frame(valid_end_fu, sequence=sequence_base + 4)
+                )
+            ]
+
+    output = io.BytesIO()
+
+    copy_local_stream_to_mpegts(
+        FakeStream(),
+        output,
+        ffmpeg_path=str(fake_ffmpeg),
+        max_packets=1,
+    )
+
+    assert output.getvalue() == (
+        b"ts:\x00\x00\x00\x01"
+        b"\x65"
+        + valid_start_fu[2:]
+        + valid_end_fu[2:]
+    )
+
+
 def test_copy_local_stream_to_mpegts_flattens_command_port_idmx_aggregates(
     tmp_path,
 ) -> None:
@@ -2745,22 +4171,29 @@ def test_copy_local_stream_to_mpegts_flattens_command_port_idmx_aggregates(
     )
     fake_ffmpeg.chmod(0o755)
     outer_header = b"\x80\x60\x5d\x5c\x7d\x52\x2a\x3e\x55\x66\x77\x88"
-    inner_header = b"\xa0\x60\xb7\x12\x16\x54\x77\xeb\x55\x66\x77\x88"
+    rtp_timestamp = 0x165477EB
+    sequence_base = 0xB712
     sps = b"\x67\x4d\x00\x29"
     pps = b"\x68\xee\x38\x80"
     first_fu = b"\x7c\x85aggregate-first"
     last_fu = b"\x7c\x45aggregate-last"
 
-    def inner_frame(body: bytes) -> bytes:
+    def inner_frame(body: bytes, *, sequence: int) -> bytes:
+        inner_header = (
+            b"\xa0\x60"
+            + sequence.to_bytes(2, "big")
+            + rtp_timestamp.to_bytes(4, "big")
+            + b"\x55\x66\x77\x88"
+        )
         frame = inner_header + body
         return len(frame).to_bytes(4, "little") + frame
 
     aggregate_body = (
         b"\x00\x10aggregate-sidecar"
-        + inner_frame(sps)
-        + inner_frame(pps)
-        + inner_frame(first_fu)
-        + inner_frame(last_fu)
+        + inner_frame(sps, sequence=sequence_base)
+        + inner_frame(pps, sequence=sequence_base + 1)
+        + inner_frame(first_fu, sequence=sequence_base + 2)
+        + inner_frame(last_fu, sequence=sequence_base + 3)
     )
     outer_frame = outer_header + aggregate_body
     packet = len(outer_frame).to_bytes(4, "little") + outer_frame
@@ -2888,6 +4321,11 @@ def test_summarize_idmx_h264_local_packets_reports_sanitized_frame_shapes() -> N
             },
         ],
         "truncated": False,
+        "incomplete_fu_a": 0,
+        "discarded_fu_a_fragments": 0,
+        "sequence_gap_count": 0,
+        "timestamp_change_count": 0,
+        "restart_count": 0,
     }
 
 

--- a/tests/test_local_stream.py
+++ b/tests/test_local_stream.py
@@ -1697,6 +1697,70 @@ def test_copy_local_stream_to_decrypted_mpegts_prefers_direct_hevc_before_h264_e
     )
 
 
+def test_copy_local_stream_to_decrypted_mpegts_honors_h264_encrypted_header_without_hevc_evidence(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_ffmpeg = tmp_path / "fake-ffmpeg"
+    fake_ffmpeg.write_text(
+        "#!/usr/bin/env python3\n"
+        "import sys\n"
+        "codec = sys.argv[sys.argv.index('-f') + 1]\n"
+        "sys.stdout.buffer.write(codec.encode() + b':' + sys.stdin.buffer.read())\n",
+        encoding="utf-8",
+    )
+    fake_ffmpeg.chmod(0o755)
+    decrypted_nals: list[bytes] = []
+
+    def fake_decrypt_h264_nal_prefix(
+        nal: bytes,
+        _aes_key: bytes,
+        *,
+        nalu_header_size: int = 1,
+    ) -> bytes:
+        assert nalu_header_size == 0
+        decrypted_nals.append(nal)
+        return b"\x65plain-" + nal[1:]
+
+    def fail_hevc_decrypt(nal: bytes, _aes_key: bytes) -> bytes:
+        raise AssertionError(f"ambiguous H.264 encrypted-header hit HEVC: {nal!r}")
+
+    monkeypatch.setattr(
+        "pyezvizapi.local_stream._decrypt_h264_nal_prefix",
+        fake_decrypt_h264_nal_prefix,
+    )
+    monkeypatch.setattr(
+        "pyezvizapi.local_stream._decrypt_hevc_nal_prefix",
+        fail_hevc_decrypt,
+    )
+    idmx_header = b"\x80\x60\x02\x03\x04\x05\x06\x07\x55\x66\x77\x88"
+    ambiguous_encrypted_idr = b"\x02\x01cipher"
+
+    def idmx_frame(body: bytes) -> bytes:
+        frame = idmx_header + body
+        return len(frame).to_bytes(4, "little") + frame
+
+    class FakeStream:
+        def iter_packets(self, *, max_packets: int | None = None) -> list[Any]:
+            assert max_packets == 1
+            return [SimpleNamespace(body=idmx_frame(ambiguous_encrypted_idr))]
+
+    output = io.BytesIO()
+
+    copy_local_stream_to_decrypted_mpegts(
+        FakeStream(),
+        output,
+        IDMX_MEDIA_KEY,
+        ffmpeg_path=str(fake_ffmpeg),
+        max_packets=1,
+        nalu_header_size=0,
+    )
+
+    expected_output = b"h264:\x00\x00\x00\x01\x65plain-\x01cipher"
+    assert decrypted_nals == [ambiguous_encrypted_idr]
+    assert output.getvalue() == expected_output
+
+
 def test_copy_local_stream_to_decrypted_mpegts_decrypts_h264_idmx_payload(
     tmp_path,
     monkeypatch: pytest.MonkeyPatch,
@@ -3917,6 +3981,47 @@ def test_collect_idmx_annexb_after_first_clean_video_window_trims_hevc_suffix(
         b"\x00\x00\x00\x01\x02\x01good-tail"
     )
     assert annexb == expected_annexb
+
+
+def test_collect_idmx_annexb_after_first_clean_video_window_starts_hevc_duration_at_irap(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    idmx_header = b"\x80\x60\x02\x03\x04\x05\x06\x07\x55\x66\x77\x88"
+
+    def idmx_frame(body: bytes) -> bytes:
+        frame = idmx_header + body
+        return len(frame).to_bytes(4, "little") + frame
+
+    first_irap_marker = b"first-irap"
+    second_irap_marker = b"second-irap"
+    late_tail_marker = b"late-tail"
+    packets = [
+        idmx_frame(b"\x40\x01vps"),
+        idmx_frame(b"\x42\x01sps"),
+        idmx_frame(b"\x44\x01pps"),
+        idmx_frame(b"\x26\x01" + first_irap_marker),
+        idmx_frame(b"\x02\x01first-tail"),
+        idmx_frame(b"\x26\x01" + second_irap_marker),
+        idmx_frame(b"\x02\x01" + late_tail_marker),
+    ]
+    times = iter([0.0, 0.01, 0.02, 0.03, 0.04, 0.13, 0.14])
+
+    monkeypatch.setattr(
+        "pyezvizapi.local_stream._ffmpeg_hevc_decode_errors",
+        lambda *_args, **_kwargs: [],
+    )
+
+    annexb, codec = collect_idmx_annexb_after_first_clean_video_window(
+        packets,
+        duration_seconds=0.05,
+        monotonic=lambda: next(times, 0.14),
+        ffmpeg_path="fake-ffmpeg",
+    )
+
+    assert codec == "hevc"
+    assert first_irap_marker in annexb
+    assert second_irap_marker not in annexb
+    assert late_tail_marker not in annexb
 
 
 def test_collect_h264_after_clean_idr_waits_for_clean_final_suffix(

--- a/tests/test_local_stream.py
+++ b/tests/test_local_stream.py
@@ -1620,6 +1620,82 @@ def test_copy_local_stream_to_decrypted_mpegts_decrypts_direct_hevc_idmx_payload
     )
 
 
+def test_copy_local_stream_to_decrypted_mpegts_prefers_direct_hevc_before_h264_encrypted_header_fallback(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_ffmpeg = tmp_path / "fake-ffmpeg"
+    fake_ffmpeg.write_text(
+        "#!/usr/bin/env python3\n"
+        "import sys\n"
+        "codec = sys.argv[sys.argv.index('-f') + 1]\n"
+        "sys.stdout.buffer.write(codec.encode() + b':' + sys.stdin.buffer.read())\n",
+        encoding="utf-8",
+    )
+    fake_ffmpeg.chmod(0o755)
+    decrypted_hevc_nals: list[bytes] = []
+
+    def fake_decrypt_hevc_nal_prefix(nal: bytes, _aes_key: bytes) -> bytes:
+        decrypted_hevc_nals.append(nal)
+        return nal
+
+    def fail_h264_decrypt(
+        _nal: bytes,
+        _aes_key: bytes,
+        *,
+        nalu_header_size: int = 1,
+    ) -> bytes:
+        raise AssertionError("direct HEVC should not hit H.264 fallback")
+
+    monkeypatch.setattr(
+        "pyezvizapi.local_stream._decrypt_hevc_nal_prefix",
+        fake_decrypt_hevc_nal_prefix,
+    )
+    monkeypatch.setattr(
+        "pyezvizapi.local_stream._decrypt_h264_nal_prefix",
+        fail_h264_decrypt,
+    )
+    rtp_timestamp = 0x3601D1EF
+    sequence_base = 0x7000
+
+    def idmx_frame(body: bytes, *, sequence: int) -> bytes:
+        idmx_header = (
+            b"\x80\x60"
+            + sequence.to_bytes(2, "big")
+            + rtp_timestamp.to_bytes(4, "big")
+            + b"\x55\x66\x77\x88"
+        )
+        frame = idmx_header + body
+        return len(frame).to_bytes(4, "little") + frame
+
+    vps = b"\x40\x01vps"
+    trail_r = b"\x02\x01trail"
+
+    class FakeStream:
+        def iter_packets(self, *, max_packets: int | None = None) -> list[Any]:
+            assert max_packets == 2
+            return [
+                SimpleNamespace(body=idmx_frame(vps, sequence=sequence_base)),
+                SimpleNamespace(body=idmx_frame(trail_r, sequence=sequence_base + 1)),
+            ]
+
+    output = io.BytesIO()
+
+    copy_local_stream_to_decrypted_mpegts(
+        FakeStream(),
+        output,
+        IDMX_MEDIA_KEY,
+        ffmpeg_path=str(fake_ffmpeg),
+        max_packets=2,
+        nalu_header_size=0,
+    )
+
+    assert decrypted_hevc_nals == [trail_r]
+    assert output.getvalue() == (
+        b"hevc:\x00\x00\x00\x01" + vps + b"\x00\x00\x00\x01" + trail_r
+    )
+
+
 def test_copy_local_stream_to_decrypted_mpegts_decrypts_h264_idmx_payload(
     tmp_path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tools/apk-re/README.md
+++ b/tools/apk-re/README.md
@@ -114,6 +114,18 @@ Summarize native before/after transform pairs:
 ./tools/apk-re/frida/compare-idmx-dumps /tmp/ezviz-hook-dumps
 ```
 
+Classify all stream-hook binary samples by boundary and media shape:
+
+```bash
+./tools/apk-re/frida/analyze-stream-dumps /tmp/ezviz-hook-dumps
+./tools/apk-re/frida/analyze-stream-dumps --json /tmp/ezviz-hook-dumps
+```
+
+Use this after a live-view run to compare `java-playm4-open-stream-head`,
+`java-playm4-input`, `HCPreview.*`, and `PlayCtrl/SystemTransform.IDMX*`
+samples without printing raw video bytes. The report only includes sizes,
+hashes, RTP/IDMX/NAL metadata, and codec classification.
+
 Trigger a cloud-storage clip download through the gadget-loaded app:
 
 ```bash

--- a/tools/apk-re/README.md
+++ b/tools/apk-re/README.md
@@ -89,6 +89,22 @@ network Frida server, pass the host:
 EZVIZ_FRIDA_HOST=192.0.2.56:27042 ./tools/apk-re/frida/run-ezviz-stream-hook
 ```
 
+If the production app blocks `frida -U -f`/PID attach but a Frida Gadget build
+is already listening, attach directly to Gadget:
+
+```bash
+frida -H 127.0.0.1:27046 -n Gadget -l tools/apk-re/frida/ezviz-stream-transform-hook.js
+```
+
+For fragile live-preview runs, create a temporary device flag before attaching
+to skip Java hooks and keep only the native stream/decrypt taps:
+
+```bash
+adb shell 'touch /data/local/tmp/ezviz-native-only.flag'
+frida -H 127.0.0.1:27046 -n Gadget -l tools/apk-re/frida/ezviz-stream-transform-hook.js
+adb shell 'rm -f /data/local/tmp/ezviz-native-only.flag'
+```
+
 Check target readiness before capture:
 
 ```bash
@@ -124,7 +140,10 @@ Classify all stream-hook binary samples by boundary and media shape:
 Use this after a live-view run to compare `java-playm4-open-stream-head`,
 `java-playm4-input`, `HCPreview.*`, and `PlayCtrl/SystemTransform.IDMX*`
 samples without printing raw video bytes. The report only includes sizes,
-hashes, RTP/IDMX/NAL metadata, and codec classification.
+hashes, RTP/IDMX/NAL metadata, and codec classification. When both
+`playctrl-idmx-aes-frame-before` and `playctrl-idmx-aes-frame-after` dumps are
+present, the JSON/text report also includes an `aes_frame_pairs` count for
+matched, same-size, and changed before/after buffers.
 
 Trigger a cloud-storage clip download through the gadget-loaded app:
 

--- a/tools/apk-re/bin/hcnetsdk-command-live-check
+++ b/tools/apk-re/bin/hcnetsdk-command-live-check
@@ -140,6 +140,30 @@ def _parse_args() -> argparse.Namespace:
         help="Do not pass --hcnetsdk-h264-skip-initial-idr-windows 1",
     )
     parser.add_argument(
+        "--wait-for-clean-idr-window",
+        action="store_true",
+        help=(
+            "Pass --hcnetsdk-h264-wait-for-clean-idr-window so H.264 command-port "
+            "captures start remuxing after the first acceptable IDR window"
+        ),
+    )
+    parser.add_argument(
+        "--clean-idr-wait-seconds",
+        default="60",
+        help=(
+            "Value for --hcnetsdk-h264-clean-idr-wait-seconds when "
+            "--wait-for-clean-idr-window is used (default: 60)"
+        ),
+    )
+    parser.add_argument(
+        "--clean-idr-max-windows",
+        default="32",
+        help=(
+            "Value for --hcnetsdk-h264-clean-idr-max-windows when "
+            "--wait-for-clean-idr-window is used (default: 32)"
+        ),
+    )
+    parser.add_argument(
         "--decrypt-video",
         action="store_true",
         help="Pass the inventory encryption key to decrypt encrypted IDMX video payloads",
@@ -161,6 +185,16 @@ def _parse_args() -> argparse.Namespace:
         "--include-metadata-in-stdout",
         action="store_true",
         help="Include full packet metadata in stdout. The report file always keeps full metadata.",
+    )
+    parser.add_argument(
+        "--save-sampled-packets",
+        action="store_true",
+        help=(
+            "Save the bounded HCNetSDK command-port media packet sample used by "
+            "metadata summaries as a raw-dump-compatible .sampled-packets.bin sidecar. "
+            "The sidecar is sampled diagnostic packet context and may include packets "
+            "outside the final clean suffix selected for the MPEG-TS output."
+        ),
     )
     return parser.parse_args()
 
@@ -318,6 +352,22 @@ def _ffprobe(ffprobe_path: str, capture_path: Path) -> subprocess.CompletedProce
     )
 
 
+def _ffmpeg_decode(ffmpeg_path: str, capture_path: Path) -> subprocess.CompletedProcess[bytes]:
+    return _run(
+        [
+            ffmpeg_path,
+            "-v",
+            "error",
+            "-i",
+            str(capture_path),
+            "-f",
+            "null",
+            "-",
+        ],
+        cwd=REPO_ROOT,
+    )
+
+
 def _stream_summary(ffprobe_stdout: bytes) -> dict[str, Any]:
     try:
         payload = json.loads(ffprobe_stdout.decode("utf-8"))
@@ -341,6 +391,18 @@ def _stream_summary(ffprobe_stdout: bytes) -> dict[str, Any]:
         "streams": streams,
         "format_duration": (payload.get("format") or {}).get("duration"),
     }
+
+
+def _has_h264_video_stream(stream_summary: dict[str, Any]) -> bool:
+    streams = stream_summary.get("streams")
+    if not isinstance(streams, list):
+        return False
+    return any(
+        isinstance(stream, dict)
+        and stream.get("codec_type") == "video"
+        and stream.get("codec_name") == "h264"
+        for stream in streams
+    )
 
 
 def _diagnose_save_failure(stderr_tail: str, metadata_path: Path) -> str:
@@ -390,6 +452,7 @@ def _save_command(
     host: str,
     capture_path: Path,
     metadata_path: Path,
+    sampled_packets_path: Path | None = None,
 ) -> list[str]:
     command = [
         args.python,
@@ -425,6 +488,13 @@ def _save_command(
         "--hcnetsdk-command-metadata-output",
         str(metadata_path),
     ]
+    if sampled_packets_path is not None:
+        command.extend(
+            [
+                "--hcnetsdk-command-sampled-packets-output",
+                str(sampled_packets_path),
+            ]
+        )
     if args.local_ip:
         command.extend(["--hcnetsdk-local-ip", args.local_ip])
     if args.decrypt_video and item.enc_key:
@@ -432,6 +502,16 @@ def _save_command(
         command.extend(["--media-key", item.enc_key])
     if not args.no_skip_initial_idr:
         command.extend(["--hcnetsdk-h264-skip-initial-idr-windows", "1"])
+    if args.wait_for_clean_idr_window:
+        command.append("--hcnetsdk-h264-wait-for-clean-idr-window")
+        command.extend(
+            [
+                "--hcnetsdk-h264-clean-idr-wait-seconds",
+                args.clean_idr_wait_seconds,
+                "--hcnetsdk-h264-clean-idr-max-windows",
+                args.clean_idr_max_windows,
+            ]
+        )
     return command
 
 
@@ -497,7 +577,7 @@ def _redact_existing_artifact(path: Path, item: CameraInventoryItem) -> None:
     _write_redacted_artifact(path, path.read_bytes(), item)
 
 
-def _check_item(
+def _check_item(  # noqa: PLR0915
     *,
     args: argparse.Namespace,
     item: CameraInventoryItem,
@@ -509,6 +589,7 @@ def _check_item(
     base = output_dir / f"camera-{camera_index:02d}-{_safe_name(item.name)}"
     credential_attempts = _credential_attempts(args, item)
     include_attempt_suffix = len(credential_attempts) > 1
+    save_sampled_packets = bool(getattr(args, "save_sampled_packets", False))
     result: dict[str, Any] = {
         "name": item.name,
         "serial": _public_serial(),
@@ -550,6 +631,11 @@ def _check_item(
                             host=host,
                             capture_path=_artifact_path(attempt_base, ".ts"),
                             metadata_path=_artifact_path(attempt_base, ".metadata.json"),
+                            sampled_packets_path=(
+                                _artifact_path(attempt_base, ".sampled-packets.bin")
+                                if save_sampled_packets
+                                else None
+                            ),
                         )
                     ),
                 }
@@ -577,6 +663,11 @@ def _check_item(
         attempt_base = _attempt_base(base, credential_source, include_suffix=include_attempt_suffix)
         capture_path = _artifact_path(attempt_base, ".ts")
         metadata_path = _artifact_path(attempt_base, ".metadata.json")
+        sampled_packets_path = (
+            _artifact_path(attempt_base, ".sampled-packets.bin")
+            if save_sampled_packets
+            else None
+        )
         stderr_path = _artifact_path(attempt_base, ".save.stderr.txt")
         stdout_path = _artifact_path(attempt_base, ".save.stdout.json")
         command = _save_command(
@@ -586,6 +677,7 @@ def _check_item(
             host=host,
             capture_path=capture_path,
             metadata_path=metadata_path,
+            sampled_packets_path=sampled_packets_path,
         )
         artifacts = {
             "capture": str(capture_path),
@@ -593,6 +685,8 @@ def _check_item(
             "save_stdout": str(stdout_path),
             "save_stderr": str(stderr_path),
         }
+        if sampled_packets_path is not None:
+            artifacts["sampled_packets"] = str(sampled_packets_path)
         save = _run(command, cwd=REPO_ROOT)
         _write_redacted_artifact(stdout_path, save.stdout, item)
         _write_redacted_artifact(stderr_path, save.stderr, item)
@@ -658,17 +752,68 @@ def _check_item(
         )
         return result
 
+    decode = _ffmpeg_decode(args.ffmpeg_path, capture_path)
+    decode_stderr_path = _artifact_path(attempt_base, ".decode.stderr.txt")
+    decode_stdout_path = _artifact_path(attempt_base, ".decode.stdout.txt")
+    decode_stderr_path.write_bytes(decode.stderr)
+    decode_stdout_path.write_bytes(decode.stdout)
+    artifacts.update(
+        {
+            "decode_stdout": str(decode_stdout_path),
+            "decode_stderr": str(decode_stderr_path),
+        }
+    )
+    decode_stderr_tail = _tail_text(decode.stderr)
+    stream_summary = _stream_summary(probe.stdout)
+    h264_decode_warnings_are_nonfatal = (
+        decode.returncode == 0
+        and bool(decode_stderr_tail.strip())
+        and _has_h264_video_stream(stream_summary)
+    )
+    if (
+        decode.returncode != 0
+        or (decode_stderr_tail.strip() and not h264_decode_warnings_are_nonfatal)
+    ):
+        result.update(
+            {
+                "ok": False,
+                "stage": "decode",
+                "credential_source": credential_source,
+                "credential_attempts": failed_attempts,
+                "returncode": decode.returncode,
+                "diagnosis": (
+                    "decode_failed" if decode.returncode != 0 else "decode_warnings"
+                ),
+                "stderr_tail": _redact_text(decode_stderr_tail, item),
+                "capture_size": capture_path.stat().st_size if capture_path.exists() else 0,
+                "metadata": _redact_sensitive(_read_metadata(metadata_path), item),
+                "artifacts": artifacts,
+                **stream_summary,
+            }
+        )
+        return result
+
     result.update(
         {
             "ok": True,
             "stage": "complete",
             "credential_source": credential_source,
             "credential_attempts": failed_attempts,
-            "diagnosis": "playable_mpegts",
+            "returncode": decode.returncode,
+            "diagnosis": (
+                "playable_mpegts_with_h264_decode_warnings"
+                if h264_decode_warnings_are_nonfatal
+                else "playable_mpegts"
+            ),
+            "stderr_tail": (
+                _redact_text(decode_stderr_tail, item)
+                if h264_decode_warnings_are_nonfatal
+                else ""
+            ),
             "capture_size": capture_path.stat().st_size,
             "metadata": _redact_sensitive(_read_metadata(metadata_path), item),
             "artifacts": artifacts,
-            **_stream_summary(probe.stdout),
+            **stream_summary,
         }
     )
     return result

--- a/tools/apk-re/bin/hcnetsdk-command-live-check
+++ b/tools/apk-re/bin/hcnetsdk-command-live-check
@@ -500,7 +500,7 @@ def _save_command(
     if args.decrypt_video and item.enc_key:
         command.append("--decrypt-video")
         command.extend(["--media-key", item.enc_key])
-    if not args.no_skip_initial_idr:
+    if not args.no_skip_initial_idr and not args.wait_for_clean_idr_window:
         command.extend(["--hcnetsdk-h264-skip-initial-idr-windows", "1"])
     if args.wait_for_clean_idr_window:
         command.append("--hcnetsdk-h264-wait-for-clean-idr-window")

--- a/tools/apk-re/frida/analyze-stream-dumps
+++ b/tools/apk-re/frida/analyze-stream-dumps
@@ -1,0 +1,251 @@
+#!/usr/bin/env python3
+"""Classify EZVIZ stream Frida binary dumps without printing raw media bytes."""
+
+from __future__ import annotations
+
+import argparse
+from collections import Counter, defaultdict
+import hashlib
+import json
+from pathlib import Path
+import re
+import sys
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO_ROOT))
+
+try:
+    from pyezvizapi.exceptions import PyEzvizError  # noqa: E402
+    from pyezvizapi.local_stream import (  # noqa: E402
+        _idmx_local_packets_to_annexb_with_codec,
+        _iter_idmx_local_frames,
+        _looks_like_idmx_local_payload,
+        summarize_h264_annexb_units,
+        summarize_hevc_annexb_irap_windows,
+        summarize_idmx_h264_local_packets,
+    )
+    from pyezvizapi.stream import MPEG_PS_START_CODE, rtp_payload  # noqa: E402
+except ModuleNotFoundError:
+    PyEzvizError = Exception  # type: ignore[misc,assignment]
+    MPEG_PS_START_CODE = b"\x00\x00\x01\xba"
+    _idmx_local_packets_to_annexb_with_codec = None
+    _iter_idmx_local_frames = None
+    _looks_like_idmx_local_payload = None
+    summarize_h264_annexb_units = None
+    summarize_hevc_annexb_irap_windows = None
+    summarize_idmx_h264_local_packets = None
+    rtp_payload = None
+
+DUMP_RE = re.compile(
+    r"^(?P<ts>\d+)-(?P<seq>\d+)-(?P<label>.+)-(?P<size>\d+)\.bin$"
+)
+ANNEX_B_LONG_START_CODE = b"\x00\x00\x00\x01"
+ANNEX_B_SHORT_START_CODE = b"\x00\x00\x01"
+RTP_VERSION_MASK = 0xC0
+RTP_VERSION_2 = 0x80
+IDMX_LOCAL_FRAME_SENTINEL = b"\x55\x66\x77\x88"
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("dump_dir", type=Path)
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit machine-readable JSON instead of a text report.",
+    )
+    parser.add_argument(
+        "--max-files-per-label",
+        type=int,
+        default=12,
+        help="Maximum per-label file samples to include in detail output.",
+    )
+    return parser.parse_args()
+
+
+def _dump_metadata(path: Path) -> dict[str, Any]:
+    match = DUMP_RE.match(path.name)
+    if not match:
+        return {
+            "path": str(path),
+            "label": "<unknown>",
+            "timestamp": None,
+            "sequence": None,
+        }
+    return {
+        "path": str(path),
+        "label": match.group("label"),
+        "timestamp": match.group("ts"),
+        "sequence": int(match.group("seq")),
+        "declared_size": int(match.group("size")),
+    }
+
+
+def _looks_like_rtp(data: bytes) -> bool:
+    if len(data) < 12:
+        return False
+    return data[0] & RTP_VERSION_MASK == RTP_VERSION_2
+
+
+def _looks_like_idmx(data: bytes) -> bool:
+    if _looks_like_idmx_local_payload is not None:
+        return bool(_looks_like_idmx_local_payload(data))
+    return IDMX_LOCAL_FRAME_SENTINEL in data
+
+
+def _iter_idmx_frames(data: bytes) -> list[bytes]:
+    if _iter_idmx_local_frames is None:
+        return []
+    return list(_iter_idmx_local_frames(data))
+
+
+def _annexb_start_count(data: bytes) -> int:
+    return data.count(ANNEX_B_LONG_START_CODE) + data.count(ANNEX_B_SHORT_START_CODE)
+
+
+def _classify_bytes(data: bytes) -> dict[str, Any]:
+    result: dict[str, Any] = {
+        "size": len(data),
+        "sha256": hashlib.sha256(data).hexdigest(),
+        "kind": "unknown",
+        "annexb_start_codes": _annexb_start_count(data),
+        "idmx_frame_count": 0,
+    }
+    if not data:
+        result["kind"] = "empty"
+        return result
+    if data.startswith(MPEG_PS_START_CODE):
+        result["kind"] = "mpeg_ps"
+        return result
+    if data.startswith(b"IMKH"):
+        result["kind"] = "hcnetsdk_imkh_header"
+        return result
+    if _looks_like_idmx(data):
+        frames = _iter_idmx_frames(data)
+        result["kind"] = "idmx"
+        result["idmx_frame_count"] = len(frames)
+        if summarize_idmx_h264_local_packets is not None:
+            result["idmx_summary"] = summarize_idmx_h264_local_packets(
+                [data],
+                max_frames=8,
+            )
+        if _idmx_local_packets_to_annexb_with_codec is not None:
+            try:
+                annexb, codec = _idmx_local_packets_to_annexb_with_codec([data])
+            except PyEzvizError as err:
+                result["annexb_error"] = str(err)
+            else:
+                result["annexb_codec"] = codec
+                result["annexb_size"] = len(annexb)
+                result["annexb_sha256"] = hashlib.sha256(annexb).hexdigest()
+                if codec == "h264" and summarize_h264_annexb_units is not None:
+                    result["annexb_summary"] = summarize_h264_annexb_units(
+                        annexb,
+                        max_units=8,
+                    )
+                elif summarize_hevc_annexb_irap_windows is not None:
+                    result["annexb_summary"] = summarize_hevc_annexb_irap_windows(
+                        annexb,
+                        max_windows=8,
+                    )
+        return result
+    if _looks_like_rtp(data):
+        result["kind"] = "rtp"
+        if rtp_payload is None:
+            result["rtp_error"] = "pyezvizapi dependencies unavailable"
+            return result
+        try:
+            payload = rtp_payload(data)
+        except PyEzvizError as err:
+            result["rtp_error"] = str(err)
+            return result
+        result["rtp_payload_size"] = len(payload)
+        result["rtp_payload_sha256"] = hashlib.sha256(payload).hexdigest()
+        nested = _classify_bytes(payload)
+        result["rtp_payload_kind"] = nested["kind"]
+        if nested["kind"] in {"idmx", "mpeg_ps"}:
+            result["rtp_payload_summary"] = nested
+        return result
+    if _annexb_start_count(data):
+        result["kind"] = "annexb"
+        if summarize_h264_annexb_units is not None:
+            result["h264_summary"] = summarize_h264_annexb_units(data, max_units=8)
+        return result
+    return result
+
+
+def _analyze_dump_dir(dump_dir: Path, *, max_files_per_label: int) -> dict[str, Any]:
+    files = sorted(path for path in dump_dir.rglob("*.bin") if path.is_file())
+    labels: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    kind_counts: Counter[str] = Counter()
+    for path in files:
+        metadata = _dump_metadata(path)
+        data = path.read_bytes()
+        detail = {**metadata, **_classify_bytes(data)}
+        labels[str(metadata["label"])].append(detail)
+        kind_counts[str(detail["kind"])] += 1
+
+    label_summaries: dict[str, Any] = {}
+    for label, entries in sorted(labels.items()):
+        label_summaries[label] = {
+            "count": len(entries),
+            "kinds": dict(Counter(str(entry["kind"]) for entry in entries)),
+            "samples": entries[:max_files_per_label],
+            "truncated": len(entries) > max_files_per_label,
+        }
+    return {
+        "dump_dir": str(dump_dir),
+        "file_count": len(files),
+        "kind_counts": dict(kind_counts),
+        "labels": label_summaries,
+    }
+
+
+def _print_text_report(report: dict[str, Any]) -> None:
+    print(f"dump_dir: {report['dump_dir']}")
+    print(f"file_count: {report['file_count']}")
+    print(f"kinds: {report['kind_counts']}")
+    print()
+    labels = report["labels"]
+    assert isinstance(labels, dict)
+    for label, label_report in labels.items():
+        print(f"{label}: {label_report['count']} file(s), kinds={label_report['kinds']}")
+        for sample in label_report["samples"]:
+            parts = [
+                f"seq={sample.get('sequence')}",
+                f"kind={sample['kind']}",
+                f"size={sample['size']}",
+                f"sha256={sample['sha256'][:16]}",
+            ]
+            if sample.get("rtp_payload_kind"):
+                parts.append(f"rtp_payload={sample['rtp_payload_kind']}")
+            if sample.get("idmx_frame_count"):
+                parts.append(f"idmx_frames={sample['idmx_frame_count']}")
+            if sample.get("annexb_codec"):
+                parts.append(
+                    f"annexb={sample['annexb_codec']}:{sample.get('annexb_size')}"
+                )
+            if sample.get("annexb_error"):
+                parts.append(f"annexb_error={sample['annexb_error']}")
+            print("  " + " ".join(parts))
+        if label_report["truncated"]:
+            print("  ...")
+        print()
+
+
+def main() -> int:
+    args = _parse_args()
+    report = _analyze_dump_dir(
+        args.dump_dir,
+        max_files_per_label=args.max_files_per_label,
+    )
+    if args.json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        _print_text_report(report)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/apk-re/frida/analyze-stream-dumps
+++ b/tools/apk-re/frida/analyze-stream-dumps
@@ -16,8 +16,8 @@ REPO_ROOT = Path(__file__).resolve().parents[3]
 sys.path.insert(0, str(REPO_ROOT))
 
 try:
-    from pyezvizapi.exceptions import PyEzvizError  # noqa: E402
-    from pyezvizapi.local_stream import (  # noqa: E402
+    from pyezvizapi.exceptions import PyEzvizError
+    from pyezvizapi.local_stream import (
         _idmx_local_packets_to_annexb_with_codec,
         _iter_idmx_local_frames,
         _looks_like_idmx_local_payload,
@@ -25,7 +25,7 @@ try:
         summarize_hevc_annexb_irap_windows,
         summarize_idmx_h264_local_packets,
     )
-    from pyezvizapi.stream import MPEG_PS_START_CODE, rtp_payload  # noqa: E402
+    from pyezvizapi.stream import MPEG_PS_START_CODE, rtp_payload
 except ModuleNotFoundError:
     PyEzvizError = Exception  # type: ignore[misc,assignment]
     MPEG_PS_START_CODE = b"\x00\x00\x01\xba"
@@ -104,7 +104,47 @@ def _annexb_start_count(data: bytes) -> int:
     return data.count(ANNEX_B_LONG_START_CODE) + data.count(ANNEX_B_SHORT_START_CODE)
 
 
-def _classify_bytes(data: bytes) -> dict[str, Any]:
+def _iter_annexb_nal_headers(data: bytes) -> list[bytes]:
+    headers: list[bytes] = []
+    offset = 0
+    while offset < len(data) and len(headers) < 256:
+        three = data.find(ANNEX_B_SHORT_START_CODE, offset)
+        four = data.find(ANNEX_B_LONG_START_CODE, offset)
+        if three < 0 and four < 0:
+            break
+        if four >= 0 and (three < 0 or four <= three):
+            start_code_offset = four
+            start_code_size = 4
+        else:
+            start_code_offset = three
+            start_code_size = 3
+        nal_offset = start_code_offset + start_code_size
+        if nal_offset < len(data):
+            headers.append(data[nal_offset : nal_offset + 2])
+        offset = nal_offset + 1
+    return headers
+
+
+def _detect_annexb_codec(data: bytes) -> str:
+    h264_score = 0
+    hevc_score = 0
+    for header in _iter_annexb_nal_headers(data):
+        if not header:
+            continue
+        h264_type = header[0] & 0x1F
+        hevc_type = (header[0] >> 1) & 0x3F
+        if h264_type in {1, 5, 6, 7, 8, 9}:
+            h264_score += 2 if h264_type in {5, 7, 8} else 1
+        if hevc_type in {32, 33, 34}:
+            hevc_score += 3
+        elif 16 <= hevc_type <= 23:
+            hevc_score += 2
+        elif 0 <= hevc_type <= 31:
+            hevc_score += 1
+    return "hevc" if hevc_score > h264_score else "h264"
+
+
+def _classify_bytes(data: bytes) -> dict[str, Any]:  # noqa: PLR0911, PLR0912
     result: dict[str, Any] = {
         "size": len(data),
         "sha256": hashlib.sha256(data).hexdigest(),
@@ -169,10 +209,84 @@ def _classify_bytes(data: bytes) -> dict[str, Any]:
         return result
     if _annexb_start_count(data):
         result["kind"] = "annexb"
-        if summarize_h264_annexb_units is not None:
-            result["h264_summary"] = summarize_h264_annexb_units(data, max_units=8)
+        codec = _detect_annexb_codec(data)
+        result["annexb_codec"] = codec
+        result["annexb_size"] = len(data)
+        if codec == "h264" and summarize_h264_annexb_units is not None:
+            result["annexb_summary"] = summarize_h264_annexb_units(
+                data,
+                max_units=8,
+            )
+        elif codec == "hevc" and summarize_hevc_annexb_irap_windows is not None:
+            result["annexb_summary"] = summarize_hevc_annexb_irap_windows(
+                data,
+                max_windows=8,
+            )
         return result
     return result
+
+
+def _summarize_aes_frame_pairs(
+    labels: dict[str, list[dict[str, Any]]],
+    *,
+    max_samples: int,
+) -> dict[str, Any] | None:
+    before = labels.get("playctrl-idmx-aes-frame-before")
+    after = labels.get("playctrl-idmx-aes-frame-after")
+    if not before or not after:
+        return None
+
+    after_by_seq = {
+        entry.get("sequence"): entry
+        for entry in after
+        if isinstance(entry.get("sequence"), int)
+    }
+    matched = 0
+    same_size = 0
+    changed = 0
+    samples: list[dict[str, Any]] = []
+    for index, before_entry in enumerate(before):
+        sequence = before_entry.get("sequence")
+        after_entry = (
+            after_by_seq.get(sequence + 1)
+            if isinstance(sequence, int)
+            else None
+        )
+        if after_entry is None and index < len(after):
+            after_entry = after[index]
+        if after_entry is None:
+            continue
+        matched += 1
+        pair_same_size = before_entry.get("size") == after_entry.get("size")
+        pair_changed = before_entry.get("sha256") != after_entry.get("sha256")
+        same_size += int(pair_same_size)
+        changed += int(pair_changed)
+        if len(samples) < max_samples:
+            samples.append(
+                {
+                    "before_sequence": sequence,
+                    "after_sequence": after_entry.get("sequence"),
+                    "size": before_entry.get("size"),
+                    "same_size": pair_same_size,
+                    "changed": pair_changed,
+                    "before_kind": before_entry.get("kind"),
+                    "after_kind": after_entry.get("kind"),
+                    "before_codec": before_entry.get("annexb_codec"),
+                    "after_codec": after_entry.get("annexb_codec"),
+                    "before_sha256": str(before_entry.get("sha256", ""))[:16],
+                    "after_sha256": str(after_entry.get("sha256", ""))[:16],
+                }
+            )
+
+    return {
+        "before_count": len(before),
+        "after_count": len(after),
+        "matched_count": matched,
+        "same_size_count": same_size,
+        "changed_count": changed,
+        "samples": samples,
+        "truncated": matched > len(samples),
+    }
 
 
 def _analyze_dump_dir(dump_dir: Path, *, max_files_per_label: int) -> dict[str, Any]:
@@ -191,26 +305,56 @@ def _analyze_dump_dir(dump_dir: Path, *, max_files_per_label: int) -> dict[str, 
         label_summaries[label] = {
             "count": len(entries),
             "kinds": dict(Counter(str(entry["kind"]) for entry in entries)),
+            "codecs": dict(
+                Counter(
+                    str(entry["annexb_codec"])
+                    for entry in entries
+                    if entry.get("annexb_codec")
+                )
+            ),
             "samples": entries[:max_files_per_label],
             "truncated": len(entries) > max_files_per_label,
         }
-    return {
+    report: dict[str, Any] = {
         "dump_dir": str(dump_dir),
         "file_count": len(files),
         "kind_counts": dict(kind_counts),
         "labels": label_summaries,
     }
+    aes_frame_pairs = _summarize_aes_frame_pairs(
+        labels,
+        max_samples=max_files_per_label,
+    )
+    if aes_frame_pairs is not None:
+        report["aes_frame_pairs"] = aes_frame_pairs
+    return report
 
 
 def _print_text_report(report: dict[str, Any]) -> None:
     print(f"dump_dir: {report['dump_dir']}")
     print(f"file_count: {report['file_count']}")
     print(f"kinds: {report['kind_counts']}")
+    if report.get("aes_frame_pairs"):
+        pairs = report["aes_frame_pairs"]
+        print(
+            "aes_frame_pairs: "
+            f"matched={pairs['matched_count']} "
+            f"same_size={pairs['same_size_count']} "
+            f"changed={pairs['changed_count']}"
+        )
     print()
     labels = report["labels"]
     assert isinstance(labels, dict)
     for label, label_report in labels.items():
-        print(f"{label}: {label_report['count']} file(s), kinds={label_report['kinds']}")
+        codec_suffix = (
+            f", codecs={label_report['codecs']}"
+            if label_report.get("codecs")
+            else ""
+        )
+        print(
+            f"{label}: {label_report['count']} file(s), "
+            f"kinds={label_report['kinds']}{codec_suffix}"
+        )
         for sample in label_report["samples"]:
             parts = [
                 f"seq={sample.get('sequence')}",

--- a/tools/apk-re/frida/ezviz-stream-transform-hook.js
+++ b/tools/apk-re/frida/ezviz-stream-transform-hook.js
@@ -4,8 +4,11 @@
  * Usage:
  *   frida -U -f com.ezviz -l tools/apk-re/frida/ezviz-stream-transform-hook.js --no-pause
  *
- * This script is intentionally diagnostic-only. It logs stream secret-key calls
- * and dumps small samples around the native demux/decrypt boundary so an
+ * Device flags:
+ *   /data/local/tmp/ezviz-native-only.flag  skip Java hooks for fragile live-preview runs
+ *
+ * This script is intentionally diagnostic-only. It logs redacted secret-key
+ * call metadata and dumps small samples around the native demux/decrypt boundary so an
  * encrypted VTM/MPEG-PS packet can be compared with PlayCtrl/SystemTransform
  * output from the official SDK path.
  */
@@ -17,11 +20,15 @@ const CALLBACK_DUMP_LIMIT = 64 * 1024;
 const JAVA_DECODE_DUMP_LIMIT = 512 * 1024;
 const HEX_LIMIT = 64;
 const MAX_DUMPS_PER_LABEL = deviceFlagExists("/data/local/tmp/ezviz-deep-idmx-dump.flag") ? 512 : 24;
+const NATIVE_ONLY = deviceFlagExists("/data/local/tmp/ezviz-native-only.flag");
 const LOG_SECRET_VALUES = false;
-const DUMP_SECRET_KEYS_RAW = deviceFlagExists("/data/local/tmp/ezviz-dump-media-keys.flag");
 const installed = new Set();
 const installedJavaDecodeClasses = new Set();
+const installedJavaStreamClasses = new Set();
 let dumpDir = "/sdcard/Download/ezviz-hook";
+if (NATIVE_ONLY) {
+  dumpDir = "/storage/emulated/0/Android/data/com.ezviz/files/ezviz-hook";
+}
 let dumpSeq = 0;
 const dumpCounts = {};
 const logCounts = {};
@@ -60,34 +67,6 @@ function bytesToHex(ptr, len) {
   }
 }
 
-function fingerprintBytes(ptr, len) {
-  if (ptr.isNull() || len <= 0) {
-    return "<none>";
-  }
-  try {
-    const data = new Uint8Array(ptr.readByteArray(len));
-    let hash = 2166136261;
-    for (let i = 0; i < data.length; i++) {
-      hash ^= data[i];
-      hash = imul32(hash, 16777619) >>> 0;
-    }
-    return "fnv32=" + leftPad(hash.toString(16), 8, "0");
-  } catch (err) {
-    return "<fingerprint-failed " + err + ">";
-  }
-}
-
-function imul32(a, b) {
-  if (typeof Math.imul === "function") {
-    return Math.imul(a, b);
-  }
-  const ah = (a >>> 16) & 0xffff;
-  const al = a & 0xffff;
-  const bh = (b >>> 16) & 0xffff;
-  const bl = b & 0xffff;
-  return ((al * bl) + (((ah * bl + al * bh) << 16) >>> 0)) | 0;
-}
-
 function leftPad(value, width, fill) {
   let text = String(value);
   while (text.length < width) {
@@ -101,9 +80,22 @@ function secretBytes(ptr, len) {
     return "<null>";
   }
   if (!LOG_SECRET_VALUES) {
-    return `<redacted len=${len} ${fingerprintBytes(ptr, len)}>`;
+    return `<redacted len=${len}>`;
   }
   return bytesToHex(ptr, len);
+}
+
+function nativeSecretBytes(ptr, lenArg) {
+  let len = 0;
+  try {
+    len = lenArg.toInt32();
+  } catch (_) {
+    return `<redacted ptr=${ptr} len=<invalid>>`;
+  }
+  if (len <= 0 || len > 4096) {
+    return `<redacted ptr=${ptr} len=${len}>`;
+  }
+  return secretBytes(ptr, len);
 }
 
 function secretCString(ptr) {
@@ -220,6 +212,56 @@ function dumpJavaByteArray(label, value, len) {
     console.log(`[dump] ${label} count=${dumpCounts[label]} len=${len} saved=${capped} path=${path}`);
   } catch (err) {
     console.log(`[dump-failed] ${label} len=${len} path=${path} err=${err}`);
+  }
+}
+
+function describeJavaMethodArg(value) {
+  if (value === null || value === undefined) {
+    return "<null>";
+  }
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+  if (typeof value === "string") {
+    return `<string len=${value.length}>`;
+  }
+  const className = safeJavaClassName(value);
+  if (className === "[B") {
+    return `byte[] len=${value.length || 0}`;
+  }
+  if (className === "java.lang.String") {
+    return `<java-string len=${safeJavaValue(value).length}>`;
+  }
+  if (className === "<null>") {
+    return "<null>";
+  }
+  return `<${className}>`;
+}
+
+function dumpFirstJavaByteArrayArg(label, argsLike) {
+  for (let i = 0; i < argsLike.length; i++) {
+    const value = argsLike[i];
+    if (value === null || value === undefined) {
+      continue;
+    }
+    let className = "";
+    try {
+      className = safeJavaClassName(value);
+    } catch (_) {
+      className = "";
+    }
+    if (className !== "[B") {
+      continue;
+    }
+    let len = value.length || 0;
+    if (i + 1 < argsLike.length) {
+      const nextLen = Number(argsLike[i + 1]);
+      if (Number.isFinite(nextLen) && nextLen > 0) {
+        len = Math.min(len, nextLen);
+      }
+    }
+    dumpJavaByteArray(label, value, len);
+    return;
   }
 }
 
@@ -404,6 +446,220 @@ function hookPointerDataFunction(moduleName, exportName, label, dumpArgIndex, le
   });
 }
 
+function retString(retval) {
+  try {
+    return `${retval} int=${retval.toInt32()}`;
+  } catch (_) {
+    return String(retval);
+  }
+}
+
+function hookArgTraceFunction(moduleName, exportName, label, argCount, logLimit) {
+  hookExport(moduleName, exportName, {
+    onEnter(args) {
+      if (!shouldLog(`[native] ${label}`, logLimit || 64)) {
+        return;
+      }
+      const parts = [];
+      for (let i = 0; i < argCount; i++) {
+        parts.push(`arg${i}=${args[i]}`);
+      }
+      console.log(`[native] ${label} ${parts.join(" ")}`);
+    },
+    onLeave(retval) {
+      if (shouldLog(`[native] ${label}:ret`, logLimit || 64)) {
+        console.log(`[native] ${label} ret=${retString(retval)}`);
+      }
+    },
+  });
+}
+
+function hookCallbackSetter(moduleName, exportName, label, cbIndex, dumpArgIndex, lenArgIndex, logLimit) {
+  hookExport(moduleName, exportName, {
+    onEnter(args) {
+      if (shouldLog(`[cb] ${label}`, logLimit || 64)) {
+        console.log(
+          `[cb] ${label} handle=${args[0]} cb=${args[cbIndex]} user=${args[2]} extra=${args[3]}`,
+        );
+      }
+      hookCallbackPointer(label, args[cbIndex], dumpArgIndex, lenArgIndex);
+    },
+    onLeave(retval) {
+      if (shouldLog(`[cb] ${label}:ret`, logLimit || 64)) {
+        console.log(`[cb] ${label} ret=${retString(retval)}`);
+      }
+    },
+  });
+}
+
+function hookLoggingCallbackSetter(moduleName, exportName, label, cbIndex, logLimit) {
+  hookExport(moduleName, exportName, {
+    onEnter(args) {
+      if (shouldLog(`[cb] ${label}`, logLimit || 64)) {
+        console.log(
+          `[cb] ${label} handle=${args[0]} cb=${args[cbIndex]} user=${args[2]} extra=${args[3]}`,
+        );
+      }
+      hookLoggingCallbackPointer(label, args[cbIndex], logLimit || 64);
+    },
+    onLeave(retval) {
+      if (shouldLog(`[cb] ${label}:ret`, logLimit || 64)) {
+        console.log(`[cb] ${label} ret=${retString(retval)}`);
+      }
+    },
+  });
+}
+
+function parseOutputDataInfoCandidate(infoPtr, offset, detail) {
+  const dataPtr = infoPtr.readPointer();
+  const len = infoPtr.add(offset).readU32();
+  if (dataPtr.isNull() || len <= 0 || len > 16 * 1024 * 1024) {
+    return null;
+  }
+  const result = {
+    dataPtr,
+    len,
+    layout: `ptr${offset}`,
+    type: detail ? infoPtr.add(offset + 4).readU16() : infoPtr.add(offset + 4).readU32(),
+  };
+  if (detail) {
+    result.frame = infoPtr.add(offset + 6).readU16();
+    result.ts = infoPtr.add(offset + 8).readU32();
+    result.mark = infoPtr.add(offset + 16).readU16();
+    result.ver = infoPtr.add(offset + 18).readU16();
+  } else {
+    result.flag = infoPtr.add(offset + 8).readU32();
+  }
+  return result;
+}
+
+function parseOutputDataInfo(infoPtr, detail) {
+  const offsets = [];
+  [Process.pointerSize, 4].forEach((offset) => {
+    if (!offsets.includes(offset)) {
+      offsets.push(offset);
+    }
+  });
+  for (const offset of offsets) {
+    try {
+      const candidate = parseOutputDataInfoCandidate(infoPtr, offset, detail);
+      if (candidate !== null) {
+        return candidate;
+      }
+    } catch (_) {
+      // Try the next ABI layout candidate.
+    }
+  }
+  return {
+    dataPtr: infoPtr.readPointer(),
+    len: 0,
+    layout: "unknown",
+    type: null,
+  };
+}
+
+function dumpOutputDataInfo(label, infoPtr, detail, logLimit) {
+  if (infoPtr === null || infoPtr === undefined || infoPtr.isNull()) {
+    return;
+  }
+  const logLabel = `[out] ${label}`;
+  if (!shouldLog(logLabel, logLimit || 128)) {
+    return;
+  }
+  try {
+    const parsed = parseOutputDataInfo(infoPtr, detail);
+    const dataPtr = parsed.dataPtr;
+    const len = parsed.len;
+    const fields = [`info=${infoPtr}`, `layout=${parsed.layout}`, `data=${dataPtr}`, `len=${len}`];
+    if (detail) {
+      fields.push(`type=${parsed.type}`);
+      fields.push(`frame=${parsed.frame}`);
+      fields.push(`ts=${parsed.ts}`);
+      fields.push(`mark=${parsed.mark}`);
+      fields.push(`ver=${parsed.ver}`);
+    } else {
+      fields.push(`type=${parsed.type}`);
+      fields.push(`flag=${parsed.flag}`);
+    }
+    if (!dataPtr.isNull() && len > 0) {
+      fields.push(`head=${bytesToHex(dataPtr, len)}`);
+      dumpBytes(
+        label.replace(/[^A-Za-z0-9_.-]+/g, "-"),
+        dataPtr,
+        Math.min(len, CALLBACK_DUMP_LIMIT),
+      );
+    }
+    console.log(`${logLabel} ${fields.join(" ")}`);
+  } catch (err) {
+    console.log(`${logLabel} parse-failed info=${infoPtr} err=${err}`);
+  }
+}
+
+function hookOutputDataInfoFunction(moduleName, exportName, label, detail, logLimit) {
+  hookExport(moduleName, exportName, {
+    onEnter(args) {
+      dumpOutputDataInfo(label, args[0], detail, logLimit);
+    },
+  });
+}
+
+function hookOutputDataInfoArgFunction(moduleName, exportName, label, infoArgIndex, detail, logLimit) {
+  hookExport(moduleName, exportName, {
+    onEnter(args) {
+      dumpOutputDataInfo(label, args[infoArgIndex], detail, logLimit);
+    },
+  });
+}
+
+function hookOutputDataInfoCallbackPointer(label, cbPtr, detail) {
+  if (cbPtr === null || cbPtr === undefined || cbPtr.isNull()) {
+    return;
+  }
+  const key = `output-info-callback:${label}:${cbPtr}`;
+  if (installed.has(key)) {
+    return;
+  }
+  try {
+    Interceptor.attach(cbPtr, {
+      onEnter(args) {
+        dumpOutputDataInfo(`callback-${label}`, args[0], detail, 128);
+      },
+    });
+    installed.add(key);
+    console.log(`[hook] output-info callback ${label} @ ${cbPtr}`);
+  } catch (err) {
+    console.log(`[warn] output-info callback hook failed label=${label} ptr=${cbPtr}: ${err}`);
+  }
+}
+
+function hookLoggingCallbackPointer(label, cbPtr, logLimit) {
+  if (cbPtr === null || cbPtr === undefined || cbPtr.isNull()) {
+    return;
+  }
+  const key = `logging-callback:${label}:${cbPtr}`;
+  if (installed.has(key)) {
+    return;
+  }
+  try {
+    Interceptor.attach(cbPtr, {
+      onEnter(args) {
+        if (!shouldLog(key, logLimit || 64)) {
+          return;
+        }
+        const parts = [];
+        for (let i = 0; i < 6; i++) {
+          parts.push(`arg${i}=${args[i]}`);
+        }
+        console.log(`[cb-call] ${label} ${parts.join(" ")}`);
+      },
+    });
+    installed.add(key);
+    console.log(`[hook] logging callback ${label} @ ${cbPtr}`);
+  } catch (err) {
+    console.log(`[warn] logging callback hook failed label=${label} ptr=${cbPtr}: ${err}`);
+  }
+}
+
 function describeDecodedFrameSize(len) {
   const commonYuv420Sizes = {
     460800: "640x480-yuv420",
@@ -436,12 +692,228 @@ function installNativeHooks() {
     },
   });
 
+  [
+    ["Java_com_ez_stream_NativeApi_createClient", "NativeApi.createClient", 3],
+    ["Java_com_ez_stream_NativeApi_createClientWithUrl", "NativeApi.createClientWithUrl", 3],
+    ["Java_com_ez_stream_NativeApi_createPreviewHandle", "NativeApi.createPreviewHandle", 3],
+    ["Java_com_ez_stream_NativeApi_createPreviewHandleWithUrl", "NativeApi.createPreviewHandleWithUrl", 3],
+    ["Java_com_ez_stream_NativeApi_destroyHandle", "NativeApi.destroyHandle", 3],
+    ["Java_com_ez_stream_NativeApi_setCallback", "NativeApi.setCallback", 4],
+    ["Java_com_ez_stream_NativeApi_setDataCallback2Java", "NativeApi.setDataCallback2Java", 4],
+    ["Java_com_ez_stream_NativeApi_startPreview", "NativeApi.startPreview", 8],
+    ["Java_com_ez_stream_NativeApi_start", "NativeApi.start", 5],
+    ["Java_com_ez_stream_NativeApi_startPlayback__JLjava_lang_String_2Ljava_lang_String_2Ljava_lang_String_2", "NativeApi.startPlayback(strings)", 6],
+    ["Java_com_ez_stream_NativeApi_startPlayback__JLjava_util_List_2", "NativeApi.startPlayback(list)", 4],
+    ["Java_com_ez_stream_NativeApi_startPreconnect", "NativeApi.startPreconnect", 3],
+    ["Java_com_ez_stream_NativeApi_stopPreview", "NativeApi.stopPreview", 4],
+    ["Java_com_ez_stream_NativeApi_setPlayPort", "NativeApi.setPlayPort", 4],
+    ["Java_com_ez_stream_NativeApi_setMediaCallback", "NativeApi.setMediaCallback", 5],
+    ["Java_com_ez_stream_NativeApi_setStreamDataCallback", "NativeApi.setStreamDataCallback", 5],
+    ["Java_com_ez_stream_NativeApi_setStreamSaveDebugPath", "NativeApi.setStreamSaveDebugPath", 5],
+    ["Java_com_ez_stream_NativeApi_setPlaybackConvert", "NativeApi.setPlaybackConvert", 6],
+    ["Java_com_ez_stream_NativeApi_setMediaPlaybackConvert", "NativeApi.setMediaPlaybackConvert", 6],
+    ["Java_com_ez_stream_NativeApi_inputData2Cloud", "NativeApi.inputData2Cloud", 5],
+    ["Java_com_ez_stream_NativeApi_inputVoiceTalkData", "NativeApi.inputVoiceTalkData", 6],
+  ].forEach(([name, label, argCount]) => {
+    hookArgTraceFunction("libezstreamclient.so", name, label, argCount, 64);
+  });
+
+  [
+    ["_Z27ezplayer_createPreviewMediaP10INIT_PARAM", "ezplayer_createPreviewMedia(INIT_PARAM*)", 1],
+    ["_Z27ezplayer_createPreviewMediaRKNSt6__ndk112basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEEE", "ezplayer_createPreviewMedia(string)", 1],
+    ["_Z14ezplayer_startPv", "ezplayer_start", 1],
+    ["_Z21ezstream_startPreviewPv", "ezstream_startPreview", 1],
+    ["_Z31ezplayer_setStreamSaveDebugPathPvRKNSt6__ndk112basic_stringIcNS0_11char_traitsIcEENS0_9allocatorIcEEEE", "ezplayer_setStreamSaveDebugPath", 2],
+    ["_Z22ezplayer_refreshPlayerPvjb", "ezplayer_refreshPlayer", 3],
+    ["_Z34ezplayer_getHCNetSDKPlaybackHandlePv", "ezplayer_getHCNetSDKPlaybackHandle", 1],
+    ["_ZN2bp13BPMediaPlayer4PlayEPKc", "BPMediaPlayer::Play", 2],
+    ["_ZN2bp17BPMediaDecoder_FF9OpenInputEPKc", "BPMediaDecoder_FF::OpenInput", 2],
+  ].forEach(([name, label, argCount]) => {
+    hookArgTraceFunction("libezstreamclient.so", name, label, argCount, 64);
+    hookArgTraceFunction("libBPlayer.so", name, label, argCount, 64);
+  });
+
+  hookExport("libezstreamclient.so", "_Z24ezplayer_setDataCallbackPvPFviPciS_ES_", {
+    onEnter(args) {
+      console.log(`[cb] ezplayer_setDataCallback player=${args[0]} cb=${args[1]} user=${args[2]}`);
+      hookCallbackPointer("ezplayer-setDataCallback", args[1], 1, 2);
+    },
+    onLeave(retval) {
+      console.log(`[cb] ezplayer_setDataCallback ret=${retString(retval)}`);
+    },
+  });
+
+  hookExport("libezstreamclient.so", "_Z32ezplayer_setPLAYM4DecodeCallbackPvPFvPciP13EZ_FRAME_INFOP21EZ_PLAYM4_SYSTEM_TIMES_ES_", {
+    onEnter(args) {
+      console.log(`[cb] ezplayer_setPLAYM4DecodeCallback player=${args[0]} cb=${args[1]}`);
+      hookCallbackPointer("ezplayer-PLAYM4DecodeCallback", args[1], 0, 1);
+    },
+    onLeave(retval) {
+      console.log(`[cb] ezplayer_setPLAYM4DecodeCallback ret=${retString(retval)}`);
+    },
+  });
+
+  [
+    ["_ZN13ez_stream_sdk11EZMediaBase15setDataCallbackEPFviPciPvES2_", "EZMediaBase::setDataCallback", 1, 1, 2],
+    ["_ZN13ez_stream_sdk11EZMediaBase17setDecodeCallbackEPFvPciP13EZ_FRAME_INFOP21EZ_PLAYM4_SYSTEM_TIMEPvES6_", "EZMediaBase::setDecodeCallback", 1, 0, 1],
+  ].forEach(([name, label, cbIndex, dumpArgIndex, lenArgIndex]) => {
+    hookExport("libezstreamclient.so", name, {
+      onEnter(args) {
+        console.log(`[cb] ${label} this=${args[0]} cb=${args[cbIndex]} user=${args[2]}`);
+        hookCallbackPointer(label, args[cbIndex], dumpArgIndex, lenArgIndex);
+      },
+      onLeave(retval) {
+        console.log(`[cb] ${label} ret=${retString(retval)}`);
+      },
+    });
+  });
+
+  [
+    ["_ZN13ez_stream_sdk11EZMediaBase9inputDataEPhi", "EZMediaBase::inputData", 1, 2],
+    ["_ZN13ez_stream_sdk11EZMediaBase14saveDataHeaderEPKhj", "EZMediaBase::saveDataHeader", 1, 2],
+    ["_ZN13ez_stream_sdk11EZMediaBase14saveStreamDataEPKci", "EZMediaBase::saveStreamData", 1, 2],
+    ["_ZN13ez_stream_sdk11EZMediaBase19onDataCallbackMediaEPviPaii", "EZMediaBase::onDataCallbackMedia", 3, 4],
+    ["_ZN11CRecvClient13SetStreamHeadEPci", "CRecvClient::SetStreamHead", 1, 2],
+    ["_Z19onMediaDataCallbackiPciPv", "onMediaDataCallback", 1, 2],
+    ["_Z23onMediaDataSizeCallbackiPciPv", "onMediaDataSizeCallback", 1, 2],
+  ].forEach(([name, label, dumpArgIndex, lenArgIndex]) => {
+    hookPointerDataFunction("libezstreamclient.so", name, `ezstreamclient.${label}`, dumpArgIndex, lenArgIndex);
+  });
+
+  hookExport("libezstreamclient.so", "_Z14eztrans_createPhjPKc17EZ_TRANSFORM_TYPEPPvPFvjS_jjS3_ES3_", {
+    onEnter(args) {
+      const len = args[1].toInt32();
+      console.log(`[eztrans] eztrans_create header=${args[0]} len=${len} type=${args[3].toInt32()} out=${args[4]} cb=${args[5]} user=${args[6]}`);
+      dumpBytes("eztrans-create-head", args[0], len);
+      hookCallbackPointer("eztrans-create-output", args[5], 1, 2);
+    },
+    onLeave(retval) {
+      console.log(`[eztrans] eztrans_create ret=${retString(retval)}`);
+    },
+  });
+
+  hookPointerDataFunction("libezstreamclient.so", "_Z13eztrans_inputPviPhj", "eztrans_input", 2, 3);
+
+  [
+    ["_Z17eztrans_create_exPKc17EZ_TRANSFORM_TYPEPPv", "eztrans_create_ex", 3],
+    ["_Z16eztrans_start_exPv", "eztrans_start_ex", 1],
+    ["_Z13eztrans_startPvPKcS1_", "eztrans_start", 3],
+    ["_Z14eztrans_setKeyPvNSt6__ndk112basic_stringIcNS0_11char_traitsIcEENS0_9allocatorIcEEEE", "eztrans_setKey", 2],
+  ].forEach(([name, label, argCount]) => {
+    hookArgTraceFunction("libezstreamclient.so", name, label, argCount, 64);
+  });
+
+  [
+    ["Java_com_hikvision_packagetransform_PackageTransform_startTransform", "PackageTransform.startTransform", 9],
+    ["Java_com_hikvision_packagetransform_PackageTransform_startTransformSimple", "PackageTransform.startTransformSimple", 7],
+    ["Java_com_hikvision_packagetransform_PackageTransform_startRealTimeTransform", "PackageTransform.startRealTimeTransform", 8],
+    ["Java_com_hikvision_packagetransform_PackageTransform_startRealTimeTransformTS", "PackageTransform.startRealTimeTransformTS", 8],
+    ["CreateHandle", "PackageTransform.CreateHandle", 1],
+    ["ReadRtpPacket", "PackageTransform.ReadRtpPacket", 2],
+    ["ReadRawData", "PackageTransform.ReadRawData", 0],
+    ["TransLoop", "PackageTransform.TransLoop", 1],
+    ["TransLoopRealTime", "PackageTransform.TransLoopRealTime", 5],
+    ["TransLoopRealTimeTS", "PackageTransform.TransLoopRealTimeTS", 5],
+    ["SetCallback", "PackageTransform.SetCallback", 2],
+    ["SetGlobalTime", "PackageTransform.SetGlobalTime", 1],
+    ["SetOption", "PackageTransform.SetOption", 1],
+    ["WaitComplete", "PackageTransform.WaitComplete", 0],
+  ].forEach(([name, label, argCount]) => {
+    hookArgTraceFunction("libPackageTransform.so", name, label, argCount, 64);
+  });
+
+  hookExport("libPackageTransform.so", "Java_com_hikvision_packagetransform_PackageTransform_inputData", {
+    onEnter(args) {
+      console.log(`[package-transform] PackageTransform.inputData jbuf=${args[2]} len=${args[3].toInt32()}`);
+    },
+    onLeave(retval) {
+      console.log(`[package-transform] PackageTransform.inputData ret=${retString(retval)}`);
+    },
+  });
+
+  hookOutputDataInfoFunction("libPackageTransform.so", "STOutputCbf", "PackageTransform.STOutputCbf", false, 128);
+  hookOutputDataInfoFunction("libPackageTransform.so", "STOutputCbf2", "PackageTransform.STOutputCbf2", true, 128);
+  hookOutputDataInfoFunction("libPackageTransform.so", "STDetailCbf", "PackageTransform.STDetailCbf", true, 128);
+
+  [
+    ["NPQ_InputData", "NPQ_InputData", 1, 2],
+    ["NPQ_InputRawData", "NPQ_InputRawData", 1, 2],
+  ].forEach(([name, label, dumpArgIndex, lenArgIndex]) => {
+    hookPointerDataFunction("libNPQos.so", name, label, dumpArgIndex, lenArgIndex, 128);
+  });
+
+  [
+    ["NPQ_Create", "NPQ_Create", 1],
+    ["NPQ_Start", "NPQ_Start", 1],
+    ["NPQ_Stop", "NPQ_Stop", 1],
+    ["NPQ_Destroy", "NPQ_Destroy", 1],
+    ["NPQ_SetNotifyParam", "NPQ_SetNotifyParam", 2],
+    ["NPQ_SetParam", "NPQ_SetParam", 3],
+    ["NPQ_SetMediaDelay", "NPQ_SetMediaDelay", 2],
+    ["NPQ_SetState", "NPQ_SetState", 2],
+  ].forEach(([name, label, argCount]) => {
+    hookArgTraceFunction("libNPQos.so", name, label, argCount, 64);
+  });
+
+  [
+    ["NPQ_RegisterDataCallBack", "NPQ_RegisterDataCallBack", 1, 2, 3],
+    ["NPQ_RegisterRecoveriedDataCallBack", "NPQ_RegisterRecoveriedDataCallBack", 1, 2, 3],
+    ["NPQ_RegisterDataInfoCallBack", "NPQ_RegisterDataInfoCallBack", 1, 2, 3],
+    ["NPQ_RegisterAudioDecFun", "NPQ_RegisterAudioDecFun", 1, 2, 3],
+  ].forEach(([name, label, cbIndex, dumpArgIndex, lenArgIndex]) => {
+    hookCallbackSetter("libNPQos.so", name, label, cbIndex, dumpArgIndex, lenArgIndex, 64);
+  });
+
+  [
+    ["NPC_InputData", "NPC_InputData", 2, 3],
+    ["_ZN8NPStream9InputDataE13NPC_DATA_TYPEPhj", "NPStream::InputData", 2, 3],
+    ["_ZN10INetStream9InputDataEjPhj", "INetStream::InputData", 2, 3],
+    ["_ZN10RTMPStream9InputDataEjPhj", "RTMPStream::InputData", 2, 3],
+    ["_ZN11RTMPSession9InputDataEPhj", "RTMPSession::InputData", 1, 2],
+    ["_ZN15RTMPPushSession9InputDataEPhj", "RTMPPushSession::InputData", 1, 2],
+    ["_ZN8MmshData9InputDataEPhj", "MmshData::InputData", 1, 2],
+  ].forEach(([name, label, dumpArgIndex, lenArgIndex]) => {
+    hookPointerDataFunction("libNPClient.so", name, label, dumpArgIndex, lenArgIndex, 128);
+  });
+
+  [
+    ["NPC_SetMsgCallBack", "NPC_SetMsgCallBack", 1, 2, 3],
+    ["_ZN8NPStream14SetMsgCallBackEPFviiPhjPvES1_", "NPStream::SetMsgCallBack", 1, 2, 3],
+  ].forEach(([name, label, cbIndex, dumpArgIndex, lenArgIndex]) => {
+    hookCallbackSetter("libNPClient.so", name, label, cbIndex, dumpArgIndex, lenArgIndex, 64);
+  });
+
+  [
+    ["NPC_SetTransmitMode", "NPC_SetTransmitMode", 3],
+    ["NPC_SetTransmitMode_Ex", "NPC_SetTransmitMode_Ex", 2],
+    ["NPC_SetPullStreamType", "NPC_SetPullStreamType", 2],
+    ["NPC_SetStreamInfo", "NPC_SetStreamInfo", 2],
+    ["_ZN8NPStream4OpenEPFviiPhjPvES1_y", "NPStream::Open", 3],
+    ["_ZN8NPStream5CloseEv", "NPStream::Close", 1],
+  ].forEach(([name, label, argCount]) => {
+    hookArgTraceFunction("libNPClient.so", name, label, argCount, 64);
+  });
+
+  [
+    ["_Z14NPCMsgCallBackiiPhjPv", "HIK_NPCClient.NPCMsgCallBack", 2, 3],
+    ["_Z15NPCDataCallBackiiPhjPv", "HIK_NPCClient.NPCDataCallBack", 2, 3],
+  ].forEach(([name, label, dumpArgIndex, lenArgIndex]) => {
+    hookPointerDataFunction("libHIK_NPCClient.so", name, label, dumpArgIndex, lenArgIndex, 128);
+  });
+
+  [
+    ["Java_org_hik_np_NPClient_NPCCreate", "NPClient.NPCCreate", 4],
+    ["Java_org_hik_np_NPClient_NPCOpen", "NPClient.NPCOpen", 5],
+    ["Java_org_hik_np_NPClient_NPCOpenEx", "NPClient.NPCOpenEx", 6],
+    ["Java_org_hik_np_NPClient_NPCSetMsgCallBack", "NPClient.NPCSetMsgCallBack", 5],
+    ["Java_org_hik_np_NPClient_NPCSetTransmitMode", "NPClient.NPCSetTransmitMode", 5],
+  ].forEach(([name, label, argCount]) => {
+    hookArgTraceFunction("libHIK_NPCClient.so", name, label, argCount, 64);
+  });
+
   hookExport("libPlayCtrl.so", "PlayM4_SetSecretKey", {
     onEnter(args) {
       // long port, long keyType, char *key, long keyLen.
-      if (DUMP_SECRET_KEYS_RAW) {
-        dumpBytes("secret-playm4-key", args[2], args[3].toInt32());
-      }
       console.log(
         `[key] PlayM4_SetSecretKey port=${args[0].toInt32()} type=${args[1].toInt32()} key=${secretBytes(args[2], args[3].toInt32())}`,
       );
@@ -521,9 +993,6 @@ function installNativeHooks() {
   hookExport("libPlayCtrl.so", "_ZN12CIDMXManager12SetDecrptKeyEPci15_IDMX_KEY_TYPE_", {
     onEnter(args) {
       const len = args[2].toInt32();
-      if (DUMP_SECRET_KEYS_RAW) {
-        dumpBytes("secret-playctrl-cidmx-key", args[1], len);
-      }
       console.log(
         `[key] PlayCtrl.CIDMXManager::SetDecrptKey this=${args[0]} key=${secretBytes(args[1], len)} type=${args[3].toInt32()}`,
       );
@@ -533,9 +1002,6 @@ function installNativeHooks() {
   hookExport("libSystemTransform.so", "SYSTRANS_SetEncryptKey", {
     onEnter(args) {
       // void *handle, enum encryptType, char *key, uint keyLen.
-      if (DUMP_SECRET_KEYS_RAW) {
-        dumpBytes("secret-systrans-key", args[2], args[3].toInt32());
-      }
       console.log(
         `[key] SYSTRANS_SetEncryptKey handle=${args[0]} type=${args[1].toInt32()} key=${secretBytes(args[2], args[3].toInt32())}`,
       );
@@ -545,12 +1011,130 @@ function installNativeHooks() {
     },
   });
 
+  hookExport("libSystemTransform.so", "_ZN15CTransformProxy13SetEncryptKeyE17_ST_ENCRYPT_TYPE_Pcj", {
+    onEnter(args) {
+      console.log(
+        `[key] CTransformProxy::SetEncryptKey this=${args[0]} type=${args[1].toInt32()} key=${secretBytes(args[2], args[3].toInt32())}`,
+      );
+    },
+    onLeave(retval) {
+      console.log(`[key] CTransformProxy::SetEncryptKey ret=${retString(retval)}`);
+    },
+  });
+
+  [
+    ["SYSTRANS_Create", "SYSTRANS_Create", 1],
+    ["SYSTRANS_CreateEx", "SYSTRANS_CreateEx", 1],
+    ["SYSTRANS_OpenStreamAdvanced", "SYSTRANS_OpenStreamAdvanced", 4],
+    ["SYSTRANS_Start", "SYSTRANS_Start", 3],
+    ["SYSTRANS_Stop", "SYSTRANS_Stop", 1],
+    ["SYSTRANS_StreamEnd", "SYSTRANS_StreamEnd", 2],
+    ["SYSTRANS_SkipErrorData", "SYSTRANS_SkipErrorData", 2],
+    ["SYSTRANS_Release", "SYSTRANS_Release", 1],
+    ["SYSTRANS_InputCustomStream", "SYSTRANS_InputCustomStream", 2],
+    ["IDMX_CreateHandle", "IDMX_CreateHandle", 1],
+    ["IDMX_OutputData", "IDMX_OutputData", 2],
+  ].forEach(([name, label, argCount]) => {
+    hookArgTraceFunction("libSystemTransform.so", name, label, argCount, 64);
+  });
+
+  [
+    ["SYSTRANS_RegisterOutputDataCallBack", "SYSTRANS_RegisterOutputDataCallBack", false],
+    ["SYSTRANS_RegisterOutputDataCallBackEx", "SYSTRANS_RegisterOutputDataCallBackEx", false],
+    ["SYSTRANS_RegisterDetailDataCallBack", "SYSTRANS_RegisterDetailDataCallBack", true],
+  ].forEach(([name, label, detail]) => {
+    hookExport("libSystemTransform.so", name, {
+      onEnter(args) {
+        console.log(`[cb] ${label} handle=${args[0]} cb=${args[1]} user=${args[2]}`);
+        hookOutputDataInfoCallbackPointer(label, args[1], detail);
+      },
+      onLeave(retval) {
+        console.log(`[cb] ${label} ret=${retString(retval)}`);
+      },
+    });
+  });
+
+  [
+    ["SYSTRANS_RegisterStreamInforCB", "SYSTRANS_RegisterStreamInforCB"],
+    ["SYSTRANS_RegisterPackInfoCallBack", "SYSTRANS_RegisterPackInfoCallBack"],
+  ].forEach(([name, label]) => {
+    hookExport("libSystemTransform.so", name, {
+      onEnter(args) {
+        console.log(`[cb] ${label} handle=${args[0]} cb=${args[1]} user=${args[2]}`);
+        hookLoggingCallbackPointer(label, args[1], 64);
+      },
+      onLeave(retval) {
+        console.log(`[cb] ${label} ret=${retString(retval)}`);
+      },
+    });
+  });
+
+  [
+    ["_ZN15CTransformProxy26RegisterOutputDataCallBackEPFvP15OUTPUTDATA_INFOPvES2_", "CTransformProxy::RegisterOutputDataCallBack(output,void*)", false],
+    ["_ZN15CTransformProxy26RegisterOutputDataCallBackEPFvP15OUTPUTDATA_INFOmEm", "CTransformProxy::RegisterOutputDataCallBack(output,ulong)", false],
+    ["_ZN15CTransformProxy26RegisterOutputDataCallBackEPFvP18_DETAIL_DATA_INFO_PvES2_", "CTransformProxy::RegisterOutputDataCallBack(detail)", true],
+    ["_ZN10CMXManager26RegisterOutputDataCallBackEPFvP15OUTPUTDATA_INFOPvES2_", "CMXManager::RegisterOutputDataCallBack(output,void*)", false],
+    ["_ZN10CMXManager26RegisterOutputDataCallBackEPFvP15OUTPUTDATA_INFOmEm", "CMXManager::RegisterOutputDataCallBack(output,ulong)", false],
+    ["_ZN10CMXManager22RegisterDetailCallBackEPFvP18_DETAIL_DATA_INFO_PvES2_", "CMXManager::RegisterDetailCallBack", true],
+    ["_ZN11CDMXManager26RegisterOutputDataCallBackEPFvP15OUTPUTDATA_INFOPvES2_", "CDMXManager::RegisterOutputDataCallBack", false],
+    ["_ZN11CDMXManager22RegisterDetailCallBackEPFvP18_DETAIL_DATA_INFO_PvES2_", "CDMXManager::RegisterDetailCallBack", true],
+    ["_ZN6CError26RegisterOutputDataCallBackEPFvP15OUTPUTDATA_INFOPvES2_", "CError::RegisterOutputDataCallBack(output,void*)", false],
+    ["_ZN6CError26RegisterOutputDataCallBackEPFvP15OUTPUTDATA_INFOmEm", "CError::RegisterOutputDataCallBack(output,ulong)", false],
+    ["_ZN6CError22RegisterDetailCallBackEPFvP18_DETAIL_DATA_INFO_PvES2_", "CError::RegisterDetailCallBack", true],
+  ].forEach(([name, label, detail]) => {
+    hookExport("libSystemTransform.so", name, {
+      onEnter(args) {
+        console.log(`[cb] ${label} this=${args[0]} cb=${args[1]} user=${args[2]}`);
+        hookOutputDataInfoCallbackPointer(label, args[1], detail);
+      },
+    });
+  });
+
+  [
+    ["_ZN15CTransformProxy21RegisterStreamInforCBEPFvP15_ST_ERROR_INFO_PvES2_", "CTransformProxy::RegisterStreamInforCB"],
+    ["_ZN15CTransformProxy24RegisterPackInfoCallBackEPFvP12ST_PACK_INFOPvES2_", "CTransformProxy::RegisterPackInfoCallBack"],
+    ["_ZN10CMXManager24RegisterPackInfoCallBackEPFvP12ST_PACK_INFOPvES2_", "CMXManager::RegisterPackInfoCallBack"],
+    ["_ZN6CError21RegisterErrorCallBackEPFvP15_ST_ERROR_INFO_PvES2_", "CError::RegisterErrorCallBack"],
+  ].forEach(([name, label]) => {
+    hookExport("libSystemTransform.so", name, {
+      onEnter(args) {
+        console.log(`[cb] ${label} this=${args[0]} cb=${args[1]} user=${args[2]}`);
+        hookLoggingCallbackPointer(label, args[1], 64);
+      },
+    });
+  });
+
+  [
+    ["_ZN10CMXManager13SetEncryptKeyE17_ST_ENCRYPT_TYPE_Pcj", "CMXManager::SetEncryptKey", 2, 3],
+    ["_ZN11CDMXManager13SetDecryptKeyE17_ST_ENCRYPT_TYPE_Pcj", "CDMXManager::SetDecryptKey", 2, 3],
+    ["_ZN12CIMuxManager13SetEncryptKeyEPhj", "CIMuxManager::SetEncryptKey", 1, 2],
+  ].forEach(([name, label, keyArgIndex, lenArgIndex]) => {
+    hookExport("libSystemTransform.so", name, {
+      onEnter(args) {
+        const len = args[lenArgIndex].toInt32();
+        console.log(`[key] ${label} this=${args[0]} key=${secretBytes(args[keyArgIndex], len)}`);
+      },
+      onLeave(retval) {
+        console.log(`[key] ${label} ret=${retString(retval)}`);
+      },
+    });
+  });
+
   hookExport("libSystemTransform.so", "SYSTRANS_InputData", {
     onEnter(args) {
       // void *handle, DATA_TYPE type, unsigned char *data, uint len.
       const len = args[3].toInt32();
       console.log(`[in] SYSTRANS_InputData handle=${args[0]} type=${args[1].toInt32()} len=${len} head=${bytesToHex(args[2], len)}`);
       dumpBytes("systrans-input", args[2], len);
+    },
+  });
+
+  hookExport("libSystemTransform.so", "SYSTRANS_InputPrivateData", {
+    onEnter(args) {
+      // void *handle, uint type, uint subType, unsigned char *data, uint len.
+      const len = args[4].toInt32();
+      console.log(`[in] SYSTRANS_InputPrivateData handle=${args[0]} type=${args[1].toInt32()} subType=${args[2].toInt32()} len=${len} head=${bytesToHex(args[3], len)}`);
+      dumpBytes("systrans-private-input", args[3], len);
     },
   });
 
@@ -679,6 +1263,22 @@ function installNativeHooks() {
     ["_ZN12IDMXRTPDemux10OutputDataEP18_IDMX_PACKET_INFO_", "IDMXRTPDemux::OutputData", 1, null],
     ["_ZN12IDMXRTPDemux11AddFuPacketEPhjS0_j", "IDMXRTPDemux::AddFuPacket", 1, 2],
     ["_ZN12IDMXRTPDemux17ProcessLostPacketEj", "IDMXRTPDemux::ProcessLostPacket", null, null],
+    ["_ZN14IDMXRTPJTDemux9InputDataEPhjPj", "IDMXRTPJTDemux::InputData", 1, 2],
+    ["_ZN14IDMXRTPJTDemux14ProcessPayloadEP20_RTPJT_DEMUX_OUTPUT_", "IDMXRTPJTDemux::ProcessPayload", 1, null],
+    ["_ZN14IDMXRTPJTDemux10OutputDataEP18_IDMX_PACKET_INFO_", "IDMXRTPJTDemux::OutputData", 1, null],
+    ["_ZN14IDMXRTPJTDemux15AddToVideoFrameEPhj", "IDMXRTPJTDemux::AddToVideoFrame", 1, 2],
+    ["_ZN14IDMXRTPJTDemux15AddToAudioFrameEPhj", "IDMXRTPJTDemux::AddToAudioFrame", 1, 2],
+    ["_ZN12IDMXRawDemux9InputDataEPhjPj", "IDMXRawDemux::InputData", 1, 2],
+    ["_ZN12IDMXRawDemux12ProcessFrameEPhj", "IDMXRawDemux::ProcessFrame", 1, 2],
+    ["_ZN12IDMXRawDemux10OutputDataEP18_IDMX_PACKET_INFO_", "IDMXRawDemux::OutputData", 1, null],
+    ["_ZN12IDMXRawDemux15AddToVideoFrameEPhj", "IDMXRawDemux::AddToVideoFrame", 1, 2],
+    ["_ZN11IDMXTSDemux9InputDataEPhjPj", "IDMXTSDemux::InputData", 1, 2],
+    ["_ZN11IDMXTSDemux14ProcessPayloadEP20_MPEG2_DEMUX_OUTPUT_", "IDMXTSDemux::ProcessPayload", 1, null],
+    ["_ZN11IDMXTSDemux19ProcessPayloadMultiEP20_MPEG2_DEMUX_OUTPUT_", "IDMXTSDemux::ProcessPayloadMulti", 1, null],
+    ["_ZN11IDMXTSDemux10OutputDataEP18_IDMX_PACKET_INFO_", "IDMXTSDemux::OutputData", 1, null],
+    ["_ZN11IDMXTSDemux10AddToFrameEPhj", "IDMXTSDemux::AddToFrame", 1, 2],
+    ["_ZN11IDMXTSDemux12AddToAPFrameEPhj", "IDMXTSDemux::AddToAPFrame", 1, 2],
+    ["_ZN11IDMXTSDemux14AddToDataFrameEPhj", "IDMXTSDemux::AddToDataFrame", 1, 2],
   ].forEach(([name, label, dumpArgIndex, lenArgIndex]) => {
     hookPointerDataFunction("libPlayCtrl.so", name, `PlayCtrl.${label}`, dumpArgIndex, lenArgIndex);
     hookPointerDataFunction("libSystemTransform.so", name, `SystemTransform.${label}`, dumpArgIndex, lenArgIndex);
@@ -693,29 +1293,172 @@ function installNativeHooks() {
     ["_ZN11CDMXManager14ParseRtpPacketEPhj", "CDMXManager::ParseRtpPacket", 1, 2],
     ["_ZN11CDMXManager17ProcessVideoFrameEP16_IDMX_FRMAE_INFO", "CDMXManager::ProcessVideoFrame", 1, null],
     ["_ZN11CDMXManager12ProcessFrameEP16_IDMX_FRMAE_INFO", "CDMXManager::ProcessFrame", 1, null],
+    ["_ZN11CDMXManager11ParseStreamEv", "CDMXManager::ParseStream", null, null],
+    ["_ZN11CDMXManager12PushFileDataEv", "CDMXManager::PushFileData", null, null],
+    ["_ZN10CMXManager9InputDataEPhjP13ST_FRAME_INFO", "CMXManager::InputData", 1, 2],
+    ["_ZN10CMXManager16InputPrivateDataEjjPhj", "CMXManager::InputPrivateData", 3, 4],
+    ["_ZN10CMXManager12ProcessFrameEPhjP13ST_FRAME_INFO", "CMXManager::ProcessFrame", 1, 2],
+    ["_ZN10CMXManager17InputCustomStreamEP21_ST_CUSTOM_DATA_INFO_", "CMXManager::InputCustomStream", 1, null],
+    ["_ZN10CMXManager10OutputDataEP15_MX_OUTPUT_BUF_P17_MX_OUTPUT_PARAM_P13ST_FRAME_INFO", "CMXManager::OutputData", null, null],
+    ["_ZN12CIMuxManager9InputDataEP16_MX_INPUT_PARAM_Phj", "CIMuxManager::InputData", 2, 3],
+    ["_ZN12CIMuxManager10OutputDataEP17_MX_OUTPUT_PARAM_PPhPj", "CIMuxManager::OutputData", null, null],
+    ["IMUX_InputData", "IMUX_InputData", 2, 3],
+    ["IMUX_OutputData", "IMUX_OutputData", null, null],
     ["_ZN11CDMXManager13SkipErrorDataEi", "CDMXManager::SkipErrorData", null, null],
+    ["_ZN11CDMXManager9StreamEndEj", "CDMXManager::StreamEnd", null, null],
+    ["_ZN15CTransformProxy9InputDataE9DATA_TYPEPhj", "CTransformProxy::InputData", 2, 3],
+    ["_ZN15CTransformProxy16InputPrivateDataEjjPhj", "CTransformProxy::InputPrivateData", 3, 4],
+    ["_ZN15CTransformProxy8RawDemuxE9DATA_TYPEPhj", "CTransformProxy::RawDemux", 2, 3],
+    ["_ZN15CTransformProxy17InputCustomStreamEP21_ST_CUSTOM_DATA_INFO_", "CTransformProxy::InputCustomStream", 1, null],
+    ["_ZN15CTransformProxy13SkipErrorDataEi", "CTransformProxy::SkipErrorData", null, null],
+    ["_ZN15CTransformProxy9StreamEndEj", "CTransformProxy::StreamEnd", null, null],
+    ["_ZN15CTransformProxy14AnalyzeSrcInfoEP14SYS_TRANS_PARA", "CTransformProxy::AnalyzeSrcInfo", null, null],
+    ["_ZN15CTransformProxy9InitDemuxEP14SYS_TRANS_PARA", "CTransformProxy::InitDemux", null, null],
   ].forEach(([name, label, dumpArgIndex, lenArgIndex]) => {
     hookPointerDataFunction("libSystemTransform.so", name, `SystemTransform.${label}`, dumpArgIndex, lenArgIndex);
   });
 
   [
+    ["_ZN6NetSDK11CPreviewMgr6CreateEiPK19NET_DVR_PREVIEWINFOPFvijPhjPvES5_j", "CPreviewMgr::Create(preview)", 3, 2, 3],
+    ["_ZN6NetSDK11CPreviewMgr6CreateEiPK27NET_DVR_PREVIEWINFO_SPECIALPFvijPhjPvES5_", "CPreviewMgr::Create(special)", 3, 2, 3],
+    ["_ZN6NetSDK15CPreviewSession19SetRealDataCallBackEPFvijPhjjEj", "CPreviewSession::SetRealDataCallBack", 1, 2, 3],
+    ["_ZN6NetSDK15CPreviewSession21SetRealDataCallBackExEPFvijPhjPvES2_", "CPreviewSession::SetRealDataCallBackEx", 1, 2, 3],
+    ["_ZN6NetSDK15CPreviewSession23SetStandardDataCallBackEPFvijPhjjEj", "CPreviewSession::SetStandardDataCallBack", 1, 2, 3],
+    ["_ZN6NetSDK15CPreviewSession25SetStandardDataCallBackExEPFvijPhjPvES2_", "CPreviewSession::SetStandardDataCallBackEx", 1, 2, 3],
+    ["_ZN6NetSDK15CPreviewSession26SetTransparentDataCallBackEPFvijPhjPvES2_", "CPreviewSession::SetTransparentDataCallBack", 1, 2, 3],
+    ["_ZN6NetSDK15CPreviewSession13SetESCallBackEPFvijPhjPvES2_", "CPreviewSession::SetESCallBack", 1, 2, 3],
+  ].forEach(([name, label, cbIndex, dumpArgIndex, lenArgIndex]) => {
+    hookExport("libHCPreview.so", name, {
+      onEnter(args) {
+        console.log(`[cb] ${label} this=${args[0]} cb=${args[cbIndex]} user=${args[cbIndex + 1]}`);
+        hookCallbackPointer(label, args[cbIndex], dumpArgIndex, lenArgIndex);
+      },
+      onLeave(retval) {
+        console.log(`[cb] ${label} ret=${retString(retval)}`);
+      },
+    });
+  });
+
+  hookExport("libHCPreview.so", "_ZN6NetSDK15CPreviewSession21SetESRealPlayCallBackEPFviP25tagNET_DVR_PACKET_INFO_EXPvES3_", {
+    onEnter(args) {
+      console.log(`[cb] CPreviewSession::SetESRealPlayCallBack this=${args[0]} cb=${args[1]} user=${args[2]}`);
+      hookLoggingCallbackPointer("CPreviewSession::SetESRealPlayCallBack", args[1], 64);
+    },
+    onLeave(retval) {
+      console.log(`[cb] CPreviewSession::SetESRealPlayCallBack ret=${retString(retval)}`);
+    },
+  });
+
+  [
+    ["_ZN6NetSDK14CGetStreamBase13GetStreamDataEPvPKvjj", "CGetStreamBase::GetStreamData", 2, 3],
+    ["_ZN6NetSDK14CGetStreamBase11ProcTcpDataEPKvjj", "CGetStreamBase::ProcTcpData", 1, 2],
+    ["_ZN6NetSDK14CGetStreamBase15PushConvertDataEPKvjjj", "CGetStreamBase::PushConvertData", 1, 2],
+    ["_ZN6NetSDK14CGetStreamBase17GetStreamDataTypeEPKvjj", "CGetStreamBase::GetStreamDataType", 1, 2],
+    ["_ZN6NetSDK14CGetStreamBase16IsNeedUseConvertEj", "CGetStreamBase::IsNeedUseConvert", null, null],
+    ["_ZN6NetSDK13CUserCallBack25InputDefaultDataToConvertEPKvjj", "CUserCallBack::InputDefaultDataToConvert", 1, 2],
+    ["_ZN6NetSDK13CUserCallBack12GetStreamHikEPKvjj", "CUserCallBack::GetStreamHik", 1, 2],
+    ["_ZN6NetSDK13CUserCallBack12GetStreamSTDEPKvjj", "CUserCallBack::GetStreamSTD", 1, 2],
+    ["_ZN6NetSDK13CUserCallBack15GetStreamV30HikEPKvjj", "CUserCallBack::GetStreamV30Hik", 1, 2],
     ["_ZN6NetSDK13CGetTCPStream17ProRTPOverTCPDataEPvPKvjj", "CGetTCPStream::ProRTPOverTCPData", 2, 3],
+    ["_ZNK11CQosOperate9AddPacketEiPhj", "CQosOperate::AddPacket", 2, 3],
+    ["_ZN6NetSDK15CGetHRUDPStream16ProcessTCPDataCBEPvPKvjj", "CGetHRUDPStream::ProcessTCPDataCB", 2, 3],
+    ["_ZN6NetSDK15CGetHRUDPStream16CopyTCPDataToBufEPKvj", "CGetHRUDPStream::CopyTCPDataToBuf", 1, 2],
+    ["_ZN6NetSDK15CGetHRUDPStream17SortAndSaveByNodeEPKhjjj", "CGetHRUDPStream::SortAndSaveByNode", 1, 2],
+    ["_ZN6NetSDK15CGetHRUDPStream11SortAndSaveEPKhjjj", "CGetHRUDPStream::SortAndSave", 1, 2],
+    ["_ZN6NetSDK15CGetHRUDPStream19InsertAtAllocatePosEPhPKhjjj", "CGetHRUDPStream::InsertAtAllocatePos", 2, 3],
+    ["_ZN6NetSDK13CGetNPQStream15NpqDataCallBackEiiPhjPv", "CGetNPQStream::NpqDataCallBack", 3, 4],
+    ["_ZN6NetSDK13CGetNPQStream14ProcStreamDataEPKvj", "CGetNPQStream::ProcStreamData", 1, 2],
+    ["_ZN6NetSDK14CGetPushStream13QosPacketSendEiPhjPv", "CGetPushStream::QosPacketSend", 2, 3],
+    ["_ZN6NetSDK14CGetPushStream12QosPacketRawEiPhjPv", "CGetPushStream::QosPacketRaw", 2, 3],
+    ["_ZN6NetSDK14CGetPushStream16RecvDataCallBackEPvPKvjj", "CGetPushStream::RecvDataCallBack", 2, 3],
+    ["_ZN6NetSDK14CGetPushStream11SendCommandEjPKvj", "CGetPushStream::SendCommand", 2, 3],
+    ["_ZN6NetSDK14CGetRTSPStream13ProcessRTPMsgEPvPKvj", "CGetRTSPStream::ProcessRTPMsg", 2, 3],
+    ["_ZN6NetSDK14CGetRTSPStream15ParseRecvExDataEPKhj", "CGetRTSPStream::ParseRecvExData", 1, 2],
+    ["_ZN6NetSDK14CGetRTSPStream11NpqCallbackEiiPhjPv", "CGetRTSPStream::NpqCallback", 3, 4],
     ["_ZN6NetSDK14CGetRTSPStream14ProcessRTPDataEPviPKvjj", "CGetRTSPStream::ProcessRTPData", 3, 4],
     ["_ZN6NetSDK14CGetRTSPStream19ProcessRTPDataNoNpqEPviPKvjj", "CGetRTSPStream::ProcessRTPDataNoNpq", 3, 4],
+    ["_ZN6NetSDK14CGetStreamBase13GetStreamDataEPvPKvjj", "CGetStreamBase::GetStreamData", 2, 3],
+    ["_ZN6NetSDK14CGetStreamBase11ProcTcpDataEPKvjj", "CGetStreamBase::ProcTcpData", 1, 2],
+    ["_ZN6NetSDK14CGetStreamBase15PushConvertDataEPKvjjj", "CGetStreamBase::PushConvertData", 1, 2],
     ["_ZN6NetSDK14CPreviewPlayer15PlayerGetStreamEPKvjjPv", "CPreviewPlayer::PlayerGetStream", 1, 2],
     ["_ZN6NetSDK14CPreviewPlayer17InputDataToPlayerEPvj", "CPreviewPlayer::InputDataToPlayer", 1, 2],
     ["_ZN6NetSDK14CPreviewPlayer14ProccessStreamEPKvjj", "CPreviewPlayer::ProccessStream", 1, 2],
+    ["_ZN6NetSDK13CUserCallBack11GetStreamTPEPKvjj", "CUserCallBack::GetStreamTP", 1, 2],
+    ["_ZN6NetSDK13CUserCallBack12GetStreamHikEPKvjj", "CUserCallBack::GetStreamHik", 1, 2],
+    ["_ZN6NetSDK13CUserCallBack12GetStreamSTDEPKvjj", "CUserCallBack::GetStreamSTD", 1, 2],
+    ["_ZN6NetSDK13CUserCallBack15GetStreamV30HikEPKvjj", "CUserCallBack::GetStreamV30Hik", 1, 2],
+    ["_ZN6NetSDK13CUserCallBack11UserGetESCBEPKvjjPv", "CUserCallBack::UserGetESCB", 1, 2],
+    ["_ZN6NetSDK13CUserCallBack15UserGetStreamTPEPKvjjPv", "CUserCallBack::UserGetStreamTP", 1, 2],
+    ["_ZN6NetSDK13CUserCallBack16UserGetStreamHikEPKvjjPv", "CUserCallBack::UserGetStreamHik", 1, 2],
+    ["_ZN6NetSDK13CUserCallBack16UserGetStreamSTDEPKvjjPv", "CUserCallBack::UserGetStreamSTD", 1, 2],
+    ["_ZN6NetSDK13CUserCallBack19UserGetStreamV30HikEPKvjjPv", "CUserCallBack::UserGetStreamV30Hik", 1, 2],
+    ["_ZN6NetSDK13CUserCallBack15InputDataToFileEPvjj", "CUserCallBack::InputDataToFile", 1, 2],
+    ["_ZN6NetSDK13CUserCallBack25InputDefaultDataToConvertEPKvjj", "CUserCallBack::InputDefaultDataToConvert", 1, 2],
+    ["_ZN6NetSDK13CUserCallBack15WriteDataToFileEPvj", "CUserCallBack::WriteDataToFile", 1, 2],
+    ["_ZN6NetSDK13CUserCallBack15UserWriteFileCBEPKvjjPv", "CUserCallBack::UserWriteFileCB", 1, 2],
     ["_ZN6NetSDK15CGetHRUDPStream17CallbackVedioDataEPKhjjj", "CGetHRUDPStream::CallbackVedioData", 1, 2],
+    ["_ZN6NetSDK14CGetStreamBase21PushDateToGetStreamCBEPKvjjj", "CGetStreamBase::PushDateToGetStreamCB", 1, 2],
+    ["_ZN6NetSDK14CGetStreamBase33PushDateToGetStreamCB_WithoutLockEPKvjjj", "CGetStreamBase::PushDateToGetStreamCB_WithoutLock", 1, 2],
+    ["_ZN6NetSDK15CGetHRUDPStream21PushDateToGetStreamCBEPKvjjj", "CGetHRUDPStream::PushDateToGetStreamCB", 1, 2],
+    ["_ZN6NetSDK13CGetNPQStream21PushDateToGetStreamCBEPKvjjj", "CGetNPQStream::PushDateToGetStreamCB", 1, 2],
   ].forEach(([name, label, dumpArgIndex, lenArgIndex]) => {
     hookPointerDataFunction("libHCPreview.so", name, `HCPreview.${label}`, dumpArgIndex, lenArgIndex);
+  });
+
+  hookExport("libHCPreview.so", "_ZNK11CQosOperate15SetCbForRawDataEiPFviPhjPvES1_", {
+    onEnter(args) {
+      console.log(`[cb] CQosOperate::SetCbForRawData this=${args[0]} type=${args[1].toInt32()} cb=${args[2]} user=${args[3]}`);
+      hookCallbackPointer("CQosOperate::SetCbForRawData", args[2], 1, 2);
+    },
+    onLeave(retval) {
+      console.log(`[cb] CQosOperate::SetCbForRawData ret=${retString(retval)}`);
+    },
+  });
+
+  [
+    ["_ZN6NetSDK14CGetStreamBase20SysTransDataCallBackEPK15OUTPUTDATA_INFOPv", "CGetStreamBase::SysTransDataCallBack"],
+    ["_ZN6NetSDK13CUserCallBack20SysTransDataCallBackEPK15OUTPUTDATA_INFOPv", "CUserCallBack::SysTransDataCallBack"],
+  ].forEach(([name, label]) => {
+    hookExport("libHCPreview.so", name, {
+      onEnter(args) {
+        dumpOutputDataInfo(`HCPreview.${label}`, args[1], false, 128);
+      },
+    });
+  });
+
+  [
+    ["COM_SetRealDataCallBack", "COM_SetRealDataCallBack", 1, 2, 3],
+    ["COM_SetRealDataCallBackEx", "COM_SetRealDataCallBackEx", 1, 2, 3],
+    ["COM_SetStandardDataCallBack", "COM_SetStandardDataCallBack", 1, 2, 3],
+    ["COM_SetStandardDataCallBackEx", "COM_SetStandardDataCallBackEx", 1, 2, 3],
+    ["COM_SetTransparentDataCallBack", "COM_SetTransparentDataCallBack", 1, 2, 3],
+    ["COM_SetESCallBack", "COM_SetESCallBack", 1, 2, 3],
+  ].forEach(([name, label, cbIndex, dumpArgIndex, lenArgIndex]) => {
+    hookExport("libHCPreview.so", name, {
+      onEnter(args) {
+        console.log(`[cb] ${label} handle=${args[0]} cb=${args[cbIndex]} user=${args[2]} extra=${args[3]}`);
+        hookCallbackPointer(label, args[cbIndex], dumpArgIndex, lenArgIndex);
+      },
+      onLeave(retval) {
+        console.log(`[cb] ${label} ret=${retString(retval)}`);
+      },
+    });
+  });
+
+  hookExport("libHCPreview.so", "COM_SetESRealPlayCallBack", {
+    onEnter(args) {
+      console.log(`[cb] COM_SetESRealPlayCallBack handle=${args[0]} cb=${args[1]} user=${args[2]} extra=${args[3]}`);
+      hookLoggingCallbackPointer("COM_SetESRealPlayCallBack", args[1], 64);
+    },
+    onLeave(retval) {
+      console.log(`[cb] COM_SetESRealPlayCallBack ret=${retString(retval)}`);
+    },
   });
 
   [
     ["COM_StartRealPlay", "COM_StartRealPlay"],
     ["COM_StopRealPlay", "COM_StopRealPlay"],
     ["COM_GetRealPlaySock", "COM_GetRealPlaySock"],
-    ["COM_SetESRealPlayCallBack", "COM_SetESRealPlayCallBack"],
-    ["COM_SetRealPlaySecretKey", "COM_SetRealPlaySecretKey"],
   ].forEach(([name, label]) => {
     hookExport("libHCPreview.so", name, {
       onEnter(args) {
@@ -729,6 +1472,222 @@ function installNativeHooks() {
         }
       },
     });
+  });
+
+  hookExport("libHCPreview.so", "COM_SetRealPlaySecretKey", {
+    onEnter(args) {
+      console.log(
+        `[key] COM_SetRealPlaySecretKey handle=${args[0]} type=${args[1].toInt32()} key=${nativeSecretBytes(args[2], args[3])}`,
+      );
+    },
+    onLeave(retval) {
+      console.log(`[key] COM_SetRealPlaySecretKey ret=${retString(retval)}`);
+    },
+  });
+
+  [
+    ["NET_DVR_RealPlay", "NET_DVR_RealPlay", 3],
+    ["NET_DVR_RealPlay_V30", "NET_DVR_RealPlay_V30", 4],
+    ["NET_DVR_RealPlay_V40", "NET_DVR_RealPlay_V40", 4],
+    ["NET_DVR_MakeKeyFrame", "NET_DVR_MakeKeyFrame", 2],
+    ["NET_DVR_MakeKeyFrameSub", "NET_DVR_MakeKeyFrameSub", 3],
+    ["NET_DVR_ZeroMakeKeyFrame", "NET_DVR_ZeroMakeKeyFrame", 2],
+    ["NET_DVR_StartRecvNakedDataListen", "NET_DVR_StartRecvNakedDataListen", 2],
+    ["NET_DVR_StopRecvNakedDataListen", "NET_DVR_StopRecvNakedDataListen", 1],
+    ["NET_DVR_PicViewRequest", "NET_DVR_PicViewRequest", 2],
+    ["COM_StartRecvNakedDataListen", "COM_StartRecvNakedDataListen", 2],
+    ["COM_PicViewRequest", "COM_PicViewRequest", 2],
+  ].forEach(([name, label, argCount]) => {
+    const moduleName = name.startsWith("COM_") ? (name.indexOf("PicView") !== -1 ? "libHCDisplay.so" : "libHCAlarm.so") : "libhcnetsdk.so";
+    hookArgTraceFunction(moduleName, name, label, argCount, 64);
+  });
+
+  [
+    ["libhcnetsdk.so", "NET_DVR_MatrixSendData", "NET_DVR_MatrixSendData", 1, 2],
+    ["libhcnetsdk.so", "NET_DVR_TransCodeInputData", "NET_DVR_TransCodeInputData", 1, 2],
+    ["libHCDisplay.so", "COM_MatrixSendData", "COM_MatrixSendData", 1, 2],
+    ["libHCDisplay.so", "COM_TransCodeInputData", "COM_TransCodeInputData", 1, 2],
+    [
+      "libHCAlarm.so",
+      "_ZNK6NetSDK19CAlarmListenSession16ProcessNakedDataEPcjP10HPR_ADDR_Ti",
+      "CAlarmListenSession::ProcessNakedData",
+      1,
+      2,
+    ],
+    [
+      "libHCAlarm.so",
+      "_ZN6NetSDK19CAlarmListenSession21RecvNakedDataCallBackEP10HPR_ADDR_TPvPKvjjij",
+      "CAlarmListenSession::RecvNakedDataCallBack",
+      3,
+      4,
+    ],
+    ["libHCPlayBack.so", "_ZN6NetSDK14CFormatSession16RecvDataCallBackEPvPKvjj", "CFormatSession::RecvDataCallBack", 2, 3],
+    ["libHCPlayBack.so", "_ZN6NetSDK11CVOD3GPFile20InputDataToSplitFileEPvjj", "CVOD3GPFile::InputDataToSplitFile", 1, 2],
+    ["libHCPlayBack.so", "_ZN6NetSDK12CVODFileBase15InputDataToFileEPvji", "CVODFileBase::InputDataToFile", 1, 2],
+    ["libHCPlayBack.so", "_ZN6NetSDK11CVOD3GPFile18StreamCallbackCoreEjPKvjPv", "CVOD3GPFile::StreamCallbackCore", 2, 3],
+    ["libHCPlayBack.so", "_ZN6NetSDK8CVODFile20InputDataToSplitFileEPvjj", "CVODFile::InputDataToSplitFile", 1, 2],
+    ["libHCPlayBack.so", "_ZN6NetSDK8CVODFile18StreamCallbackCoreEjPKvjPv", "CVODFile::StreamCallbackCore", 2, 3],
+    ["libHCPlayBack.so", "_ZN6NetSDK12CVODFileBase14StreamCallbackEjPKvjPv", "CVODFileBase::StreamCallback", 2, 3],
+    ["libHCPlayBack.so", "_ZN6NetSDK10CVODPlayer17InputDataToPlayerEPvjj", "CVODPlayer::InputDataToPlayer", 1, 2],
+    ["libHCPlayBack.so", "_ZN6NetSDK10CVODPlayer14StreamCallbackEjPKvjPv", "CVODPlayer::StreamCallback", 2, 3],
+    ["libHCPlayBack.so", "_ZN6NetSDK10CVODUserCB14StreamCallbackEjPKvjPv", "CVODUserCB::StreamCallback", 2, 3],
+    ["libHCPlayBack.so", "_ZN6NetSDK20CVODHikClusterStream23ClusterRecvDataCallBackEPvPKvjj", "CVODHikClusterStream::ClusterRecvDataCallBack", 2, 3],
+    ["libHCPlayBack.so", "_ZN6NetSDK14CVODStreamBase16RecvDataCallBackEPvPKvjj", "CVODStreamBase::RecvDataCallBack", 2, 3],
+    ["libHCPlayBack.so", "_ZN6NetSDK15CVODISAPIStream14ProcessRTPDataEPviPKvjj", "CVODISAPIStream::ProcessRTPData", 3, 4],
+    ["libHCPlayBack.so", "_ZN6NetSDK13CVODNPQStream15NpqDataCallBackEiiPhjPv", "CVODNPQStream::NpqDataCallBack", 3, 4],
+    ["libHCPlayBack.so", "_ZN6NetSDK13CVODNPQStream19UDPRecvDataCallBackEPvPKvjj", "CVODNPQStream::UDPRecvDataCallBack", 2, 3],
+    ["libHCDisplay.so", "_ZN6NetSDK21CPassiveDecodeSession15ParseRecvExDataEPhj", "CPassiveDecodeSession::ParseRecvExData", 1, 2],
+    ["libHCDisplay.so", "_ZN6NetSDK21CPassiveDecodeSession16RecvDataCallBackEPvPKvjj", "CPassiveDecodeSession::RecvDataCallBack", 2, 3],
+    ["libHCDisplay.so", "_ZN6NetSDK20CPassiveTransSession16RecvDataCallBackEPvPKvjj", "CPassiveTransSession::RecvDataCallBack", 2, 3],
+    ["libHCDisplay.so", "_ZN6NetSDK20CPassiveTransSession11ProcTcpDataEjPKvj", "CPassiveTransSession::ProcTcpData", 2, 3],
+    ["libHCDisplay.so", "_ZN6NetSDK20CPassiveTransSession19InputDataToCallBackEjPvj", "CPassiveTransSession::InputDataToCallBack", 2, 3],
+    ["libHCDisplay.so", "_ZN6NetSDK20CPassiveTransSession15UdpDataCallBackEPvPKvjj", "CPassiveTransSession::UdpDataCallBack", 2, 3],
+    ["libHCDisplay.so", "_ZN6NetSDK17CPicScreenSession21ScreenPicRecvCallBackEPvPKvjj", "CPicScreenSession::ScreenPicRecvCallBack", 2, 3],
+    ["libHCCore.so", "_ZN6NetSDK12CAnalyzeData9InputDataEPhj", "CAnalyzeData::InputData", 1, 2],
+    ["libHCCore.so", "_ZN6NetSDK13CNpqInterface9InputDataEiPhj", "CNpqInterface::InputData", 2, 3],
+    ["libHCCore.so", "_ZN17IHardDecodePlayer9InputDataEPvj", "IHardDecodePlayer::InputData", 1, 2],
+    ["libHCCore.so", "_ZN17ISoftDecodePlayer9InputDataEPvj", "ISoftDecodePlayer::InputData", 1, 2],
+    ["libHCCore.so", "_ZN17ISoftDecodePlayer11DecCallBackEiPciP9frameinfoii", "ISoftDecodePlayer::DecCallBack", 2, 3],
+    ["libHCCore.so", "_ZN17ISoftDecodePlayer15DisplayCallBackEiPciiiiii", "ISoftDecodePlayer::DisplayCallBack", 2, 3],
+    ["libHCCore.so", "_ZN6NetSDK14CStreamConvert9InputDataEPvj", "CStreamConvert::InputData", 1, 2],
+  ].forEach(([moduleName, name, label, dumpArgIndex, lenArgIndex]) => {
+    hookPointerDataFunction(moduleName, name, label, dumpArgIndex, lenArgIndex, 128);
+  });
+
+  [
+    ["libHCPlayBack.so", "_ZN6NetSDK11CVOD3GPFile20SysTransDataCallBackEPK15OUTPUTDATA_INFOPv", "CVOD3GPFile::SysTransDataCallBack"],
+    ["libHCPlayBack.so", "_ZN6NetSDK14CVODStreamBase20SysTransDataCallBackEPK15OUTPUTDATA_INFOPv", "CVODStreamBase::SysTransDataCallBack"],
+  ].forEach(([moduleName, name, label]) => {
+    hookOutputDataInfoArgFunction(moduleName, name, label, 1, false, 128);
+  });
+
+  hookExport("libHCCore.so", "_ZN6NetSDK14CStreamConvert15SetDataCallBackEPFvPK15OUTPUTDATA_INFOPvES4_", {
+    onEnter(args) {
+      console.log(`[cb] CStreamConvert::SetDataCallBack this=${args[0]} cb=${args[1]} user=${args[2]}`);
+      hookOutputDataInfoCallbackPointer("CStreamConvert::SetDataCallBack", args[1], false);
+    },
+    onLeave(retval) {
+      console.log(`[cb] CStreamConvert::SetDataCallBack ret=${retString(retval)}`);
+    },
+  });
+
+  [
+    [
+      "libhcnetsdk.so",
+      "NET_DVR_SetNakedDataRecvCallBack",
+      "NET_DVR_SetNakedDataRecvCallBack",
+      1,
+      2,
+      3,
+    ],
+    ["libHCAlarm.so", "COM_SetNakedDataRecvCallBack", "COM_SetNakedDataRecvCallBack", 1, 2, 3],
+    ["libhcnetsdk.so", "NET_DVR_SetPicViewDataCallBack", "NET_DVR_SetPicViewDataCallBack", 1, 2, 3],
+    ["libHCDisplay.so", "COM_SetPicViewDataCallBack", "COM_SetPicViewDataCallBack", 1, 2, 3],
+    ["libhcnetsdk.so", "NET_DVR_SetPlayDataCallBack", "NET_DVR_SetPlayDataCallBack", 1, 2, 3],
+    ["libhcnetsdk.so", "NET_DVR_SetPlayDataCallBack_V40", "NET_DVR_SetPlayDataCallBack_V40", 1, 2, 3],
+    ["libHCPlayBack.so", "COM_SetPlayDataCallBack", "COM_SetPlayDataCallBack", 1, 2, 3],
+    ["libHCPlayBack.so", "COM_SetPlayDataCallBack_V40", "COM_SetPlayDataCallBack_V40", 1, 2, 3],
+    [
+      "libezstreamclient.so",
+      "_ZN13ez_stream_sdk30EZ_NET_DVR_SetPlayDataCallBackEiPFvijPhjjEj",
+      "ez_stream_sdk::EZ_NET_DVR_SetPlayDataCallBack",
+      1,
+      2,
+      3,
+    ],
+    [
+      "libezstreamclient.so",
+      "_ZN13ez_stream_sdk34EZ_NET_DVR_SetPlayDataCallBack_V40EiPFviiPhjPvES1_",
+      "ez_stream_sdk::EZ_NET_DVR_SetPlayDataCallBack_V40",
+      1,
+      2,
+      3,
+    ],
+  ].forEach(([moduleName, name, label, cbIndex, dumpArgIndex, lenArgIndex]) => {
+    hookCallbackSetter(moduleName, name, label, cbIndex, dumpArgIndex, lenArgIndex, 64);
+  });
+
+  [
+    ["libhcnetsdk.so", "NET_DVR_SetPreviewResponseCallBack", "NET_DVR_SetPreviewResponseCallBack", 1],
+    ["libhcnetsdk.so", "NET_DVR_SetPlaybackResponseCallBack", "NET_DVR_SetPlaybackResponseCallBack", 1],
+    ["libhcnetsdk.so", "NET_DVR_SetPicViewResponseCallBack", "NET_DVR_SetPicViewResponseCallBack", 1],
+    ["libHCCore.so", "COM_SetPreviewResponseCallBack", "COM_SetPreviewResponseCallBack", 1],
+    ["libHCCore.so", "COM_SetPlaybackResponseCallBack", "COM_SetPlaybackResponseCallBack", 1],
+    ["libHCCore.so", "COM_SetPicViewResponseCallBack", "COM_SetPicViewResponseCallBack", 1],
+    ["libhcnetsdk.so", "NET_DVR_SetPlayBackESCallBack", "NET_DVR_SetPlayBackESCallBack", 1],
+    ["libHCPlayBack.so", "COM_SetPlayESCallBack", "COM_SetPlayESCallBack", 1],
+  ].forEach(([moduleName, name, label, cbIndex]) => {
+    hookLoggingCallbackSetter(moduleName, name, label, cbIndex, 64);
+  });
+
+  [
+    ["libhcnetsdk.so", "NET_DVR_SetSDKSecretKey", "NET_DVR_SetSDKSecretKey"],
+    ["libHCCore.so", "COM_SetStreamSecretKey", "COM_SetStreamSecretKey"],
+  ].forEach(([moduleName, name, label]) => {
+    hookExport(moduleName, name, {
+      onEnter(args) {
+        console.log(`[key] ${label} handle=${args[0]} key=${secretBytes(args[1], 16)} extra=${args[2]} ${args[3]}`);
+      },
+      onLeave(retval) {
+        console.log(`[key] ${label} ret=${retString(retval)}`);
+      },
+    });
+  });
+
+  [
+    ["NET_DVR_SetRealPlaySecretKey", "NET_DVR_SetRealPlaySecretKey"],
+    ["NET_DVR_SetPlayBackSecretKey", "NET_DVR_SetPlayBackSecretKey"],
+  ].forEach(([name, label]) => {
+    hookExport("libhcnetsdk.so", name, {
+      onEnter(args) {
+        console.log(
+          `[key] ${label} handle=${args[0]} type=${args[1].toInt32()} key=${nativeSecretBytes(args[2], args[3])}`,
+        );
+      },
+      onLeave(retval) {
+        console.log(`[key] ${label} ret=${retString(retval)}`);
+      },
+    });
+  });
+
+  hookExport("libHCPlayBack.so", "COM_SetPlayBackSecretKey", {
+    onEnter(args) {
+      console.log(
+        `[key] COM_SetPlayBackSecretKey handle=${args[0]} type=${args[1].toInt32()} key=${nativeSecretBytes(args[2], args[3])}`,
+      );
+    },
+    onLeave(retval) {
+      console.log(`[key] COM_SetPlayBackSecretKey ret=${retString(retval)}`);
+    },
+  });
+
+  [
+    ["NET_DVR_SetRealDataCallBack", "NET_DVR_SetRealDataCallBack"],
+    ["NET_DVR_SetRealDataCallBackEx", "NET_DVR_SetRealDataCallBackEx"],
+    ["NET_DVR_SetStandardDataCallBack", "NET_DVR_SetStandardDataCallBack"],
+    ["NET_DVR_SetStandardDataCallBackEx", "NET_DVR_SetStandardDataCallBackEx"],
+    ["NET_DVR_SetTransparentDataCallBack", "NET_DVR_SetTransparentDataCallBack"],
+    ["NET_DVR_SetESCallBack", "NET_DVR_SetESCallBack"],
+  ].forEach(([name, label]) => {
+    hookExport("libhcnetsdk.so", name, {
+      onEnter(args) {
+        console.log(`[cb] ${label} handle=${args[0]} cb=${args[1]} user=${args[2]} extra=${args[3]}`);
+        hookCallbackPointer(label, args[1], 2, 3);
+      },
+      onLeave(retval) {
+        console.log(`[cb] ${label} ret=${retString(retval)}`);
+      },
+    });
+  });
+
+  hookExport("libhcnetsdk.so", "NET_DVR_SetESRealPlayCallBack", {
+    onEnter(args) {
+      console.log(`[cb] NET_DVR_SetESRealPlayCallBack handle=${args[0]} cb=${args[1]} user=${args[2]} extra=${args[3]}`);
+      hookLoggingCallbackPointer("NET_DVR_SetESRealPlayCallBack", args[1], 64);
+    },
+    onLeave(retval) {
+      console.log(`[cb] NET_DVR_SetESRealPlayCallBack ret=${retString(retval)}`);
+    },
   });
 
   hookExport("libPlayCtrl.so", "PlayM4_SetDecodeCallBack", {
@@ -848,6 +1807,231 @@ function installJavaHooks() {
       file.mkdirs();
       dumpDir = file.getAbsolutePath().toString();
       console.log(`[init] dumpDir=${dumpDir}`);
+    }
+
+    function hookJavaMethodGroup(className, classLabel, methodNames, dumpByteArrays) {
+      try {
+        const Klass = Java.use(className);
+        let hooked = 0;
+        for (const methodName of methodNames) {
+          if (Klass[methodName] === undefined) {
+            continue;
+          }
+          for (const overload of Klass[methodName].overloads) {
+            const argSig = overload.argumentTypes
+              ? overload.argumentTypes.map((type) => type.className).join(",")
+              : "?";
+            overload.implementation = function () {
+              const parts = [];
+              for (let i = 0; i < arguments.length; i++) {
+                parts.push(`arg${i}=${describeJavaMethodArg(arguments[i])}`);
+              }
+              console.log(`[java] ${classLabel}.${methodName}(${argSig}) ${parts.join(" ")}`);
+              if (dumpByteArrays) {
+                dumpFirstJavaByteArrayArg(`java-${classLabel}-${methodName}`.replace(/[^A-Za-z0-9_.-]+/g, "-"), arguments);
+              }
+              const ret = overload.apply(this, arguments);
+              console.log(`[java] ${classLabel}.${methodName} ret=${describeJavaMethodArg(ret)}`);
+              return ret;
+            };
+            hooked += 1;
+          }
+        }
+        if (hooked > 0) {
+          console.log(`[hook] Java ${classLabel} method-group overloads=${hooked}`);
+        }
+      } catch (err) {
+        console.log(`[warn] Java ${classLabel} method-group unavailable: ${err}`);
+      }
+    }
+
+    function hookJavaStreamCallbackClass(className, sourceLabel) {
+      if (!className || className.startsWith("<") || installedJavaStreamClasses.has(className)) {
+        return;
+      }
+      try {
+        const CallbackClass = Java.use(className);
+        let hooked = 0;
+        [
+          "onDataCallBack",
+          "onDataListener",
+          "onOutputData",
+          "onConvertData",
+          "onDataOutput",
+          "onRespData",
+          "onDataRefresh",
+          "onMessageCallBack",
+          "onStatisticsCallBack",
+          "onNPCData",
+          "onNPCMsg",
+        ].forEach((methodName) => {
+          if (CallbackClass[methodName] === undefined) {
+            return;
+          }
+          for (const overload of CallbackClass[methodName].overloads) {
+            const argSig = overload.argumentTypes
+              ? overload.argumentTypes.map((type) => type.className).join(",")
+              : "?";
+            overload.implementation = function () {
+              const parts = [];
+              for (let i = 0; i < arguments.length; i++) {
+                parts.push(`arg${i}=${describeJavaMethodArg(arguments[i])}`);
+              }
+              console.log(`[java-cb] ${className}.${methodName} source=${sourceLabel}(${argSig}) ${parts.join(" ")}`);
+              dumpFirstJavaByteArrayArg(`java-cb-${className}-${methodName}`.replace(/[^A-Za-z0-9_.-]+/g, "-"), arguments);
+              const ret = overload.apply(this, arguments);
+              console.log(`[java-cb] ${className}.${methodName} ret=${describeJavaMethodArg(ret)}`);
+              return ret;
+            };
+            hooked += 1;
+          }
+        });
+        if (hooked > 0) {
+          installedJavaStreamClasses.add(className);
+          console.log(`[hook] Java stream callback ${className} overloads=${hooked} source=${sourceLabel}`);
+        }
+      } catch (err) {
+        console.log(`[warn] Java stream callback hook unavailable class=${className}: ${err}`);
+      }
+    }
+
+    function hookJavaCallbackRegistration(Klass, classLabel, methodName, cbArgIndex) {
+      if (Klass[methodName] === undefined) {
+        return;
+      }
+      let hooked = 0;
+      for (const overload of Klass[methodName].overloads) {
+        const argSig = overload.argumentTypes
+          ? overload.argumentTypes.map((type) => type.className).join(",")
+          : "?";
+        overload.implementation = function () {
+          const callbackObj = arguments[cbArgIndex];
+          const callbackClass = safeJavaClassName(callbackObj);
+          console.log(`[java-cb-reg] ${classLabel}.${methodName}(${argSig}) cb=${callbackClass}`);
+          hookJavaStreamCallbackClass(callbackClass, `${classLabel}.${methodName}`);
+          dumpFirstJavaByteArrayArg(`java-reg-${classLabel}-${methodName}`.replace(/[^A-Za-z0-9_.-]+/g, "-"), arguments);
+          const ret = overload.apply(this, arguments);
+          console.log(`[java-cb-reg] ${classLabel}.${methodName} ret=${describeJavaMethodArg(ret)}`);
+          return ret;
+        };
+        hooked += 1;
+      }
+      if (hooked > 0) {
+        console.log(`[hook] Java callback registration ${classLabel}.${methodName} overloads=${hooked}`);
+      }
+    }
+
+    hookJavaMethodGroup("com.ez.stream.NativeApi", "NativeApi", [
+      "createClient",
+      "createClientWithUrl",
+      "createPreviewHandle",
+      "createPreviewHandleWithUrl",
+      "destroyHandle",
+      "setCallback",
+      "setDataCallback2Java",
+      "setPlayPort",
+      "setSecretKey",
+      "startPreview",
+      "start",
+      "startPlayback",
+      "startPreconnect",
+      "stopPreview",
+      "stop",
+      "setMediaCallback",
+      "setStreamDataCallback",
+      "setStreamSaveDebugPath",
+      "setPlaybackConvert",
+      "setMediaPlaybackConvert",
+      "refreshPlayer",
+      "forceIFrame",
+    ], false);
+
+    hookJavaMethodGroup("com.ez.stream.NativeApi", "NativeApi.byte-input", [
+      "inputData2Cloud",
+      "inputVoiceTalkData",
+    ], true);
+
+    hookJavaMethodGroup("com.hikvision.packagetransform.PackageTransform", "PackageTransform", [
+      "startTransform",
+      "startTransformSimple",
+      "startRealTimeTransform",
+      "startRealTimeTransformTS",
+      "inputData",
+    ], true);
+
+    hookJavaMethodGroup("com.ez.player.EZMediaPlayer", "EZMediaPlayer", [
+      "onDataListener",
+      "onDataRefresh",
+      "onDelayListener",
+      "onErrorListener",
+      "onInfoListener",
+      "setOnStreamDataListener",
+      "start",
+      "setSecretKey",
+    ], true);
+
+    hookJavaMethodGroup("com.ez.stream.EZStreamClient", "EZStreamClient", [
+      "setCallback",
+      "setDataCallback2Java",
+      "setPlaybackConvert",
+      "startPreview",
+      "startPlayback",
+    ], true);
+
+    hookJavaMethodGroup("com.ez.stream.SystemTransform", "SystemTransform", [
+      "create",
+      "createEx",
+      "inputData",
+      "setEncryptKey",
+      "start",
+      "startEx",
+      "stop",
+      "release",
+    ], true);
+
+    try {
+      const NativeApi = Java.use("com.ez.stream.NativeApi");
+      hookJavaCallbackRegistration(NativeApi, "NativeApi", "setCallback", 1);
+      hookJavaCallbackRegistration(NativeApi, "NativeApi", "setStreamDataCallback", 1);
+      hookJavaCallbackRegistration(NativeApi, "NativeApi", "setMediaCallback", 1);
+      hookJavaCallbackRegistration(NativeApi, "NativeApi", "setDownloadCallback", 1);
+      hookJavaCallbackRegistration(NativeApi, "NativeApi", "setDisplayCallback", 1);
+      hookJavaCallbackRegistration(NativeApi, "NativeApi", "setRenderCallback", 1);
+      hookJavaCallbackRegistration(NativeApi, "NativeApi", "setRenderFrameInfoCallback", 1);
+    } catch (err) {
+      console.log(`[warn] Java NativeApi callback registration hooks unavailable: ${err}`);
+    }
+
+    try {
+      const EZStreamClient = Java.use("com.ez.stream.EZStreamClient");
+      hookJavaCallbackRegistration(EZStreamClient, "EZStreamClient", "setCallback", 0);
+      hookJavaCallbackRegistration(EZStreamClient, "EZStreamClient", "setStreamDataCallback", 0);
+      hookJavaCallbackRegistration(EZStreamClient, "EZStreamClient", "setMediaCallback", 0);
+    } catch (err) {
+      console.log(`[warn] Java EZStreamClient callback registration hooks unavailable: ${err}`);
+    }
+
+    try {
+      const EZMediaPlayer = Java.use("com.ez.player.EZMediaPlayer");
+      hookJavaCallbackRegistration(EZMediaPlayer, "EZMediaPlayer", "setOnStreamDataListener", 0);
+    } catch (err) {
+      console.log(`[warn] Java EZMediaPlayer stream listener hook unavailable: ${err}`);
+    }
+
+    try {
+      const SystemTransform = Java.use("com.ez.stream.SystemTransform");
+      hookJavaCallbackRegistration(SystemTransform, "SystemTransform", "create", 4);
+    } catch (err) {
+      console.log(`[warn] Java SystemTransform callback registration hook unavailable: ${err}`);
+    }
+
+    try {
+      const NPClient = Java.use("org.hik.np.NPClient");
+      hookJavaCallbackRegistration(NPClient, "NPClient", "NPCOpen", 1);
+      hookJavaCallbackRegistration(NPClient, "NPClient", "NPCOpenEx", 1);
+      hookJavaCallbackRegistration(NPClient, "NPClient", "NPCSetMsgCallBack", 1);
+    } catch (err) {
+      console.log(`[warn] Java NPClient callback registration hooks unavailable: ${err}`);
     }
 
     try {
@@ -1261,5 +2445,9 @@ function installJavaHooks() {
 }
 
 installNativeHooks();
-setImmediate(installJavaHooks);
+if (NATIVE_ONLY) {
+  console.log(`[init] native-only mode enabled dumpDir=${dumpDir}`);
+} else {
+  setImmediate(installJavaHooks);
+}
 setInterval(installNativeHooks, 1000);

--- a/tools/apk-re/frida/ezviz-stream-transform-hook.js
+++ b/tools/apk-re/frida/ezviz-stream-transform-hook.js
@@ -304,7 +304,13 @@ function hookExport(moduleName, exportName, callbacks) {
   if (ptr === null) {
     return;
   }
-  Interceptor.attach(ptr, callbacks);
+  try {
+    Interceptor.attach(ptr, callbacks);
+  } catch (err) {
+    console.log(`[warn] hook failed ${key} @ ${ptr}: ${err}`);
+    installed.add(key);
+    return;
+  }
   installed.add(key);
   console.log(`[hook] ${key} @ ${ptr}`);
 }
@@ -357,6 +363,47 @@ function hookCallbackPointer(label, cbPtr, dumpArgIndex, lenArgIndex) {
   }
 }
 
+function hookPointerDataFunction(moduleName, exportName, label, dumpArgIndex, lenArgIndex, logLimit) {
+  hookExport(moduleName, exportName, {
+    onEnter(args) {
+      this.label = label;
+      if (!shouldLog(`[native] ${label}`, logLimit || 128)) {
+        return;
+      }
+      const parts = [`this=${args[0]}`];
+      if (label.indexOf("ProcessLostPacket") !== -1) {
+        parts.push(`lost=${args[1].toInt32()}`);
+      }
+      if (dumpArgIndex !== null && dumpArgIndex !== undefined) {
+        let len = 256;
+        if (lenArgIndex !== null && lenArgIndex !== undefined) {
+          try {
+            len = Math.max(args[lenArgIndex].toInt32(), 0);
+          } catch (_) {
+            len = 256;
+          }
+        }
+        parts.push(`arg${dumpArgIndex}=${args[dumpArgIndex]}`);
+        parts.push(`len=${len}`);
+        if (!args[dumpArgIndex].isNull() && len > 0) {
+          parts.push(`head=${bytesToHex(args[dumpArgIndex], len)}`);
+          dumpBytes(
+            label.replace(/[^A-Za-z0-9_.-]+/g, "-"),
+            args[dumpArgIndex],
+            Math.min(len, CALLBACK_DUMP_LIMIT),
+          );
+        }
+      }
+      console.log(`[native] ${label} ${parts.join(" ")}`);
+    },
+    onLeave(retval) {
+      if (shouldLog(`[native] ${label}:ret`, logLimit || 128)) {
+        console.log(`[native] ${label} ret=${retval.toInt32()}`);
+      }
+    },
+  });
+}
+
 function describeDecodedFrameSize(len) {
   const commonYuv420Sizes = {
     460800: "640x480-yuv420",
@@ -402,6 +449,64 @@ function installNativeHooks() {
     onLeave(retval) {
       console.log(`[key] PlayM4_SetSecretKey ret=${retval.toInt32()}`);
     },
+  });
+
+  hookExport("libPlayCtrl.so", "PlayM4_SetStreamOpenMode", {
+    onEnter(args) {
+      // long port, unsigned int mode. Live preview uses this before raw InputData.
+      console.log(`[playm4] PlayM4_SetStreamOpenMode port=${args[0].toInt32()} mode=${args[1].toInt32()}`);
+    },
+    onLeave(retval) {
+      console.log(`[playm4] PlayM4_SetStreamOpenMode ret=${retval.toInt32()}`);
+    },
+  });
+
+  hookExport("libPlayCtrl.so", "PlayM4_OpenStream", {
+    onEnter(args) {
+      // long port, unsigned char *fileHeadBuf, unsigned int size, unsigned int poolSize.
+      const len = args[2].toInt32();
+      console.log(
+        `[playm4] PlayM4_OpenStream port=${args[0].toInt32()} len=${len} pool=${args[3].toInt32()} head=${bytesToHex(args[1], len)}`,
+      );
+      dumpBytes("playm4-open-stream-head", args[1], len);
+    },
+    onLeave(retval) {
+      console.log(`[playm4] PlayM4_OpenStream ret=${retval.toInt32()}`);
+    },
+  });
+
+  hookExport("libPlayCtrl.so", "PlayM4_CloseStream", {
+    onEnter(args) {
+      console.log(`[playm4] PlayM4_CloseStream port=${args[0].toInt32()}`);
+    },
+    onLeave(retval) {
+      console.log(`[playm4] PlayM4_CloseStream ret=${retval.toInt32()}`);
+    },
+  });
+
+  hookExport("libPlayCtrl.so", "PlayM4_SkipErrorData", {
+    onEnter(args) {
+      console.log(`[playm4] PlayM4_SkipErrorData port=${args[0].toInt32()} skip=${args[1].toInt32()}`);
+    },
+    onLeave(retval) {
+      console.log(`[playm4] PlayM4_SkipErrorData ret=${retval.toInt32()}`);
+    },
+  });
+
+  [
+    ["_ZN13ez_stream_sdk11EZMediaBase11startPlayerEv", "EZMediaBase::startPlayer"],
+    ["_ZN13ez_stream_sdk14EZMediaPreview11startPlayerEv", "EZMediaPreview::startPlayer"],
+    ["_ZN13ez_stream_sdk15EZMediaPlayback11startPlayerEv", "EZMediaPlayback::startPlayer"],
+    ["_ZN13ez_stream_sdk17EZMediaPlaybackEx11startPlayerEv", "EZMediaPlaybackEx::startPlayer"],
+  ].forEach(([name, label]) => {
+    hookExport("libezstreamclient.so", name, {
+      onEnter(args) {
+        console.log(`[player] ${label} this=${args[0]}`);
+      },
+      onLeave(retval) {
+        console.log(`[player] ${label} ret=${retval.toInt32()}`);
+      },
+    });
   });
 
   hookExport("libPlayCtrl.so", "IDMX_SetDecrptKey", {
@@ -566,6 +671,64 @@ function installNativeHooks() {
       console.log(`[in] PlayM4_InputData port=${args[0].toInt32()} len=${len} head=${bytesToHex(args[1], len)}`);
       dumpBytes("playm4-input", args[1], len);
     },
+  });
+
+  [
+    ["_ZN12IDMXRTPDemux9InputDataEPhjPj", "IDMXRTPDemux::InputData", 1, 2],
+    ["_ZN12IDMXRTPDemux14ProcessPayloadEP18_RTP_DEMUX_OUTPUT_", "IDMXRTPDemux::ProcessPayload", 1, null],
+    ["_ZN12IDMXRTPDemux10OutputDataEP18_IDMX_PACKET_INFO_", "IDMXRTPDemux::OutputData", 1, null],
+    ["_ZN12IDMXRTPDemux11AddFuPacketEPhjS0_j", "IDMXRTPDemux::AddFuPacket", 1, 2],
+    ["_ZN12IDMXRTPDemux17ProcessLostPacketEj", "IDMXRTPDemux::ProcessLostPacket", null, null],
+  ].forEach(([name, label, dumpArgIndex, lenArgIndex]) => {
+    hookPointerDataFunction("libPlayCtrl.so", name, `PlayCtrl.${label}`, dumpArgIndex, lenArgIndex);
+    hookPointerDataFunction("libSystemTransform.so", name, `SystemTransform.${label}`, dumpArgIndex, lenArgIndex);
+  });
+
+  [
+    ["_ZN12CIDMXManager9InputDataEPhjPj", "CIDMXManager::InputData", 1, 2],
+    ["_ZN12CIDMXManager10OutputDataEP16_IDMX_FRMAE_INFO", "CIDMXManager::OutputData", 1, null],
+    ["_ZN12CIDMXManager17ProcessCodecFrameEPhjj", "CIDMXManager::ProcessCodecFrame", 1, 2],
+    ["_ZN12CIDMXManager17GetVideoFrameInfoEP18_IDMX_PACKET_INFO_", "CIDMXManager::GetVideoFrameInfo", 1, null],
+    ["_ZN11CDMXManager9InputDataE9DATA_TYPEPhj", "CDMXManager::InputData", 2, 3],
+    ["_ZN11CDMXManager14ParseRtpPacketEPhj", "CDMXManager::ParseRtpPacket", 1, 2],
+    ["_ZN11CDMXManager17ProcessVideoFrameEP16_IDMX_FRMAE_INFO", "CDMXManager::ProcessVideoFrame", 1, null],
+    ["_ZN11CDMXManager12ProcessFrameEP16_IDMX_FRMAE_INFO", "CDMXManager::ProcessFrame", 1, null],
+    ["_ZN11CDMXManager13SkipErrorDataEi", "CDMXManager::SkipErrorData", null, null],
+  ].forEach(([name, label, dumpArgIndex, lenArgIndex]) => {
+    hookPointerDataFunction("libSystemTransform.so", name, `SystemTransform.${label}`, dumpArgIndex, lenArgIndex);
+  });
+
+  [
+    ["_ZN6NetSDK13CGetTCPStream17ProRTPOverTCPDataEPvPKvjj", "CGetTCPStream::ProRTPOverTCPData", 2, 3],
+    ["_ZN6NetSDK14CGetRTSPStream14ProcessRTPDataEPviPKvjj", "CGetRTSPStream::ProcessRTPData", 3, 4],
+    ["_ZN6NetSDK14CGetRTSPStream19ProcessRTPDataNoNpqEPviPKvjj", "CGetRTSPStream::ProcessRTPDataNoNpq", 3, 4],
+    ["_ZN6NetSDK14CPreviewPlayer15PlayerGetStreamEPKvjjPv", "CPreviewPlayer::PlayerGetStream", 1, 2],
+    ["_ZN6NetSDK14CPreviewPlayer17InputDataToPlayerEPvj", "CPreviewPlayer::InputDataToPlayer", 1, 2],
+    ["_ZN6NetSDK14CPreviewPlayer14ProccessStreamEPKvjj", "CPreviewPlayer::ProccessStream", 1, 2],
+    ["_ZN6NetSDK15CGetHRUDPStream17CallbackVedioDataEPKhjjj", "CGetHRUDPStream::CallbackVedioData", 1, 2],
+  ].forEach(([name, label, dumpArgIndex, lenArgIndex]) => {
+    hookPointerDataFunction("libHCPreview.so", name, `HCPreview.${label}`, dumpArgIndex, lenArgIndex);
+  });
+
+  [
+    ["COM_StartRealPlay", "COM_StartRealPlay"],
+    ["COM_StopRealPlay", "COM_StopRealPlay"],
+    ["COM_GetRealPlaySock", "COM_GetRealPlaySock"],
+    ["COM_SetESRealPlayCallBack", "COM_SetESRealPlayCallBack"],
+    ["COM_SetRealPlaySecretKey", "COM_SetRealPlaySecretKey"],
+  ].forEach(([name, label]) => {
+    hookExport("libHCPreview.so", name, {
+      onEnter(args) {
+        if (shouldLog(`[hcpreview] ${label}`, 64)) {
+          console.log(`[hcpreview] ${label} args=${args[0]} ${args[1]} ${args[2]} ${args[3]}`);
+        }
+      },
+      onLeave(retval) {
+        if (shouldLog(`[hcpreview] ${label}:ret`, 64)) {
+          console.log(`[hcpreview] ${label} ret=${retval.toInt32()}`);
+        }
+      },
+    });
   });
 
   hookExport("libPlayCtrl.so", "PlayM4_SetDecodeCallBack", {
@@ -795,6 +958,70 @@ function installJavaHooks() {
       console.log("[hook] Java org.MediaPlayer.PlayM4.Player.SetSecretKey");
     } catch (err) {
       console.log(`[warn] Java PlayM4 hook unavailable: ${err}`);
+    }
+
+    try {
+      const Player = Java.use("org.MediaPlayer.PlayM4.Player");
+      if (Player.setStreamOpenMode !== undefined) {
+        for (const overload of Player.setStreamOpenMode.overloads) {
+          overload.implementation = function () {
+            console.log(`[java-playm4] Player.setStreamOpenMode port=${arguments[0]} mode=${arguments[1]}`);
+            const ret = overload.apply(this, arguments);
+            console.log(`[java-playm4] Player.setStreamOpenMode ret=${ret}`);
+            return ret;
+          };
+        }
+      }
+      if (Player.openStream !== undefined) {
+        for (const overload of Player.openStream.overloads) {
+          overload.implementation = function () {
+            const data = arguments[1];
+            const len = Number(arguments[2]) || (data ? data.length : 0);
+            console.log(
+              `[java-playm4] Player.openStream port=${arguments[0]} len=${len} pool=${arguments[3]} dataLen=${data ? data.length : 0}`,
+            );
+            dumpJavaByteArray("java-playm4-open-stream-head", data, len);
+            const ret = overload.apply(this, arguments);
+            console.log(`[java-playm4] Player.openStream ret=${ret}`);
+            return ret;
+          };
+        }
+      }
+      if (Player.openStreamAdvanced !== undefined) {
+        for (const overload of Player.openStreamAdvanced.overloads) {
+          overload.implementation = function () {
+            const data = arguments[3];
+            const len = data ? data.length : 0;
+            console.log(
+              `[java-playm4] Player.openStreamAdvanced port=${arguments[0]} mode=${arguments[1]} session=${safeJavaValue(arguments[2])} dataLen=${len} pool=${arguments[4]}`,
+            );
+            dumpJavaByteArray("java-playm4-open-stream-advanced-head", data, len);
+            const ret = overload.apply(this, arguments);
+            console.log(`[java-playm4] Player.openStreamAdvanced ret=${ret}`);
+            return ret;
+          };
+        }
+      }
+      if (Player.inputData !== undefined) {
+        for (const overload of Player.inputData.overloads) {
+          overload.implementation = function () {
+            const data = arguments[1];
+            const len = Number(arguments[2]) || (data ? data.length : 0);
+            if (shouldLog("[java-playm4] Player.inputData", 256)) {
+              console.log(`[java-playm4] Player.inputData port=${arguments[0]} len=${len} dataLen=${data ? data.length : 0}`);
+              dumpJavaByteArray("java-playm4-input", data, len);
+            }
+            const ret = overload.apply(this, arguments);
+            if (shouldLog("[java-playm4] Player.inputData:ret", 256)) {
+              console.log(`[java-playm4] Player.inputData ret=${ret}`);
+            }
+            return ret;
+          };
+        }
+      }
+      console.log("[hook] Java org.MediaPlayer.PlayM4.Player stream input/open methods");
+    } catch (err) {
+      console.log(`[warn] Java PlayM4 stream input hooks unavailable: ${err}`);
     }
 
     function hookJavaDecodeCallbackClass(className) {


### PR DESCRIPTION
## Summary
- improve HCNetSDK command-port MPEG-TS reliability with clean H.264 IDR and HEVC IRAP suffix recovery
- add sampled-packet diagnostic sidecars and sanitized dump summary tooling
- document decode-warning policy and native PlayCtrl AES-boundary follow-up scope

## Privacy scrub
- scanned branch-added lines for passwords, encryption keys, serials, MACs, LAN IPs, and home hostnames
- replaced room-style fixture labels with neutral synthetic camera labels
- remaining sensitive-looking values are synthetic test fixtures such as `SERIAL-CAMERA-01`, `dummy-camera-password-01`, and `dummy-enc-key-03`

## Tests
- `.venv/bin/ruff check .`
- `node --check tools/apk-re/frida/ezviz-stream-transform-hook.js`
- `.venv/bin/python -m py_compile pyezvizapi/local_stream.py pyezvizapi/client.py pyezvizapi/__main__.py tools/apk-re/bin/hcnetsdk-command-live-check tools/apk-re/frida/analyze-stream-dumps`
- `.venv/bin/mypy --install-types --non-interactive pyezvizapi`
- `.venv/bin/pytest --cov=pyezvizapi --cov-report=term-missing --cov-report=xml --cov-fail-under=85`