### PR TITLE
Prepare release v1.0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This project follows [Semantic Versioning](https://semver.org/) for published re
 
 ## Unreleased
 
+## v1.0.5.0 - 2026-06-20
+
 ### Added
 
 - Added direct-local SDK streaming support for cached local-SDK credentials, including CAS probing, stream bootstrap, and FFmpeg remuxing for local live-view captures.


### PR DESCRIPTION
## Summary
- move current `Unreleased` changelog entries into a dated `v1.0.5.0` release section
- leave a fresh empty `Unreleased` section for future changes

## Validation
- changelog release-section shape check
- `git diff --check`

After this PR is reviewed and merged, run **Upload Python Package** manually with version `1.0.5.0`.