### PR TITLE
Fix CAS framing and Android client type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,10 @@ This project follows [Semantic Versioning](https://semver.org/) for published re
   expired public TLS certificates by tolerating WebPKI expiry for the CAS socket
   only after normal TLS verification fails specifically for expiry, while still
   requiring the expired peer certificate to match the CAS hostname.
+- Fixed CAS cloud request compatibility with the Android app by defaulting CAS
+  XML requests to `ClientType=3`, exposing an explicit `EzvizCAS` client type
+  override, and reading complete framed CAS socket responses instead of relying
+  on a single partial `recv()`.
 
 - Fixed the DVR config sidecar to exit nonzero on failed `NET_DVR_GetDVRConfig` reads before emitting output buffers.
 

--- a/pyezvizapi/cas.py
+++ b/pyezvizapi/cas.py
@@ -232,6 +232,8 @@ def _recv_cas_frame(sock: Any) -> bytes:
         header = CasFrameHeader.parse(header_bytes)
     except ValueError as err:
         raise PyEzvizError("CAS response frame header is invalid") from err
+    # Android's native reader consumes body length + a 32 byte tail even when
+    # the response header leaves the tail-size field as zero.
     tail_size = header.tail_size_hint or CAS_RESPONSE_DIGEST_SIZE
     return header_bytes + _recv_exact(sock, header.body_size_hint + tail_size)
 

--- a/pyezvizapi/cas.py
+++ b/pyezvizapi/cas.py
@@ -35,6 +35,7 @@ CAS_VERSION_MARKER = b"\x01\x00\x00\x00"
 CAS_COMMAND_GET_OPERATION_CODE = 0x2001
 CAS_COMMAND_VERIFY = 0x2005
 CAS_COMMAND_DEVICE_MESSAGE = 0x300F
+CAS_ANDROID_CLIENT_TYPE = 3
 CAS_TLS_CIPHERS = (
     "DEFAULT:!aNULL:!eNULL:!MD5:!3DES:!DES:!RC4:!IDEA:!SEED:!aDSS:!SRP:!PSK"
 )
@@ -211,6 +212,44 @@ def _send_all(sock: Any, payload: bytes) -> None:
         sent += count
 
 
+def _recv_exact(sock: Any, size: int) -> bytes:
+    """Read exactly size bytes from a socket-like transport."""
+    chunks: list[bytes] = []
+    remaining = size
+    while remaining > 0:
+        chunk = sock.recv(remaining)
+        if not chunk:
+            raise PyEzvizError("Socket closed before CAS response was complete")
+        chunks.append(chunk)
+        remaining -= len(chunk)
+    return b"".join(chunks)
+
+
+def _recv_cas_frame(sock: Any) -> bytes:
+    """Read one complete framed CAS response."""
+    header_bytes = _recv_exact(sock, CAS_FRAME_HEADER_SIZE)
+    try:
+        header = CasFrameHeader.parse(header_bytes)
+    except ValueError as err:
+        raise PyEzvizError("CAS response frame header is invalid") from err
+    tail_size = header.tail_size_hint or CAS_RESPONSE_DIGEST_SIZE
+    return header_bytes + _recv_exact(sock, header.body_size_hint + tail_size)
+
+
+def _cas_response_body(response_bytes: bytes, *, context: str) -> bytes:
+    """Return the body declared by a CAS response frame header."""
+    try:
+        header = CasFrameHeader.parse(response_bytes)
+    except ValueError as err:
+        raise PyEzvizError(f"CAS {context} response frame header is invalid") from err
+    body_start = CAS_FRAME_HEADER_SIZE
+    body_end = body_start + header.body_size_hint
+    body = response_bytes[body_start:body_end]
+    if len(body) != header.body_size_hint:
+        raise PyEzvizError(f"CAS {context} response frame body is incomplete")
+    return body
+
+
 def xor_enc_dec(msg: bytes, xor_key: bytes = XOR_KEY) -> bytes:
     """XOR encode/decode bytes with the given key."""
     with BytesIO(msg) as stream:
@@ -273,6 +312,7 @@ def _build_operation_code_request(
     session_id: str | None,
     devserial: str,
     hardware_code: str = FEATURE_CODE,
+    client_type: int = CAS_ANDROID_CLIENT_TYPE,
 ) -> bytes:
     """Build the observed get-operation-code CAS request."""
     body = (
@@ -281,7 +321,7 @@ def _build_operation_code_request(
             f"<ClientID>{session_id}</ClientID>"
             f"\n\t<Sign>{hardware_code}</Sign>\n\t"
             f"<DevSerial>{devserial}</DevSerial>"
-            f"\n\t<ClientType>0</ClientType>\n</Request>\n"
+            f"\n\t<ClientType>{client_type}</ClientType>\n</Request>\n"
         ).encode("latin1")
     )
     return (
@@ -320,6 +360,7 @@ def _build_defence_request(
     serial: str,
     device_session: CasDeviceSession,
     enable: int,
+    client_type: int = CAS_ANDROID_CLIENT_TYPE,
 ) -> bytes:
     """Build the observed devDefence CAS request."""
     payload = (
@@ -332,7 +373,7 @@ def _build_defence_request(
         + b'<?xml version="1.0" encoding="utf-8"?>\n<Request>\n\t'
         + (
             f'<Verify ClientSession="{session_id}" '
-            f'ToDevice="{serial}" ClientType="0" />\n\t'
+            f'ToDevice="{serial}" ClientType="{client_type}" />\n\t'
             f'<Message Length="240" />\n</Request>\n'
         ).encode("latin1")
         + _cas_frame_header(
@@ -368,10 +409,12 @@ class EzvizCAS:
         self,
         token: dict[str, Any] | None,
         *,
+        client_type: int = CAS_ANDROID_CLIENT_TYPE,
         verify_tls_certificate: bool = False,
     ) -> None:
         """Initialize the client object."""
         self._session = None
+        self._client_type = client_type
         self._verify_tls_certificate = verify_tls_certificate
         self._token: dict[str, Any] = token or {
             "session_id": None,
@@ -409,6 +452,7 @@ class EzvizCAS:
         port: int,
         use_tls: bool,
         recv_size: int = 1024,
+        expect_frame: bool = True,
     ) -> CasTransportResult:
         """Send raw CAS bytes over either the cloud TLS or experimental LAN path."""
         sock: Any | None = None
@@ -440,7 +484,9 @@ class EzvizCAS:
                     sock.settimeout(CAS_SOCKET_TIMEOUT)
 
             _send_all(sock, payload)
-            response_bytes = sock.recv(recv_size)
+            response_bytes = (
+                _recv_cas_frame(sock) if expect_frame else sock.recv(recv_size)
+            )
         except TimeoutError as err:
             raise PyEzvizError("Timed out waiting for CAS response") from err
         except ConnectionResetError as err:
@@ -468,6 +514,7 @@ class EzvizCAS:
                 session_id=cast(str | None, self._token["session_id"]),
                 devserial=devserial,
                 hardware_code=self._hardware_code(),
+                client_type=self._client_type,
             ),
             host=host,
             port=port,
@@ -476,8 +523,8 @@ class EzvizCAS:
         response_bytes = result.response
         _LOGGER.debug("Get Encryption Key: %r", response_bytes)
 
-        # Trim header, digest and convert xml to dict.
-        body = response_bytes[CAS_FRAME_HEADER_SIZE:-CAS_RESPONSE_DIGEST_SIZE]
+        # Trim the framed header/tail and convert XML to dict.
+        body = _cas_response_body(response_bytes, context="get-encryption")
         if not body:
             raise PyEzvizError("CAS get-encryption response did not contain an XML body")
         try:
@@ -499,10 +546,12 @@ class EzvizCAS:
                 session_id=cast(str | None, self._token["session_id"]),
                 devserial=devserial,
                 hardware_code=self._hardware_code(),
+                client_type=self._client_type,
             ),
             host=host,
             port=port,
             use_tls=False,
+            expect_frame=False,
         )
 
     def set_camera_defence_state(self, serial: str, enable: int = 1) -> bool:
@@ -515,6 +564,7 @@ class EzvizCAS:
                 serial=serial,
                 device_session=device_session,
                 enable=enable,
+                client_type=self._client_type,
             ),
             host=host,
             port=port,

--- a/tests/test_cas.py
+++ b/tests/test_cas.py
@@ -13,6 +13,7 @@ from cryptography.x509.oid import ExtendedKeyUsageOID, NameOID
 import pytest
 
 from pyezvizapi.cas import (
+    CAS_ANDROID_CLIENT_TYPE,
     CAS_COMMAND_DEVICE_MESSAGE,
     CAS_COMMAND_GET_OPERATION_CODE,
     CAS_COMMAND_VERIFY,
@@ -30,8 +31,39 @@ from pyezvizapi.exceptions import PyEzvizError
 
 DEV_SERIAL_XML = b"<DevSerial>CAM123</DevSerial>"
 CLIENT_SESSION_XML = b'ClientSession="session-id"'
+ANDROID_CLIENT_TYPE_XML = (
+    f"<ClientType>{CAS_ANDROID_CLIENT_TYPE}</ClientType>".encode("latin1")
+)
+ANDROID_DEFENCE_CLIENT_TYPE_XML = (
+    f'ClientType="{CAS_ANDROID_CLIENT_TYPE}"'.encode("latin1")
+)
+CUSTOM_CLIENT_TYPE_XML = b"<ClientType>1</ClientType>"
 LOCAL_RESPONSE = b"local-response"
 OPERATION_CODE_XML = b"<OperationCode>0123456</OperationCode>"
+
+
+def _u32(value: int) -> bytes:
+    return value.to_bytes(4, "big")
+
+
+def _cas_response(
+    body: bytes,
+    *,
+    command: int = CAS_COMMAND_GET_OPERATION_CODE,
+    tail: bytes = b"t" * 32,
+) -> bytes:
+    return (
+        CAS_FRAME_MAGIC
+        + CAS_VERSION_MARKER
+        + _u32(5)
+        + _u32(0)
+        + _u32(command)
+        + _u32(0)
+        + _u32(len(body))
+        + _u32(len(tail))
+        + body
+        + tail
+    )
 
 
 _TEST_CA_KEY = rsa.generate_private_key(public_exponent=65537, key_size=2048)
@@ -164,7 +196,9 @@ class FakeSocket:
         return len(payload)
 
     def recv(self, size: int = 1024) -> bytes:
-        return self.response
+        chunk = self.response[:size]
+        self.response = self.response[size:]
+        return chunk
 
     def getpeercert(self, binary_form: bool = False) -> bytes | dict[str, Any]:
         if binary_form:
@@ -239,7 +273,7 @@ def test_cas_get_encryption_parses_xml_response(monkeypatch) -> None:
         b'<Response><Session Key="1234567890abcdef" OperationCode="0123456789" '
         b'EncryptType="2" /></Response>'
     )
-    fake_socket = FakeSocket((b"h" * 32) + body + (b"t" * 32))
+    fake_socket = FakeSocket(_cas_response(body))
     connect_calls: list[tuple[str, int]] = []
 
     def fake_create_connection(address: tuple[str, int]) -> FakeSocket:
@@ -261,6 +295,7 @@ def test_cas_get_encryption_parses_xml_response(monkeypatch) -> None:
     assert device_session.operation_code == "0123456789"
     assert device_session.encrypt_type == 2
     assert DEV_SERIAL_XML in fake_socket.sent[0]
+    assert ANDROID_CLIENT_TYPE_XML in fake_socket.sent[0]
     assert fake_socket.ssl_context is not None
     assert fake_socket.ssl_context.check_hostname is True
     assert fake_socket.ssl_context.verify_mode == ssl.CERT_REQUIRED
@@ -277,6 +312,52 @@ def test_cas_get_encryption_parses_xml_response(monkeypatch) -> None:
     assert fake_socket.closed is True
 
 
+def test_cas_get_encryption_allows_custom_client_type(monkeypatch) -> None:
+    body = (
+        b'<?xml version="1.0" encoding="utf-8"?>'
+        b'<Response><Session Key="1234567890abcdef" OperationCode="0123456789" '
+        b'EncryptType="2" /></Response>'
+    )
+    fake_socket = FakeSocket(_cas_response(body))
+
+    monkeypatch.setattr(
+        "pyezvizapi.cas.socket.create_connection",
+        lambda _address: fake_socket,
+    )
+    monkeypatch.setattr("pyezvizapi.cas.ssl.create_default_context", FakeSSLContext)
+    monkeypatch.setattr("pyezvizapi.cas.random.randrange", lambda value: 1)
+
+    result = EzvizCAS(_token(), client_type=1).cas_get_encryption("CAM123")
+
+    assert result["Response"]["Session"]["@Key"] == "1234567890abcdef"
+    assert CUSTOM_CLIENT_TYPE_XML in fake_socket.sent[0]
+    assert ANDROID_CLIENT_TYPE_XML not in fake_socket.sent[0]
+
+
+def test_cas_get_encryption_reads_chunked_framed_response(monkeypatch) -> None:
+    class ChunkedSocket(FakeSocket):
+        def recv(self, size: int = 1024) -> bytes:
+            return super().recv(min(size, 7))
+
+    body = (
+        b'<?xml version="1.0" encoding="utf-8"?>'
+        b'<Response><Session Key="1234567890abcdef" OperationCode="0123456789" '
+        b'EncryptType="2" /></Response>'
+    )
+    fake_socket = ChunkedSocket(_cas_response(body))
+
+    monkeypatch.setattr(
+        "pyezvizapi.cas.socket.create_connection",
+        lambda _address: fake_socket,
+    )
+    monkeypatch.setattr("pyezvizapi.cas.ssl.create_default_context", FakeSSLContext)
+    monkeypatch.setattr("pyezvizapi.cas.random.randrange", lambda value: 1)
+
+    result = _cas_client().cas_get_encryption("CAM123")
+
+    assert result["Response"]["Session"]["@OperationCode"] == "0123456789"
+
+
 def test_cas_get_encryption_can_require_tls_certificate_validation(
     monkeypatch,
 ) -> None:
@@ -285,7 +366,7 @@ def test_cas_get_encryption_can_require_tls_certificate_validation(
         b'<Response><Session Key="1234567890abcdef" OperationCode="0123456789" '
         b'EncryptType="2" /></Response>'
     )
-    fake_socket = FakeSocket((b"h" * 32) + body + (b"t" * 32))
+    fake_socket = FakeSocket(_cas_response(body))
 
     monkeypatch.setattr(
         "pyezvizapi.cas.socket.create_connection",
@@ -314,7 +395,7 @@ def test_cas_get_encryption_tolerates_only_expired_tls_certificate(
         b'EncryptType="2" /></Response>'
     )
     verified_socket = FakeSocket(verify_error=_certificate_expired_error())
-    relaxed_socket = FakeSocket((b"h" * 32) + body + (b"t" * 32))
+    relaxed_socket = FakeSocket(_cas_response(body))
     sockets = [verified_socket, relaxed_socket]
     connect_calls: list[tuple[str, int]] = []
 
@@ -387,7 +468,7 @@ def test_cas_get_encryption_accepts_wildcard_certificate_hostname(
     )
     verified_socket = FakeSocket(verify_error=_certificate_expired_error())
     relaxed_socket = FakeSocket(
-        (b"h" * 32) + body + (b"t" * 32),
+        _cas_response(body),
         cert=_test_certificate(dns_names=("*.ezvizlife.com",)),
     )
     sockets = [verified_socket, relaxed_socket]
@@ -411,7 +492,7 @@ def test_cas_get_encryption_rejects_common_name_only_certificate(
 ) -> None:
     verified_socket = FakeSocket(verify_error=_certificate_expired_error())
     relaxed_socket = FakeSocket(
-        (b"h" * 32) + b"<Response />" + (b"t" * 32),
+        _cas_response(b"<Response />"),
         cert=_test_certificate(dns_names=(), common_names=("cas.example.test",)),
     )
     sockets = [verified_socket, relaxed_socket]
@@ -432,7 +513,7 @@ def test_cas_get_encryption_rejects_mismatched_certificate_hostname(
 ) -> None:
     verified_socket = FakeSocket(verify_error=_certificate_expired_error())
     relaxed_socket = FakeSocket(
-        (b"h" * 32) + b"<Response />" + (b"t" * 32),
+        _cas_response(b"<Response />"),
         cert=_test_certificate(dns_names=("other.example.test",)),
     )
     sockets = [verified_socket, relaxed_socket]
@@ -476,7 +557,7 @@ def test_cas_device_session_rejects_non_session_response() -> None:
 
 
 def test_cas_get_encryption_rejects_empty_xml_body(monkeypatch) -> None:
-    fake_socket = FakeSocket((b"h" * 32) + (b"t" * 32))
+    fake_socket = FakeSocket(_cas_response(b""))
 
     monkeypatch.setattr(
         "pyezvizapi.cas.socket.create_connection",
@@ -491,7 +572,7 @@ def test_cas_get_encryption_rejects_empty_xml_body(monkeypatch) -> None:
 
 
 def test_cas_get_encryption_rejects_malformed_xml_body(monkeypatch) -> None:
-    fake_socket = FakeSocket((b"h" * 32) + b"<Response>" + (b"t" * 32))
+    fake_socket = FakeSocket(_cas_response(b"<Response>"))
 
     monkeypatch.setattr(
         "pyezvizapi.cas.socket.create_connection",
@@ -589,7 +670,7 @@ def test_probe_local_operation_code_reports_connection_reset(monkeypatch) -> Non
 
 
 def test_set_camera_defence_state_sends_encrypted_payload(monkeypatch) -> None:
-    fake_socket = FakeSocket(b"ok")
+    fake_socket = FakeSocket(_cas_response(b"ok", command=CAS_COMMAND_VERIFY))
     connect_calls: list[tuple[str, int]] = []
 
     def fake_create_connection(address: tuple[str, int]) -> FakeSocket:
@@ -617,6 +698,7 @@ def test_set_camera_defence_state_sends_encrypted_payload(monkeypatch) -> None:
     assert connect_calls == [("cas.example.test", 443)]
     assert len(fake_socket.sent) == 1
     assert CLIENT_SESSION_XML in fake_socket.sent[0]
+    assert ANDROID_DEFENCE_CLIENT_TYPE_XML in fake_socket.sent[0]
     assert fake_socket.sent[0].endswith(f"{1:064x}"[:64].encode("latin1"))
 
     verify_header = CasFrameHeader.parse(fake_socket.sent[0])

--- a/tests/test_cas.py
+++ b/tests/test_cas.py
@@ -21,6 +21,7 @@ from pyezvizapi.cas import (
     CAS_FRAME_MAGIC,
     CAS_OPERATION_CODE_RANDOM_TRAILER_SIZE,
     CAS_RANDOM_TRAILER_SIZE,
+    CAS_RESPONSE_DIGEST_SIZE,
     CAS_VERSION_MARKER,
     CasDeviceSession,
     CasFrameHeader,
@@ -51,6 +52,7 @@ def _cas_response(
     *,
     command: int = CAS_COMMAND_GET_OPERATION_CODE,
     tail: bytes = b"t" * 32,
+    tail_size_hint: int | None = None,
 ) -> bytes:
     return (
         CAS_FRAME_MAGIC
@@ -60,7 +62,7 @@ def _cas_response(
         + _u32(command)
         + _u32(0)
         + _u32(len(body))
-        + _u32(len(tail))
+        + _u32(len(tail) if tail_size_hint is None else tail_size_hint)
         + body
         + tail
     )
@@ -190,12 +192,14 @@ class FakeSocket:
         self.closed = False
         self.ssl_context: FakeSSLContext | None = None
         self.server_hostname: str | None = None
+        self.recv_sizes: list[int] = []
 
     def send(self, payload: bytes) -> int:
         self.sent.append(payload)
         return len(payload)
 
     def recv(self, size: int = 1024) -> bytes:
+        self.recv_sizes.append(size)
         chunk = self.response[:size]
         self.response = self.response[size:]
         return chunk
@@ -356,6 +360,30 @@ def test_cas_get_encryption_reads_chunked_framed_response(monkeypatch) -> None:
     result = _cas_client().cas_get_encryption("CAM123")
 
     assert result["Response"]["Session"]["@OperationCode"] == "0123456789"
+
+
+def test_cas_get_encryption_reads_native_zero_tail_hint_response(monkeypatch) -> None:
+    body = (
+        b'<?xml version="1.0" encoding="utf-8"?>'
+        b'<Response><Session Key="1234567890abcdef" OperationCode="0123456789" '
+        b'EncryptType="2" /></Response>'
+    )
+    fake_socket = FakeSocket(_cas_response(body, tail_size_hint=0))
+
+    monkeypatch.setattr(
+        "pyezvizapi.cas.socket.create_connection",
+        lambda _address: fake_socket,
+    )
+    monkeypatch.setattr("pyezvizapi.cas.ssl.create_default_context", FakeSSLContext)
+    monkeypatch.setattr("pyezvizapi.cas.random.randrange", lambda value: 1)
+
+    result = _cas_client().cas_get_encryption("CAM123")
+
+    assert result["Response"]["Session"]["@OperationCode"] == "0123456789"
+    assert fake_socket.recv_sizes == [
+        CAS_FRAME_HEADER_SIZE,
+        len(body) + CAS_RESPONSE_DIGEST_SIZE,
+    ]
 
 
 def test_cas_get_encryption_can_require_tls_certificate_validation(


### PR DESCRIPTION
## Summary

- Default CAS XML requests to Android-compatible `ClientType=3`, while keeping an explicit `EzvizCAS(..., client_type=...)` override.
- Read complete framed CAS cloud responses using the declared 32-byte header body length and the native 32-byte response tail instead of a single partial `recv()`.
- Extend CAS tests for default Android client type, custom client type, chunked framed response reads, and the native zero-tail-header response shape.

## APK / Native Framing Check

- Android initializes the EZVIZ player/CAS path with client type `3`.
- `libezstreamclient.so`'s TLS receive path reads a 32-byte CAS header, asks the parser for the response body length, then reads `body_length + 32` more bytes.
- Existing native TLS traces match that exactly: body `119 -> 151`, body `150 -> 182`, and body `8304 -> 8336`. The response header's tail-size field is commonly `0`, so the fallback 32-byte tail is intentional.

## Safety / Sensitive Data Check

- Reviewed the PR diff for PII, passwords, tokens, private IPs, real camera serials, and raw live artifacts.
- Pattern scans only found expected code field names (`token`, `session_id`, etc.), generated test CA variables, and synthetic fixtures such as `CAM123` / `cas.example.test`.
- No live capture artifacts, credentials, real serials, or keys are included.

## Validation

- `.venv/bin/pytest tests/test_cas.py` -> 22 passed
- `.venv/bin/pytest` -> 854 passed
- `.venv/bin/ruff check`
- `.venv/bin/mypy pyezvizapi tests/test_cas.py`
- `.venv/bin/pyright pyezvizapi`
- `git diff --check`

## Live Smoke

- Owner-run CAS smoke against online H3 devices returned valid CAS tuples with both legacy `client_type=0` and Android-style `client_type=3`.
- Owner-run direct-local SDK smoke against an H3 endpoint bootstrapped preview/stream setup and read first media with both client types, so the H3 issue does not appear to be caused by CAS client type alone.