### PR TITLE
Add HCNetSDK safe ability client wrappers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ This project follows [Semantic Versioning](https://semver.org/) for published re
 - Added typed pure-Python parsers and convenience reads for safe HCNetSDK `AccessProtocolAbility` and `VideoPicAbility` XML fields.
 - Added a typed pure-Python parser and convenience read for safe HCNetSDK `AudioVideoCompressInfo` stream/audio ability fields.
 - Added a typed pure-Python parser and convenience read for safe HCNetSDK `CAMERAPARA` image/front-parameter ability ranges.
+- Added pure-Python client convenience reads for safe HCNetSDK soft/hardware, playback-conversion, and PTZ ability fields.
 - Added binary-confirmed command-port mapping plus decoded and summary helpers for `NET_DVR_USER_V30` user/password/right-table reads; decoded password bytes are hidden from default object reprs.
 
 ### Fixed

--- a/pyezvizapi/hcnetsdk.py
+++ b/pyezvizapi/hcnetsdk.py
@@ -10120,6 +10120,24 @@ class HcNetSdkPurePythonClient:
         """Read image-display ranges through the live-backed front-parameter path."""
         return self.ipc_front_parameter_ability()
 
+    def soft_hardware_ability(self) -> EzvizLanDeviceSoftHardwareAbility:
+        """Read and parse local device software/hardware ability output."""
+        return ezviz_lan_soft_hardware_ability(
+            self.device_ability(ezviz_lan_soft_hardware_ability_request(1))
+        )
+
+    def playback_convert_ability(self) -> EzvizLanPlaybackConvertAbility:
+        """Read and parse local playback conversion ability output."""
+        return ezviz_lan_playback_convert_ability(
+            self.device_ability(ezviz_lan_record_ability_request(1))
+        )
+
+    def ptz_ability(self, channel: int = 1) -> EzvizLanPtzAbility:
+        """Read and parse local PTZ ability output."""
+        return ezviz_lan_ptz_ability(
+            self.device_ability(ezviz_lan_ptz_ability_request(1, channel))
+        )
+
     def dvr_config(
         self,
         request: HcNetSdkDvrConfigRequest,

--- a/tests/test_hcnetsdk.py
+++ b/tests/test_hcnetsdk.py
@@ -3309,6 +3309,82 @@ def test_hcnetsdk_pure_python_client_wraps_ability_convenience_parsers() -> None
     )
 
 
+def test_hcnetsdk_pure_python_client_wraps_safe_ability_helpers() -> None:
+    rsa_key = RSA.generate(1024)
+    challenge = b"0123456789abcdef0123456789abcdef"
+    seed = b"s" * 64
+    first_login_response = build_hcnetsdk_tcp_frame(
+        PKCS1_v1_5.new(rsa_key.publickey()).encrypt(challenge) + seed
+    )
+    second_login_response = build_hcnetsdk_tcp_frame(
+        HCNETSDK_COMMAND_PORT_TEST_SESSION_ID + b"CAM123\x00",
+        field_4=0x10A24BF1,
+    )
+    response_xmls = (
+        b"<DeviceAbility><SoftwareCapability>"
+        b"<MaxPreviewNum>4</MaxPreviewNum><PtzSupport>1</PtzSupport>"
+        b"</SoftwareCapability><HardwareCapability>"
+        b"<SDNum>1</SDNum><HardDiskNum>0</HardDiskNum>"
+        b"</HardwareCapability></DeviceAbility>",
+        b"<RecordAbility><PlayConvert><VideoResolutionList>"
+        b"<VideoResolutionEntry><Index>3</Index>"
+        b"<VideoFrameRate>15,25</VideoFrameRate>"
+        b"<VideoBitrate><Range>128,256,512</Range></VideoBitrate>"
+        b"</VideoResolutionEntry></VideoResolutionList></PlayConvert>"
+        b"</RecordAbility>",
+        b"<PTZAbility>"
+        b'<controlType opt="UP,DOWN,LEFT,RIGHT"/>'
+        b"<Mirror><Range>0,1</Range></Mirror>"
+        b"</PTZAbility>",
+    )
+    controls = tuple(
+        _FakeSocket([build_hcnetsdk_tcp_frame(b"\x00" + xml)])
+        for xml in response_xmls
+    )
+    sockets: list[_FakeSocket] = []
+    for control in controls:
+        sockets.extend(
+            [
+                _FakeSocket([first_login_response, second_login_response]),
+                control,
+            ]
+        )
+
+    def socket_factory(address: tuple[str, int], timeout: float | None) -> _FakeSocket:
+        assert address == ("192.0.2.10", 8000)
+        assert timeout == COMMAND_PORT_DEFAULT_TIMEOUT
+        return sockets.pop(0)
+
+    client = HcNetSdkPurePythonClient(
+        HcNetSdkLanEndpoint(serial="CAM123", host="192.0.2.10"),
+        b"123456",
+        local_ip="192.0.2.56",
+        socket_factory=socket_factory,
+        rsa_key=rsa_key,
+    )
+
+    soft_hardware = client.soft_hardware_ability()
+    playback = client.playback_convert_ability()
+    ptz = client.ptz_ability(channel=1)
+    requests = (
+        ezviz_lan_soft_hardware_ability_request(1),
+        ezviz_lan_record_ability_request(1),
+        ezviz_lan_ptz_ability_request(1, 1),
+    )
+    sent_bodies = tuple(
+        parse_hcnetsdk_tcp_frame(control.sent[0]).body for control in controls
+    )
+
+    assert soft_hardware.success is True
+    assert soft_hardware.max_preview_num == 4
+    assert playback.resolutions[0].frame_rates == (15, 25)
+    assert ptz.control_type_options == ("UP", "DOWN", "LEFT", "RIGHT")
+    assert all(
+        sent[16:] == hcnetsdk_device_ability_command_port_body_tail(request)
+        for sent, request in zip(sent_bodies, requests, strict=True)
+    )
+
+
 def test_hcnetsdk_pure_python_client_wraps_ipc_front_parameter_ability() -> None:
     rsa_key = RSA.generate(1024)
     challenge = b"0123456789abcdef0123456789abcdef"


### PR DESCRIPTION
## Summary
- add `HcNetSdkPurePythonClient` convenience reads for existing safe soft/hardware, playback conversion, and PTZ ability parsers
- cover the wrappers with fake command-port responses and request-tail assertions
- update the changelog

## Validation
- `uv run pytest`
- `uv run ruff check .`
- `uv run mypy pyezvizapi tests/test_hcnetsdk.py`
- `uv run pyright pyezvizapi`
- `uv run python -m build --outdir /tmp/pyezvizapi-build-check`
- `git diff --check`

## Safety
- reviewed added diff lines for PII/secrets; only generated test RSA material and TEST-NET/synthetic camera fixtures appear
- no raw live traces, private addresses, serials, passwords, or camera secrets are included